### PR TITLE
BackLink - Set href to # if onClick provided but no href

### DIFF
--- a/components/back-link/src/__snapshots__/test.js.snap
+++ b/components/back-link/src/__snapshots__/test.js.snap
@@ -68,19 +68,71 @@ exports[`Back Link matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 <StyledHoc
-  onClick={[Function]}
+  href="#"
+  onClick={
+    [MockFunction] {
+      "calls": Array [
+        Array [],
+      ],
+      "results": Array [
+        Object {
+          "isThrow": false,
+          "value": undefined,
+        },
+      ],
+    }
+  }
 >
   <BackLink
     className="emotion-3 emotion-0"
-    onClick={[Function]}
+    href="#"
+    onClick={
+      [MockFunction] {
+        "calls": Array [
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      }
+    }
   >
     <Anchor
       className="emotion-3 emotion-0"
-      onClick={[Function]}
+      href="#"
+      onClick={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
+          ],
+          "results": Array [
+            Object {
+              "isThrow": false,
+              "value": undefined,
+            },
+          ],
+        }
+      }
     >
       <a
         className="emotion-0 emotion-1 emotion-2"
-        onClick={[Function]}
+        href="#"
+        onClick={
+          [MockFunction] {
+            "calls": Array [
+              Array [],
+            ],
+            "results": Array [
+              Object {
+                "isThrow": false,
+                "value": undefined,
+              },
+            ],
+          }
+        }
       >
         example
       </a>

--- a/components/back-link/src/__snapshots__/test.js.snap
+++ b/components/back-link/src/__snapshots__/test.js.snap
@@ -25,7 +25,6 @@ exports[`Back Link matches wrapper snapshot: wrapper mount 1`] = `
   border: 0;
   background-color: transparent;
   color: #0b0c0c;
-  border-bottom: 1px solid #0b0c0c;
   -webkit-text-decoration: none;
   text-decoration: none;
   margin-bottom: 15px;
@@ -36,6 +35,10 @@ exports[`Back Link matches wrapper snapshot: wrapper mount 1`] = `
     font-size: 16px;
     line-height: 1.25;
   }
+}
+
+.emotion-1[href] {
+  border-bottom: 1px solid #0b0c0c;
 }
 
 .emotion-1::before {
@@ -76,7 +79,7 @@ exports[`Back Link matches wrapper snapshot: wrapper mount 1`] = `
       ],
       "results": Array [
         Object {
-          "isThrow": false,
+          "type": "return",
           "value": undefined,
         },
       ],
@@ -93,7 +96,7 @@ exports[`Back Link matches wrapper snapshot: wrapper mount 1`] = `
         ],
         "results": Array [
           Object {
-            "isThrow": false,
+            "type": "return",
             "value": undefined,
           },
         ],
@@ -110,7 +113,7 @@ exports[`Back Link matches wrapper snapshot: wrapper mount 1`] = `
           ],
           "results": Array [
             Object {
-              "isThrow": false,
+              "type": "return",
               "value": undefined,
             },
           ],
