### PR TITLE
Comment out chromatic from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - codecov
   - yarn build:dist # the dist build is only used to track bundle size delta
   - yarn bundlesize
-  - if [ $TRAVIS_EVENT_TYPE = 'push' ]; then yarn chromatic-test; fi
+  # - if [ $TRAVIS_EVENT_TYPE = 'push' ]; then yarn chromatic-test; fi
 before_deploy:
   - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc # we only want to run this on deploys as this guarantees we have an NPM_TOKEN env var
   # only create releases folder once, before_deploy gets called before every provider so save time by only doing once


### PR DESCRIPTION
Chromatic is currently not linked and causes travis to fail when building which could be preventing NPM releases from working. Commenting it out to test this.

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