@@ -127,7 +130,7 @@ exports[`Back Link matches wrapper snapshot: wrapper mount 1`] = `
             ],
             "results": Array [
               Object {
-                "isThrow": false,
+                "type": "return",
                 "value": undefined,
               },
             ],

--- a/components/back-link/src/index.js
+++ b/components/back-link/src/index.js
@@ -10,7 +10,9 @@ import {
   NTA_LIGHT,
 } from '@govuk-react/constants';
 
-const Anchor = styled('a')({
+const Anchor = styled('a')(({
+  href, onClick,
+}) => ({
   fontFamily: NTA_LIGHT,
   WebkitFontSmoothing: 'antialiased',
   MozOsxFontSmoothing: 'grayscale',
@@ -28,7 +30,7 @@ const Anchor = styled('a')({
   border: 0,
   backgroundColor: 'transparent',
   color: `${BLACK}`,
-  borderBottom: `1px solid ${BLACK}`,
+  borderBottom: href ? `1px solid ${BLACK}` : 'none',
   textDecoration: 'none',
   '::before': {
     display: 'block',
@@ -50,7 +52,7 @@ const Anchor = styled('a')({
     backgroundColor: `${YELLOW}`,
     outline: `3px solid ${YELLOW}`,
   },
-});
+}));
 
 /**
  *
@@ -75,8 +77,8 @@ const Anchor = styled('a')({
  * - https://github.com/alphagov/govuk-frontend/tree/master/src/components/back-link
  *
  */
-const BackLink = ({ onClick, ...props }) => (
-  <Anchor onClick={onClick} {...props} />
+const BackLink = ({ onClick, href, ...props }) => (
+  <Anchor onClick={onClick} href={onClick && !href ? '#' : href} {...props} />
 );
 
 BackLink.propTypes = {

--- a/components/back-link/src/index.js
+++ b/components/back-link/src/index.js
@@ -10,9 +10,7 @@ import {
   NTA_LIGHT,
 } from '@govuk-react/constants';
 
-const Anchor = styled('a')(({
-  href, onClick,
-}) => ({
+const Anchor = styled('a')({
   fontFamily: NTA_LIGHT,
   WebkitFontSmoothing: 'antialiased',
   MozOsxFontSmoothing: 'grayscale',
@@ -30,8 +28,10 @@ const Anchor = styled('a')(({
   border: 0,
   backgroundColor: 'transparent',
   color: `${BLACK}`,
-  borderBottom: href ? `1px solid ${BLACK}` : 'none',
   textDecoration: 'none',
+  '&[href]': {
+    borderBottom: `1px solid ${BLACK}`,
+  },
   '::before': {
     display: 'block',
     width: 0,
@@ -52,7 +52,7 @@ const Anchor = styled('a')(({
     backgroundColor: `${YELLOW}`,
     outline: `3px solid ${YELLOW}`,
   },
-}));
+});
 
 /**
  *

--- a/components/back-link/src/stories.js
+++ b/components/back-link/src/stories.js
@@ -21,3 +21,11 @@ examples.add('With href', () => (
   <BackLink href="#">Back</BackLink>
 ));
 
+examples.add('Without href', () => (
+  <BackLink>Back</BackLink>
+));
+
+examples.add('With onClick handler and no href', () => (
+  // eslint-disable-next-line no-alert, no-undef
+  <BackLink onClick={() => {}}>Back</BackLink>
+));

--- a/components/back-link/src/stories.js
+++ b/components/back-link/src/stories.js
@@ -26,6 +26,5 @@ examples.add('Without href', () => (
 ));
 
 examples.add('With onClick handler and no href', () => (
-  // eslint-disable-next-line no-alert, no-undef
   <BackLink onClick={() => {}}>Back</BackLink>
 ));

--- a/components/back-link/src/test.js
+++ b/components/back-link/src/test.js
@@ -1,27 +1,35 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { mount } from 'enzyme';
-import sinon from 'sinon';
+import { mount, shallow } from 'enzyme';
 
 import BackLink from './';
 
 describe('Back Link', () => {
-  const onButtonClick = sinon.spy();
-  const wrapper = <BackLink onClick={onButtonClick}>example</BackLink>;
+  const onButtonClick = jest.fn();
 
   it('renders without crashing', () => {
-    const div = document.createElement('div');
-    ReactDOM.render(wrapper, div);
+    const wrapper = shallow(<BackLink>example</BackLink>);
+    expect(wrapper.exists()).toBe(true);
   });
 
   it('simulates click events', () => {
-    mount(wrapper)
-      .find('a')
-      .simulate('click');
-    expect(onButtonClick).toHaveProperty('callCount', 1);
+    const wrapper = mount(<BackLink onClick={onButtonClick}>example</BackLink>);
+    wrapper.find('a').prop('onClick')();
+    expect(onButtonClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds an href when only onClick provided', () => {
+    const wrapper = mount(<BackLink onClick={onButtonClick}>example</BackLink>);
+    const anchor = wrapper.find('Anchor');
+    expect(anchor.props().href).toBe('#');
+  });
+
+  it('does not add an href when onClick not provided', () => {
+    const wrapper = mount(<BackLink>example</BackLink>);
+    expect(wrapper.find('Anchor').props().href).toBeUndefined();
   });
 
   it('matches wrapper snapshot', () => {
-    expect(mount(wrapper)).toMatchSnapshot('wrapper mount');
+    const wrapper = mount(<BackLink onClick={onButtonClick} href="#">example</BackLink>);
+    expect(wrapper).toMatchSnapshot('wrapper mount');
   });
 });


### PR DESCRIPTION
This commit addresses #449.

- If an `onClick` is provided but no `href` is provided, the `href` is set to be "#".
- Stories updated
- Tests amended
-- shallow used
-- Sinon replaced with `jest.fn()`
-- New tests added

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
