### PR TITLE
Improve typography in govuk-react to more closely match govuk-frontend

### DIFF
--- a/API.md
+++ b/API.md
@@ -198,7 +198,7 @@ Date with hint text & error
 
 With custom input name props
 ```jsx
-<DateInput hintText="For example, 31 03 1980"
+<DateField hintText="For example, 31 03 1980"
   inputNames={{
     day: 'dayInputName',
     month: 'monthInputName',
@@ -584,13 +584,13 @@ import { H1, H2, H3, H4, H5, H6 } from "@govuk-react/header";
 
 Differing sizes
 ```jsx
-<Header level={6} size="XXLARGE">
-  h6 with XXLARGE style
+<Header level={6} size={80}>
+  h6 with font size 80
 </Header>
-<Header level={2} size="XSMALL">
-  h2 with XSMALL style
+<Header level={2} size="SMALL">
+  h2 with SMALL size
 </Header>
-<H3 size="LARGE">h3 with LARGE style</H3>
+<H3 size="LARGE">h3 with LARGE size</H3>
 ```
 
 Props pass through
@@ -608,7 +608,7 @@ Props pass through
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
  `level` |  | ```1``` | number | Semantic heading level value between 1 and 6
- `size` |  | ```undefined``` | enumObject.keys(FONT_SIZES) | Visual size level, accepts   `XLARGE`, `LARGE`, `MEDIUM`, `SMALL`, `XSMALL`
+ `size` |  | ```undefined``` | enum(...Object.keys(HEADING_SIZES) \| ...Object.keys(TYPOGRAPHY_SCALE)) | Visual size level, accepts:<br/>   `XLARGE`, `LARGE`, `MEDIUM`, `SMALL`, `XL`, `L`, `M`, `S`<br/>   or a numeric size that fits in the GDS font scale list
 
 
 HiddenText
@@ -1205,8 +1205,7 @@ Page
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `beforeChildren` |  | ```undefined``` | node | Add content that needs to appear outside `<main>` element.
-For example: The back link component, phase banner component
+ `beforeChildren` |  | ```undefined``` | node | Add content that needs to appear outside `<main>` element.<br/>For example: The back link component, phase banner component
  `children` |  | ```undefined``` | node | Add content that needs to appear centered in the `<main>` element
  `container` |  | ```({ children }) => <WidthContainer>{children}</WidthContainer>``` | func | Render props to allow the width container element to be overriden
  `footer` |  | ```undefined``` | node | Override the default footer component.
@@ -1280,7 +1279,7 @@ Panel with header and HTML body
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `panelBody` |  | ```undefined``` | union(string|array) | Panel body text
+ `panelBody` |  | ```undefined``` | union(string \| array) | Panel body text
  `panelTitle` | true | `````` | string | Panel title text
 
 

--- a/API.md
+++ b/API.md
@@ -1836,7 +1836,6 @@ TopNav with logo, service title and navigation items
 ```jsx
 import CrownIcon from '@govuk-react/icon-crown';
 import SearchBox from '@govuk-react/search-box';
-import Header from '@govuk-react/header';
 import TopNav, { asNavLinkAnchor, asTopNavAnchor } from '@govuk-react/top-nav';
 
 const LogoAnchor = asTopNavAnchor('a');
@@ -1852,7 +1851,7 @@ const Company = (
 
 const ServiceTitle = (
   <NavAnchor href={link} target="new">
-    <Header mb="0" level={3}>Service Title</Header>
+    Service Title
   </NavAnchor>
 );
 
@@ -1869,7 +1868,6 @@ const Search = (
 ```jsx
 import { BrowserRouter, Link } from 'react-router-dom';
 import CrownIcon from '@govuk-react/icon-crown';
-import Header from '@govuk-react/header';
 import TopNav, { asLogoAnchor, asNavLinkAnchor } from '@govuk-react/top-nav';
 
 const LogoLink = asTopNavAnchor(Link);
@@ -1884,7 +1882,7 @@ const CompanyLink = (
 
 const ServiceTitleLink = (
   <NavLink to={reactRouterLink}>
-    <Header mb="0" level={3}>Service Title</Header>
+    Service Title
   </NavLink>
 );
 

--- a/API.md
+++ b/API.md
@@ -599,10 +599,9 @@ Props pass through
 ```
 
 ### References:
-- https://govuk-elements.herokuapp.com/typography/#typography-headings
+- https://design-system.service.gov.uk/styles/typography/#headings
 - https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_typography.scss
-- https://github.com/alphagov/govuk-frontend/blob/master/src/globals/scss/core/_typography.scss
-- https://github.com/alphagov/govuk_elements/blob/master/packages/govuk-elements-sass/public/sass/elements/_elements-typography.scss
+- https://github.com/alphagov/govuk-frontend/blob/master/src/core/_typography.scss
 
 ### Properties
 Prop | Required | Default | Type | Description

--- a/components/date-field/README.md
+++ b/components/date-field/README.md
@@ -54,7 +54,7 @@ Prop | Required | Default | Type | Description
  `defaultValues` |  | ```{   day: undefined,   month: undefined,   year: undefined, }``` | custom | 
  `errorText` |  | ```undefined``` | string | Error text
  `hintText` |  | ```undefined``` | string | Optional hint text
- `input` |  | ```undefined``` | shape[object Object] | Properties that are sent to the input, matching final form input type
+ `input` |  | ```undefined``` | shape[object Object] | Properties that are sent to the input, matching final form and redux form input type
  `inputNames` |  | ```{   day: undefined,   month: undefined,   year: undefined, }``` | shape[object Object] | Input name attributes
 
 

--- a/components/date-field/src/index.js
+++ b/components/date-field/src/index.js
@@ -52,7 +52,7 @@ const StyledContainer = styled('div')(
  *
  * With custom input name props
  * ```jsx
- * <DateInput hintText="For example, 31 03 1980"
+ * <DateField hintText="For example, 31 03 1980"
  *   inputNames={{
  *     day: 'dayInputName',
  *     month: 'monthInputName',

--- a/components/error-summary/src/__snapshots__/test.js.snap
+++ b/components/error-summary/src/__snapshots__/test.js.snap
@@ -38,24 +38,33 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
 
 .emotion-1 {
   font-family: "nta",Arial,sans-serif;
-  font-weight: bold;
-  margin: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
   font-size: 24px;
   line-height: 1.0416666666666667;
-  margin-bottom: 15px;
+  display: block;
+  margin-top: 0;
+  margin-bottom: 20px;
+}
+
+@media print {
+  .emotion-1 {
+    font-size: 24px;
+    line-height: 1.05;
+  }
 }
 
 @media only screen and (min-width:641px) {
   .emotion-1 {
     font-size: 36px;
     line-height: 1.1111111111111112;
-    margin-bottom: 20px;
   }
 }
 
-@media print {
+@media only screen and (min-width:641px) {
   .emotion-1 {
-    font-size: 18px;
+    margin-bottom: 30px;
   }
 }
 

--- a/components/error-summary/src/__snapshots__/test.js.snap
+++ b/components/error-summary/src/__snapshots__/test.js.snap
@@ -37,6 +37,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
 }
 
 .emotion-1 {
+  color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -46,6 +47,12 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
   display: block;
   margin-top: 0;
   margin-bottom: 20px;
+}
+
+@media print {
+  .emotion-1 {
+    color: #000;
+  }
 }
 
 @media print {

--- a/components/header/README.md
+++ b/components/header/README.md
@@ -44,10 +44,9 @@ Props pass through
 ```
 
 ### References:
-- https://govuk-elements.herokuapp.com/typography/#typography-headings
+- https://design-system.service.gov.uk/styles/typography/#headings
 - https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_typography.scss
-- https://github.com/alphagov/govuk-frontend/blob/master/src/globals/scss/core/_typography.scss
-- https://github.com/alphagov/govuk_elements/blob/master/packages/govuk-elements-sass/public/sass/elements/_elements-typography.scss
+- https://github.com/alphagov/govuk-frontend/blob/master/src/core/_typography.scss
 
 ### Properties
 Prop | Required | Default | Type | Description

--- a/components/header/README.md
+++ b/components/header/README.md
@@ -29,13 +29,13 @@ import { H1, H2, H3, H4, H5, H6 } from "@govuk-react/header";
 
 Differing sizes
 ```jsx
-<Header level={6} size="XXLARGE">
-  h6 with XXLARGE style
+<Header level={6} size={80}>
+  h6 with font size 80
 </Header>
-<Header level={2} size="XSMALL">
-  h2 with XSMALL style
+<Header level={2} size="SMALL">
+  h2 with SMALL size
 </Header>
-<H3 size="LARGE">h3 with LARGE style</H3>
+<H3 size="LARGE">h3 with LARGE size</H3>
 ```
 
 Props pass through
@@ -53,6 +53,6 @@ Props pass through
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
  `level` |  | ```1``` | number | Semantic heading level value between 1 and 6
- `size` |  | ```undefined``` | enumObject.keys(FONT_SIZES) | Visual size level, accepts   `XLARGE`, `LARGE`, `MEDIUM`, `SMALL`, `XSMALL`
+ `size` |  | ```undefined``` | enum(...Object.keys(HEADING_SIZES) \| ...Object.keys(TYPOGRAPHY_SCALE)) | Visual size level, accepts:<br/>   `XLARGE`, `LARGE`, `MEDIUM`, `SMALL`, `XL`, `L`, `M`, `S`<br/>   or a numeric size that fits in the GDS font scale list
 
 

--- a/components/header/package.json
+++ b/components/header/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.4.0",
     "@govuk-react/hoc": "^0.4.0",
+    "@govuk-react/lib": "^0.4.0",
     "govuk-colours": "^1.0.3"
   },
   "peerDependencies": {

--- a/components/header/src/__snapshots__/test.js.snap
+++ b/components/header/src/__snapshots__/test.js.snap
@@ -3,24 +3,33 @@
 exports[`Header matches wrapper snapshot: wrapper mount 1`] = `
 .emotion-1 {
   font-family: "nta",Arial,sans-serif;
-  font-weight: bold;
-  margin: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
   font-size: 32px;
   line-height: 1.09375;
-  margin-bottom: 20px;
+  display: block;
+  margin-top: 0;
+  margin-bottom: 30px;
+}
+
+@media print {
+  .emotion-1 {
+    font-size: 32px;
+    line-height: 1.15;
+  }
 }
 
 @media only screen and (min-width:641px) {
   .emotion-1 {
     font-size: 48px;
     line-height: 1.0416666666666667;
-    margin-bottom: 30px;
   }
 }
 
-@media print {
+@media only screen and (min-width:641px) {
   .emotion-1 {
-    font-size: 18px;
+    margin-bottom: 50px;
   }
 }
 

--- a/components/header/src/__snapshots__/test.js.snap
+++ b/components/header/src/__snapshots__/test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Header matches wrapper snapshot: wrapper mount 1`] = `
 .emotion-1 {
+  color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -11,6 +12,12 @@ exports[`Header matches wrapper snapshot: wrapper mount 1`] = `
   display: block;
   margin-top: 0;
   margin-bottom: 30px;
+}
+
+@media print {
+  .emotion-1 {
+    color: #000;
+  }
 }
 
 @media print {

--- a/components/header/src/index.js
+++ b/components/header/src/index.js
@@ -110,7 +110,7 @@ Header.propTypes = {
   level: PropTypes.number,
   /**
    * Visual size level, accepts:
-   *    `XLARGE`, `LARGE`, `MEDIUM`, `SMALL`, 'XL', 'L', 'M', 'S'
+   *    `XLARGE`, `LARGE`, `MEDIUM`, `SMALL`, `XL`, `L`, `M`, `S`
    *    or a numeric size that fits in the GDS font scale list
    */
   size: PropTypes.oneOf([...Object.keys(HEADING_SIZES), ...Object.keys(TYPOGRAPHY_SCALE)]),

--- a/components/header/src/index.js
+++ b/components/header/src/index.js
@@ -91,10 +91,9 @@ const StyledHeader = styled(({
  * ```
  *
  * ### References:
- * - https://govuk-elements.herokuapp.com/typography/#typography-headings
+ * - https://design-system.service.gov.uk/styles/typography/#headings
  * - https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_typography.scss
- * - https://github.com/alphagov/govuk-frontend/blob/master/src/globals/scss/core/_typography.scss
- * - https://github.com/alphagov/govuk_elements/blob/master/packages/govuk-elements-sass/public/sass/elements/_elements-typography.scss
+ * - https://github.com/alphagov/govuk-frontend/blob/master/src/core/_typography.scss
  */
 const Header = props => <StyledHeader {...props} />;
 

--- a/components/header/src/index.js
+++ b/components/header/src/index.js
@@ -8,7 +8,7 @@ import {
   MEDIA_QUERIES,
   TYPOGRAPHY_SCALE,
 } from '@govuk-react/constants';
-import { govukFont } from '@govuk-react/lib';
+import { typography } from '@govuk-react/lib';
 import { withWhiteSpace } from '@govuk-react/hoc';
 
 // use `size` only with string for XLARGE, SMALL etc and number for px size
@@ -19,7 +19,7 @@ const StyledHeader = styled(({
   level, children, size, ...props
 }) =>
   createElement(LEVEL_TAG[level], props, children))(
-  // TODO add in govuk-text-colour
+  typography.textColour,
   ({ level, size = LEVEL_SIZE[level] }) => {
     const actualSize = Number.isNaN(Number(size)) ? HEADING_SIZES[size] : size;
 
@@ -29,7 +29,7 @@ const StyledHeader = styled(({
 
     return Object.assign(
       {},
-      govukFont({ size: actualSize, weight: 'bold' }),
+      typography.font({ size: actualSize, weight: 'bold' }),
     );
   },
   {

--- a/components/header/src/index.js
+++ b/components/header/src/index.js
@@ -2,34 +2,54 @@ import styled from 'react-emotion';
 import React, { createElement } from 'react';
 import PropTypes from 'prop-types';
 import {
-  MEDIA_QUERIES,
-  NTA_LIGHT,
+  HEADING_SIZES,
   LEVEL_SIZE,
-  FONT_SIZES,
   LEVEL_TAG,
+  MEDIA_QUERIES,
+  TYPOGRAPHY_SCALE,
 } from '@govuk-react/constants';
+import { govukFont } from '@govuk-react/lib';
 import { withWhiteSpace } from '@govuk-react/hoc';
 
-const StyledHeader = styled(({ level, children, ...props }) =>
+// use `size` only with string for XLARGE, SMALL etc and number for px size
+// so if `size` is a string, we find a numeric size based off `HEADING_SIZES`
+// but if `size` is a number we just send through that number
+
+const StyledHeader = styled(({
+  level, children, size, ...props
+}) =>
   createElement(LEVEL_TAG[level], props, children))(
-  {
-    fontFamily: NTA_LIGHT,
-    fontWeight: 'bold',
-    margin: 0,
+  // TODO add in govuk-text-colour
+  ({ level, size = LEVEL_SIZE[level] }) => {
+    const actualSize = Number.isNaN(Number(size)) ? HEADING_SIZES[size] : size;
+
+    if (!actualSize) {
+      throw Error(`Unknown size ${size} used for header.`);
+    }
+
+    return Object.assign(
+      {},
+      govukFont({ size: actualSize, weight: 'bold' }),
+    );
   },
-  ({ level, size = LEVEL_SIZE[level] }) => ({
-    fontSize: FONT_SIZES[size].mobile.fontSize,
-    lineHeight: FONT_SIZES[size].mobile.lineHeight,
-    marginBottom: FONT_SIZES[size].mobile.spacing,
-    [MEDIA_QUERIES.LARGESCREEN]: {
-      fontSize: FONT_SIZES[size].tablet.fontSize,
-      lineHeight: FONT_SIZES[size].tablet.lineHeight,
-      marginBottom: FONT_SIZES[size].tablet.spacing,
-    },
-    [MEDIA_QUERIES.PRINT]: {
-      fontSize: FONT_SIZES[size].print.fontSize,
-    },
-  }),
+  {
+    display: 'block',
+    marginTop: 0,
+  },
+  ({ level, size = LEVEL_SIZE[level] }) => {
+    const actualSize = Number.isNaN(Number(size)) ? HEADING_SIZES[size] : size;
+    const scaleInfo = TYPOGRAPHY_SCALE[actualSize];
+
+    return Object.assign(
+      {},
+      {
+        marginBottom: scaleInfo.mobile.spacing,
+        [MEDIA_QUERIES.TABLET]: {
+          marginBottom: scaleInfo.tablet.spacing,
+        },
+      },
+    );
+  },
 );
 
 /**
@@ -56,13 +76,13 @@ const StyledHeader = styled(({ level, children, ...props }) =>
  *
  * Differing sizes
  * ```jsx
- * <Header level={6} size="XXLARGE">
- *   h6 with XXLARGE style
+ * <Header level={6} size={80}>
+ *   h6 with font size 80
  * </Header>
- * <Header level={2} size="XSMALL">
- *   h2 with XSMALL style
+ * <Header level={2} size="SMALL">
+ *   h2 with SMALL size
  * </Header>
- * <H3 size="LARGE">h3 with LARGE style</H3>
+ * <H3 size="LARGE">h3 with LARGE size</H3>
  * ```
  *
  * Props pass through
@@ -89,9 +109,11 @@ Header.propTypes = {
    */
   level: PropTypes.number,
   /**
-   * Visual size level, accepts   `XLARGE`, `LARGE`, `MEDIUM`, `SMALL`, `XSMALL`
+   * Visual size level, accepts:
+   *    `XLARGE`, `LARGE`, `MEDIUM`, `SMALL`, 'XL', 'L', 'M', 'S'
+   *    or a numeric size that fits in the GDS font scale list
    */
-  size: PropTypes.oneOf(Object.keys(FONT_SIZES)),
+  size: PropTypes.oneOf([...Object.keys(HEADING_SIZES), ...Object.keys(TYPOGRAPHY_SCALE)]),
 };
 
 export default withWhiteSpace()(Header);

--- a/components/header/src/stories.js
+++ b/components/header/src/stories.js
@@ -19,7 +19,7 @@ const headingRanges = {
 stories.addDecorator(withKnobs);
 stories.addDecorator(WithDocsCustom(ReadMe));
 
-stories.add('Component default', () => (<Header level={number('level', 6, headingRanges)}>{text('Children', 'Heading text')}</Header>));
+stories.add('Component default', () => (<Header level={number('level', 2, headingRanges)}>{text('Children', 'Heading text')}</Header>));
 
 examples.add('Levels 1-6', () => (
   <div>
@@ -43,10 +43,10 @@ examples.add('Shortcuts 1-6', () => (
 ));
 examples.add('Differing sizes', () => (
   <div>
-    <Header level={6} size="XXLARGE">
+    <Header level={6} size={80}>
       h6 with XXLARGE style
     </Header>
-    <Header level={2} size="XSMALL">
+    <Header level={2} size={16}>
       h2 with XSMALL style
     </Header>
     <H3 size="LARGE">h3 with size large</H3>

--- a/components/header/src/test.js
+++ b/components/header/src/test.js
@@ -6,11 +6,11 @@ import Header from '.';
 import { H1, H2, H3, H4, H5, H6 } from './presets';
 
 describe('Header', () => {
-  const example = 'example';
-  const wrapper = <Header>{example}</Header>;
-
   it('renders a Header and all the H-level tags without crashing', () => {
+    const example = 'example';
+    const wrapper = <Header>{example}</Header>;
     const div = document.createElement('div');
+
     ReactDOM.render(wrapper, div);
     ReactDOM.render(<H1>{example}</H1>, div);
     ReactDOM.render(<H2>{example}</H2>, div);
@@ -20,9 +20,28 @@ describe('Header', () => {
     ReactDOM.render(<H6>{example}</H6>, div);
   });
 
-  // TODO add test that only valid GDS font sizes can be used
+  it('allows custom string-based font size without crashing', () => {
+    ReactDOM.render(<Header size="SMALL">Test</Header>, document.createElement('div'));
+  });
+
+  it('allows custom numeric GDS font size without crashing', () => {
+    ReactDOM.render(<Header size={16}>Test</Header>, document.createElement('div'));
+  });
+
+  it('throws an error if an unsupported size is used', () => {
+    const example = 'example';
+    const div = document.createElement('div');
+
+    expect(() => { ReactDOM.render(<Header size={0}>{example}</Header>, div); }).toThrow();
+    expect(() => { ReactDOM.render(<Header size={1}>{example}</Header>, div); }).toThrow();
+    expect(() => { ReactDOM.render(<Header size={99999}>{example}</Header>, div); }).toThrow();
+    expect(() => { ReactDOM.render(<Header size="test">{example}</Header>, div); }).toThrow();
+  });
 
   it('matches wrapper snapshot', () => {
+    const example = 'example';
+    const wrapper = <Header>{example}</Header>;
+
     expect(mount(wrapper)).toMatchSnapshot('wrapper mount');
   });
 });

--- a/components/header/src/test.js
+++ b/components/header/src/test.js
@@ -20,6 +20,8 @@ describe('Header', () => {
     ReactDOM.render(<H6>{example}</H6>, div);
   });
 
+  // TODO add test that only valid GDS font sizes can be used
+
   it('matches wrapper snapshot', () => {
     expect(mount(wrapper)).toMatchSnapshot('wrapper mount');
   });

--- a/components/panel/README.md
+++ b/components/panel/README.md
@@ -28,7 +28,7 @@ Panel with header and HTML body
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `panelBody` |  | ```undefined``` | union(string|array) | Panel body text
+ `panelBody` |  | ```undefined``` | union(string \| array) | Panel body text
  `panelTitle` | true | `````` | string | Panel title text
 
 

--- a/components/related-items/src/__snapshots__/test.js.snap
+++ b/components/related-items/src/__snapshots__/test.js.snap
@@ -45,24 +45,33 @@ exports[`Styled matches wrapper snapshot: wrapper mount 1`] = `
 
 .emotion-1 {
   font-family: "nta",Arial,sans-serif;
-  font-weight: bold;
-  margin: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
   font-size: 18px;
-  line-height: 1.2;
+  line-height: 1.1111111111111112;
+  display: block;
+  margin-top: 0;
   margin-bottom: 15px;
+}
+
+@media print {
+  .emotion-1 {
+    font-size: 18px;
+    line-height: 1.15;
+  }
 }
 
 @media only screen and (min-width:641px) {
   .emotion-1 {
     font-size: 24px;
     line-height: 1.25;
-    margin-bottom: 20px;
   }
 }
 
-@media print {
+@media only screen and (min-width:641px) {
   .emotion-1 {
-    font-size: 16px;
+    margin-bottom: 20px;
   }
 }
 

--- a/components/related-items/src/__snapshots__/test.js.snap
+++ b/components/related-items/src/__snapshots__/test.js.snap
@@ -44,6 +44,7 @@ exports[`Styled matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .emotion-1 {
+  color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -53,6 +54,12 @@ exports[`Styled matches wrapper snapshot: wrapper mount 1`] = `
   display: block;
   margin-top: 0;
   margin-bottom: 15px;
+}
+
+@media print {
+  .emotion-1 {
+    color: #000;
+  }
 }
 
 @media print {

--- a/components/top-nav/README.md
+++ b/components/top-nav/README.md
@@ -88,7 +88,7 @@ Prop | Required | Default | Type | Description
  `bgColor` |  | ```BLACK``` | string | Top nav background color
  `children` |  | ```undefined``` | node | List Navigation items with anchor tags e.g. NavAnchor components
  `color` |  | ```WHITE``` | string | Top nav text color
- `company` |  | ```undefined``` | node | Company component e.g. GOV UK
+ `company` |  | ```<IconTitle icon={<CrownIcon width="36" height="32" />}>GOV.UK</IconTitle>``` | node | Company component e.g. GOV UK
  `defaultOpen` |  | ```false``` | bool | Is the mobile navigation open by default?
  `search` |  | ```false``` | node | Search component
  `serviceTitle` |  | ```undefined``` | node | Service title component e.g. Food Standards Authority

--- a/components/top-nav/README.md
+++ b/components/top-nav/README.md
@@ -13,7 +13,6 @@ TopNav with logo, service title and navigation items
 ```jsx
 import CrownIcon from '@govuk-react/icon-crown';
 import SearchBox from '@govuk-react/search-box';
-import Header from '@govuk-react/header';
 import TopNav, { asNavLinkAnchor, asTopNavAnchor } from '@govuk-react/top-nav';
 
 const LogoAnchor = asTopNavAnchor('a');
@@ -29,7 +28,7 @@ const Company = (
 
 const ServiceTitle = (
   <NavAnchor href={link} target="new">
-    <Header mb="0" level={3}>Service Title</Header>
+    Service Title
   </NavAnchor>
 );
 
@@ -46,7 +45,6 @@ const Search = (
 ```jsx
 import { BrowserRouter, Link } from 'react-router-dom';
 import CrownIcon from '@govuk-react/icon-crown';
-import Header from '@govuk-react/header';
 import TopNav, { asLogoAnchor, asNavLinkAnchor } from '@govuk-react/top-nav';
 
 const LogoLink = asTopNavAnchor(Link);
@@ -61,7 +59,7 @@ const CompanyLink = (
 
 const ServiceTitleLink = (
   <NavLink to={reactRouterLink}>
-    <Header mb="0" level={3}>Service Title</Header>
+    Service Title
   </NavLink>
 );
 

--- a/components/top-nav/package.json
+++ b/components/top-nav/package.json
@@ -7,6 +7,7 @@
     "@govuk-react/hoc": "^0.4.0",
     "@govuk-react/icon-crown": "0.0.5",
     "@govuk-react/icons": "^0.4.0",
+    "@govuk-react/lib": "^0.4.0",
     "@govuk-react/search-box": "^0.4.0",
     "govuk-colours": "^1.0.3"
   },

--- a/components/top-nav/src/__snapshots__/test.js.snap
+++ b/components/top-nav/src/__snapshots__/test.js.snap
@@ -138,7 +138,27 @@ exports[`TopNav matches the <TopNav> with a <NavLinkAnchor> tag snapshot: enzyme
 }
 
 .emotion-10 {
+  font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.1111111111111112;
   width: 50%;
+}
+
+@media print {
+  .emotion-10 {
+    font-size: 18px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-10 {
+    font-size: 24px;
+    line-height: 1.25;
+  }
 }
 
 @media only screen and (min-width:641px) {
@@ -670,7 +690,27 @@ exports[`TopNav matches the <TopNav> with multiple <Anchor> tags snapshot: enzym
 }
 
 .emotion-10 {
+  font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.1111111111111112;
   width: 50%;
+}
+
+@media print {
+  .emotion-10 {
+    font-size: 18px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-10 {
+    font-size: 24px;
+    line-height: 1.25;
+  }
 }
 
 @media only screen and (min-width:641px) {
@@ -1218,7 +1258,27 @@ exports[`TopNav with icon title: icon title 1`] = `
 }
 
 .emotion-10 {
+  font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.1111111111111112;
   width: 50%;
+}
+
+@media print {
+  .emotion-10 {
+    font-size: 18px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-10 {
+    font-size: 24px;
+    line-height: 1.25;
+  }
 }
 
 @media only screen and (min-width:641px) {

--- a/components/top-nav/src/index.js
+++ b/components/top-nav/src/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { BLACK, WHITE } from 'govuk-colours';
 import { MEDIA_QUERIES } from '@govuk-react/constants';
+import { typography } from '@govuk-react/lib';
 import CrownIcon from '@govuk-react/icon-crown';
 
 import styled from 'react-emotion';
@@ -20,12 +21,15 @@ import MenuButton from './atoms/menu-button/';
 import IconTitle from './atoms/icon-title';
 
 // Layout/position of ServiceTitle
-const ServiceTitleWrapper = styled('div')({
-  width: '50%',
-  [MEDIA_QUERIES.LARGESCREEN]: {
-    width: 'auto',
+const ServiceTitleWrapper = styled('div')(
+  typography.font({ size: 24 }),
+  {
+    width: '50%',
+    [MEDIA_QUERIES.LARGESCREEN]: {
+      width: 'auto',
+    },
   },
-});
+);
 
 // Layout/position of MenuButtonWrapper
 const MenuButtonWrapper = styled('div')({
@@ -59,7 +63,6 @@ const Input = styled('input')({
  * ```jsx
  * import CrownIcon from '@govuk-react/icon-crown';
  * import SearchBox from '@govuk-react/search-box';
- * import Header from '@govuk-react/header';
  * import TopNav, { asNavLinkAnchor, asTopNavAnchor } from '@govuk-react/top-nav';
  *
  * const LogoAnchor = asTopNavAnchor('a');
@@ -75,7 +78,7 @@ const Input = styled('input')({
  *
  * const ServiceTitle = (
  *   <NavAnchor href={link} target="new">
- *     <Header mb="0" level={3}>Service Title</Header>
+ *     Service Title
  *   </NavAnchor>
  * );
  *
@@ -92,7 +95,6 @@ const Input = styled('input')({
  * ```jsx
  * import { BrowserRouter, Link } from 'react-router-dom';
  * import CrownIcon from '@govuk-react/icon-crown';
- * import Header from '@govuk-react/header';
  * import TopNav, { asLogoAnchor, asNavLinkAnchor } from '@govuk-react/top-nav';
  *
  * const LogoLink = asTopNavAnchor(Link);
@@ -107,7 +109,7 @@ const Input = styled('input')({
  *
  * const ServiceTitleLink = (
  *   <NavLink to={reactRouterLink}>
- *     <Header mb="0" level={3}>Service Title</Header>
+ *     Service Title
  *   </NavLink>
  * );
  *

--- a/components/top-nav/src/stories.js
+++ b/components/top-nav/src/stories.js
@@ -4,7 +4,6 @@ import { storiesOf } from '@storybook/react';
 import CrownIcon from '@govuk-react/icon-crown';
 import { Search as SearchIcon } from '@govuk-react/icons';
 import SearchBox from '@govuk-react/search-box';
-import Header from '@govuk-react/header';
 import { WithDocsCustom } from '@govuk-react/storybook-components';
 
 import TopNav, { asNavLinkAnchor, asTopNavAnchor } from '.';
@@ -29,7 +28,7 @@ const Company = (
 
 const ServiceTitle = (
   <NavAnchor href={link} target="new">
-    <Header mb={0} level={3}>Service Title</Header>
+    Service Title
   </NavAnchor>
 );
 
@@ -45,7 +44,7 @@ const CompanyLink = (
 
 const ServiceTitleLink = (
   <NavLink to={reactRouterLink}>
-    <Header mb={0} level={3}>Service Title</Header>
+    Service Title
   </NavLink>
 );
 

--- a/packages/api-docs/src/markdown/generateProp.js
+++ b/packages/api-docs/src/markdown/generateProp.js
@@ -1,9 +1,10 @@
 import generatePropType from './generatePropType';
 import generatePropDefaultValue from './generatePropDefaultValue';
+import generatePropDescription from './generatePropDescription';
 
 export default function generateProp(propName, prop) {
   const defaultValue = prop.defaultValue ? generatePropDefaultValue(prop.defaultValue) : '';
   const propType = prop.type ? generatePropType(prop.type) : '';
-  const description = prop.description ? prop.description : '';
+  const description = prop.description ? generatePropDescription(prop.description) : '';
   return ` \`${propName}\` | ${prop.required ? 'true' : ''} | \`\`\`${defaultValue}\`\`\` | ${propType} | ${description}`;
 }

--- a/packages/api-docs/src/markdown/generatePropDescription.js
+++ b/packages/api-docs/src/markdown/generatePropDescription.js
@@ -1,0 +1,4 @@
+export default function generatePropDescription(description) {
+  // Allow multi-line descriptions
+  return description.replace(/\n/g, '<br/>');
+}

--- a/packages/api-docs/src/markdown/generatePropType.js
+++ b/packages/api-docs/src/markdown/generatePropType.js
@@ -3,7 +3,7 @@ export default function generatePropType(type) {
   if (Array.isArray(type.value)) {
     values = `(${type.value
       .map(typeValue => typeValue.name || typeValue.value)
-      .join('|')})`;
+      .join(' \\| ')})`;
   } else {
     values = type.value;
   }

--- a/packages/constants/src/index.js
+++ b/packages/constants/src/index.js
@@ -42,20 +42,23 @@ export const MEDIA_QUERIES = {
   LARGESCREEN: `@media only screen and (min-width: ${BREAKPOINTS.LARGESCREEN})`,
   MAX: `@media only screen and (min-width: ${SITE_WIDTH_PLUS_GUTTERS})`,
   PRINT: '@media print',
+  TABLET: `@media only screen and (min-width: ${BREAKPOINTS.TABLET})`,
 };
 
 // TODO: figure out how to optionally include locally installed font, e.g. "GDS Transport Website"
 export const NTA_LIGHT = '"nta", Arial, sans-serif';
 export const NTA_LIGHT_TABULAR = `ntatabularnumbers", ${NTA_LIGHT}`;
-export const FONT_STACK = `${NTA_LIGHT} !default`;
-export const FONT_STACK_TABULAR = `${NTA_LIGHT_TABULAR} !default`;
-export const FONT_STACK_PRINT = 'sans-serif !default';
+export const FONT_STACK = `${NTA_LIGHT}`;
+export const FONT_STACK_TABULAR = `${NTA_LIGHT_TABULAR}`;
+export const FONT_STACK_PRINT = 'sans-serif';
+
+// TODO FONT_SIZE and LINE_HEIGHT can be replaced with `govukFont` lib call
 export const FONT_SIZE = {
   SIZE_14: '14px',
   SIZE_16: '16px',
-  SIZE_18: '18px',
+  SIZE_18: '18px', // not directly used in govuk-frontend
   SIZE_19: '19px',
-  SIZE_20: '20px',
+  SIZE_20: '20px', // Not used in govuk-frontend
   SIZE_24: '24px',
   SIZE_27: '27px',
 };
@@ -63,7 +66,9 @@ export const FONT_SIZE = {
 export const LINE_HEIGHT = {
   SIZE_14: '1.1428571429',
   SIZE_16: '1.25',
-  SIZE_19: '1.3',
-  SIZE_18: '1.3',
+  SIZE_18: '1.3', // approximate - value in typography is correct
+  SIZE_19: '1.3', // ditto
+  // SIZE_24 differs here from 24 def in typography scale, which is 1.25
+  // however that appears to be a mistake
   SIZE_24: '1.35',
 };

--- a/packages/constants/src/spacing.js
+++ b/packages/constants/src/spacing.js
@@ -1,4 +1,4 @@
-// https://github.com/alphagov/govuk-frontend/blob/master/src/globals/scss/settings/_spacing.scss
+// https://github.com/alphagov/govuk-frontend/blob/master/src/settings/_spacing.scss
 
 export const RESPONSIVE_0 = {
   mobile: 0,

--- a/packages/constants/src/typography.js
+++ b/packages/constants/src/typography.js
@@ -6,140 +6,181 @@
 // using spacing values from https://github.com/alphagov/govuk-frontend/blob/master/src/globals/scss/core/_typography.scss
 import { RESPONSIVE_8, RESPONSIVE_6, RESPONSIVE_4 } from './spacing';
 
-const FONT_80 = {
-  tablet: {
-    lineHeight: 80 / 80,
-    fontSize: 80,
-    spacing: RESPONSIVE_8.tablet,
+export const TYPOGRAPHY_SCALE = {
+  80: {
+    mobile: {
+      fontSize: 53,
+      lineHeight: 55 / 53,
+      spacing: RESPONSIVE_8.mobile,
+    },
+    tablet: {
+      fontSize: 80,
+      lineHeight: 80 / 80,
+      spacing: RESPONSIVE_8.tablet,
+    },
+    print: {
+      fontSize: 53,
+      lineHeight: 1.1,
+    },
   },
-  mobile: {
-    lineHeight: 55 / 53,
-    fontSize: 53,
-    spacing: RESPONSIVE_8.mobile,
+
+  48: {
+    mobile: {
+      fontSize: 32,
+      lineHeight: 35 / 32,
+      spacing: RESPONSIVE_8.mobile,
+    },
+    tablet: {
+      fontSize: 48,
+      lineHeight: 50 / 48,
+      spacing: RESPONSIVE_8.tablet,
+    },
+    print: {
+      fontSize: 32,
+      lineHeight: 1.15,
+    },
   },
-  print: {
-    fontSize: 28,
+
+  36: {
+    mobile: {
+      fontSize: 24,
+      lineHeight: 25 / 24,
+      spacing: RESPONSIVE_6.mobile,
+    },
+    tablet: {
+      fontSize: 36,
+      lineHeight: 40 / 36,
+      spacing: RESPONSIVE_6.tablet,
+    },
+    print: {
+      fontSize: 24,
+      lineHeight: 1.05,
+    },
+  },
+
+  27: {
+    mobile: {
+      fontSize: 18,
+      lineHeight: 20 / 18,
+      spacing: RESPONSIVE_4.mobile,
+    },
+    tablet: {
+      fontSize: 27,
+      lineHeight: 30 / 27,
+      spacing: RESPONSIVE_4.tablet,
+    },
+    print: {
+      fontSize: 18,
+      lineHeight: 1.15,
+    },
+  },
+
+  24: {
+    mobile: {
+      fontSize: 18,
+      lineHeight: 20 / 18,
+      spacing: RESPONSIVE_4.mobile,
+    },
+    tablet: {
+      fontSize: 24,
+      lineHeight: 30 / 24,
+      spacing: RESPONSIVE_4.tablet,
+    },
+    print: {
+      fontSize: 18,
+      lineHeight: 1.15,
+    },
+  },
+
+  19: {
+    mobile: {
+      fontSize: 16,
+      lineHeight: 20 / 16,
+      spacing: RESPONSIVE_4.mobile,
+    },
+    tablet: {
+      fontSize: 19,
+      lineHeight: 25 / 19,
+      spacing: RESPONSIVE_4.tablet,
+    },
+    print: {
+      fontSize: 14,
+      lineHeight: 1.15,
+    },
+  },
+
+  16: {
+    mobile: {
+      fontSize: 14,
+      lineHeight: 16 / 14,
+      spacing: RESPONSIVE_4.mobile,
+    },
+    tablet: {
+      fontSize: 16,
+      lineHeight: 20 / 16,
+      spacing: RESPONSIVE_4.tablet,
+    },
+    print: {
+      fontSize: 14,
+      lineHeight: 1.2,
+    },
+  },
+
+  14: {
+    mobile: {
+      fontSize: 12,
+      lineHeight: 15 / 12,
+      spacing: RESPONSIVE_4.mobile,
+    },
+    tablet: {
+      fontSize: 14,
+      lineHeight: 20 / 14,
+      spacing: RESPONSIVE_4.tablet,
+    },
+    print: {
+      fontSize: 12,
+      lineHeight: 1.2,
+    },
   },
 };
 
-const FONT_48 = {
-  tablet: {
-    lineHeight: 50 / 48,
-    fontSize: 48,
-    spacing: RESPONSIVE_6.tablet,
-  },
-  mobile: {
-    lineHeight: 35 / 32,
-    fontSize: 32,
-    spacing: RESPONSIVE_6.mobile,
-  },
-  print: {
-    fontSize: 18,
-  },
+// NB Spacing values set above relate to headings
+// body classes use different responsive margins
+// captions use govuk-spacing(1) for xl and l sizes only
+// TODO move spacing info out into separate data
+
+// heading sizes supported in govuk-frontend
+export const HEADING_SIZES = {
+  XLARGE: 48,
+  XL: 48,
+  LARGE: 36,
+  L: 36,
+  MEDIUM: 24,
+  M: 24,
+  SMALL: 19,
+  S: 19,
 };
 
-const FONT_36 = {
-  tablet: {
-    lineHeight: 40 / 36,
-    fontSize: 36,
-    spacing: RESPONSIVE_4.tablet,
-  },
-  mobile: {
-    lineHeight: 25 / 24,
-    fontSize: 24,
-    spacing: RESPONSIVE_4.mobile,
-  },
-  print: {
-    fontSize: 18,
-  },
+// caption sizes supported in govuk-frontend
+export const CAPTION_SIZES = {
+  XLARGE: 27,
+  XL: 27,
+  LARGE: 24,
+  L: 24,
+  MEDIUM: 19,
+  M: 19,
 };
 
-const FONT_27 = {
-  tablet: {
-    lineHeight: 30 / 27,
-    fontSize: 27,
-    spacing: RESPONSIVE_4.tablet,
-  },
-  mobile: {
-    lineHeight: 20 / 18,
-    fontSize: 20,
-    spacing: RESPONSIVE_4.mobile,
-  },
-  print: {
-    fontSize: 16,
-  },
-};
-
-const FONT_24 = {
-  tablet: {
-    lineHeight: 30 / 24,
-    fontSize: 24,
-    spacing: RESPONSIVE_4.tablet,
-  },
-  mobile: {
-    lineHeight: 24 / 20,
-    fontSize: 18,
-    spacing: RESPONSIVE_4.mobile,
-  },
-  print: {
-    fontSize: 16,
-  },
-};
-
-const FONT_19 = {
-  tablet: {
-    lineHeight: 25 / 19,
-    fontSize: 19,
-    spacing: RESPONSIVE_4.tablet,
-  },
-  mobile: {
-    lineHeight: 20 / 16,
-    fontSize: 16,
-    spacing: RESPONSIVE_4.mobile,
-  },
-  print: {
-    fontSize: 14,
-  },
-};
-
-const FONT_16 = {
-  tablet: {
-    lineHeight: 20 / 16,
-    fontSize: 16,
-    spacing: RESPONSIVE_4.tablet,
-  },
-  mobile: {
-    lineHeight: 16 / 14,
-    fontSize: 14,
-    spacing: RESPONSIVE_4.mobile,
-  },
-  print: {
-    fontSize: 12,
-  },
-};
-
-// Association between 'xsmall' format used by https://github.com/alphagov/govuk_elements/blob/master/packages/govuk-elements-sass/public/sass/elements/_elements-typography.scss
-// and core-xx format used by https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_typography.scss
-//
-// core-80 is misleading as it is not always 80px, therefore xsmall format is preferred,
-// but lookup to original mixin values is kept for clarity.
-const XXLARGE = FONT_80;
-const XLARGE = FONT_48;
-const LARGE = FONT_36;
-const MEDIUMLARGE = FONT_27;
-const MEDIUM = FONT_24;
-const SMALL = FONT_19;
-const XSMALL = FONT_16;
-
-// all available font sizes
-export const FONT_SIZES = {
-  XXLARGE,
-  XLARGE,
-  LARGE,
-  MEDIUMLARGE,
-  MEDIUM,
-  SMALL,
-  XSMALL,
+// body text sizes supported in govuk-frontend
+export const BODY_SIZES = {
+  LARGE: 24,
+  L: 24,
+  MEDIUM: 19,
+  M: 19,
+  SMALL: 16,
+  S: 16,
+  XSMALL: 14,
+  XS: 14,
 };
 
 // Lookup between numerical header level and associated html element
@@ -158,6 +199,11 @@ export const LEVEL_SIZE = {
   2: 'LARGE',
   3: 'MEDIUM',
   4: 'SMALL',
-  5: 'XSMALL',
-  6: 'XSMALL',
+  5: 'SMALL',
+  6: 'SMALL',
+};
+
+export const FONT_WEIGHTS = {
+  bold: '700',
+  regular: '400',
 };

--- a/packages/constants/src/typography.js
+++ b/packages/constants/src/typography.js
@@ -1,9 +1,8 @@
-// https://govuk-elements.herokuapp.com/typography/#typography-headings
-// https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_typography.scss
-// https://github.com/alphagov/govuk-frontend/blob/master/src/globals/scss/core/_typography.scss
-// https://github.com/alphagov/govuk_elements/blob/master/packages/govuk-elements-sass/public/sass/elements/_elements-typography.scss
+// https://design-system.service.gov.uk/styles/typography/
+// https://github.com/alphagov/govuk-frontend/blob/master/src/settings/_typography-responsive.scss
+// https://github.com/alphagov/govuk-frontend/blob/master/src/settings/_typography-font.scss
+// https://github.com/alphagov/govuk-frontend/blob/master/src/core/_typography.scss
 
-// using spacing values from https://github.com/alphagov/govuk-frontend/blob/master/src/globals/scss/core/_typography.scss
 import { RESPONSIVE_8, RESPONSIVE_6, RESPONSIVE_4 } from './spacing';
 
 export const TYPOGRAPHY_SCALE = {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -2,7 +2,8 @@
   "name": "@govuk-react/lib",
   "version": "0.4.0",
   "dependencies": {
-    "@govuk-react/constants": "^0.4.0"
+    "@govuk-react/constants": "^0.4.0",
+    "govuk-colours": "^1.0.3"
   },
   "scripts": {
     "build": "yarn build:lib && yarn build:es",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@govuk-react/lib",
+  "version": "0.4.0",
+  "dependencies": {
+    "@govuk-react/constants": "^0.4.0"
+  },
+  "scripts": {
+    "build": "yarn build:lib && yarn build:es",
+    "build:lib": "rimraf lib && babel src -d lib --source-maps --config-file ../../babel.config.js",
+    "build:es": "rimraf es && cross-env BABEL_ENV=es babel src -d es --source-maps --config-file ../../babel.config.js"
+  },
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "author": "Steve Sims",
+  "license": "MIT",
+  "homepage": "https://github.com/govuk-react/govuk-react#readme",
+  "description": "govuk-react: A port of the govuk-frontend components for React using Emotion.",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/lib/src/index.js
+++ b/packages/lib/src/index.js
@@ -1,0 +1,1 @@
+export * from './typography';

--- a/packages/lib/src/index.js
+++ b/packages/lib/src/index.js
@@ -1,1 +1,1 @@
-export * from './typography';
+export * as typography from './typography';

--- a/packages/lib/src/typography.js
+++ b/packages/lib/src/typography.js
@@ -1,0 +1,56 @@
+import {
+  FONT_STACK,
+  FONT_STACK_PRINT,
+  FONT_STACK_TABULAR,
+  FONT_WEIGHTS,
+  MEDIA_QUERIES,
+  TYPOGRAPHY_SCALE,
+} from '@govuk-react/constants';
+
+// TODO add govuk-text-colour
+
+export function govukTypographyCommon(fontFamily = FONT_STACK) {
+  return {
+    fontFamily,
+    WebkitFontSmoothing: 'antialiased',
+    MozOsxFontSmoothing: 'grayscale',
+    [MEDIA_QUERIES.PRINT]: {
+      fontFamily: FONT_STACK_PRINT,
+    },
+  };
+}
+
+function getSizeStyle(scale, lineHeight = scale.lineHeight) {
+  return {
+    fontSize: `${scale.fontSize}px`,
+    lineHeight,
+  };
+}
+
+export function govukTypographyResponsive(size, overrideLineHeight) {
+  const scale = TYPOGRAPHY_SCALE[size];
+
+  if (!scale) {
+    throw Error(`Unknown font size ${size} - expected a point from the typography scale.`);
+  }
+
+  return Object.assign(
+    {},
+    getSizeStyle(scale.mobile, overrideLineHeight),
+    {
+      [MEDIA_QUERIES.TABLET]: getSizeStyle(scale.tablet, overrideLineHeight),
+      [MEDIA_QUERIES.PRINT]: getSizeStyle(scale.print, overrideLineHeight),
+    },
+  );
+}
+
+export function govukFont({
+  size, weight = 'regular', tabular = false, lineHeight,
+}) {
+  return Object.assign(
+    {},
+    govukTypographyCommon(tabular ? FONT_STACK_TABULAR : undefined),
+    FONT_WEIGHTS[weight] ? { fontWeight: FONT_WEIGHTS[weight] } : undefined,
+    size ? govukTypographyResponsive(size, lineHeight) : undefined,
+  );
+}

--- a/packages/lib/src/typography/index.js
+++ b/packages/lib/src/typography/index.js
@@ -1,3 +1,7 @@
+// This lib is effectively a port of govuk-frontend's typography sass helpers
+// Tracking:
+// https://github.com/alphagov/govuk-frontend/blob/master/src/helpers/_typography.scss
+
 import {
   FONT_STACK,
   FONT_STACK_PRINT,

--- a/packages/lib/src/typography/index.js
+++ b/packages/lib/src/typography/index.js
@@ -6,10 +6,18 @@ import {
   MEDIA_QUERIES,
   TYPOGRAPHY_SCALE,
 } from '@govuk-react/constants';
+import { BLACK } from 'govuk-colours';
 
-// TODO add govuk-text-colour
+export const textColour = {
+  color: BLACK,
+  [MEDIA_QUERIES.PRINT]: {
+    color: '#000',
+  },
+};
 
-export function govukTypographyCommon(fontFamily = FONT_STACK) {
+export const textColor = textColour;
+
+export function common(fontFamily = FONT_STACK) {
   return {
     fontFamily,
     WebkitFontSmoothing: 'antialiased',
@@ -27,7 +35,7 @@ function getSizeStyle(scale, lineHeight = scale.lineHeight) {
   };
 }
 
-export function govukTypographyResponsive(size, overrideLineHeight) {
+export function responsive(size, overrideLineHeight) {
   const scale = TYPOGRAPHY_SCALE[size];
 
   if (!scale) {
@@ -44,13 +52,13 @@ export function govukTypographyResponsive(size, overrideLineHeight) {
   );
 }
 
-export function govukFont({
+export function font({
   size, weight = 'regular', tabular = false, lineHeight,
-}) {
+} = {}) {
   return Object.assign(
     {},
-    govukTypographyCommon(tabular ? FONT_STACK_TABULAR : undefined),
+    common(tabular ? FONT_STACK_TABULAR : undefined),
     FONT_WEIGHTS[weight] ? { fontWeight: FONT_WEIGHTS[weight] } : undefined,
-    size ? govukTypographyResponsive(size, lineHeight) : undefined,
+    size ? responsive(size, lineHeight) : undefined,
   );
 }

--- a/packages/lib/src/typography/test.js
+++ b/packages/lib/src/typography/test.js
@@ -1,0 +1,109 @@
+import {
+  FONT_STACK,
+  FONT_STACK_PRINT,
+  FONT_STACK_TABULAR,
+  FONT_WEIGHTS,
+  MEDIA_QUERIES,
+  TYPOGRAPHY_SCALE,
+} from '@govuk-react/constants';
+import * as typography from '.';
+
+describe('typography lib', () => {
+  it('includes textColour', () => {
+    expect(typography.textColour).toBeTruthy();
+  });
+
+  it('includes textColor alias for textColour', () => {
+    expect(typography.textColor).toEqual(typography.textColour);
+  });
+
+  describe('common', () => {
+    it('sets default font', () => {
+      const result = typography.common();
+
+      expect(result.fontFamily).toEqual(FONT_STACK);
+      expect(result[MEDIA_QUERIES.PRINT].fontFamily).toEqual(FONT_STACK_PRINT);
+    });
+
+    it('allows an override fontFamily value', () => {
+      const result = typography.common('test');
+
+      expect(result.fontFamily).toEqual('test');
+      expect(result[MEDIA_QUERIES.PRINT].fontFamily).toEqual(FONT_STACK_PRINT);
+    });
+  });
+
+  describe('responsive', () => {
+    it('allows any font size defined in the typography scale', () => {
+      Object.keys(TYPOGRAPHY_SCALE).forEach((size) => {
+        expect(() => typography.responsive(size)).not.toThrow();
+      });
+    });
+
+    it('produces mobile-first sizes with definitions for tablet and print', () => {
+      Object.entries(TYPOGRAPHY_SCALE).forEach(([size, scale]) => {
+        const style = typography.responsive(size);
+
+        expect(style.fontSize).toEqual(`${scale.mobile.fontSize}px`);
+        expect(style[MEDIA_QUERIES.PRINT].fontSize).toEqual(`${scale.print.fontSize}px`);
+        expect(style[MEDIA_QUERIES.TABLET].fontSize).toEqual(`${scale.tablet.fontSize}px`);
+
+        expect(style.lineHeight).toEqual(scale.mobile.lineHeight);
+        expect(style[MEDIA_QUERIES.PRINT].lineHeight).toEqual(scale.print.lineHeight);
+        expect(style[MEDIA_QUERIES.TABLET].lineHeight).toEqual(scale.tablet.lineHeight);
+      });
+    });
+
+    it('can override lineHeight', () => {
+      Object.keys(TYPOGRAPHY_SCALE).forEach((size) => {
+        const style = typography.responsive(size, 999);
+
+        expect(style.lineHeight).toEqual(999);
+        expect(style[MEDIA_QUERIES.PRINT].lineHeight).toEqual(999);
+        expect(style[MEDIA_QUERIES.TABLET].lineHeight).toEqual(999);
+      });
+    });
+
+    it('throws when not given a size', () => {
+      expect(() => typography.responsive()).toThrow();
+    });
+
+    it('throws when given a size not in the typography scale', () => {
+      expect(() => typography.responsive('test')).toThrow();
+      expect(() => typography.responsive(99999)).toThrow();
+    });
+  });
+
+  describe('font', () => {
+    it('defaults to standard font, regular weight', () => {
+      const style = typography.font();
+
+      expect(style)
+        .toEqual(Object.assign({}, typography.common(), { fontWeight: FONT_WEIGHTS.regular }));
+    });
+
+    it('can accept tabular flag to pick tabular font', () => {
+      const style = typography.font({ tabular: true });
+
+      expect(style.fontFamily).toEqual(FONT_STACK_TABULAR);
+    });
+
+    it('accepts weight values from FONT_WEIGHTS list', () => {
+      Object.entries(FONT_WEIGHTS).forEach(([weight, value]) => {
+        expect(typography.font({ weight }).fontWeight).toEqual(value);
+      });
+    });
+
+    it('ignores weight values we do not support', () => {
+      expect(typography.font({ weight: 'fooBar' }).fontWeight).toBeUndefined();
+    });
+
+    it('allows size and custom lineHeight to be set', () => {
+      Object.keys(TYPOGRAPHY_SCALE).forEach((size) => {
+        const style = typography.font({ size, lineHeight: 999 });
+
+        expect(style).toEqual(expect.objectContaining(typography.responsive(size, 999)));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add @govuk/lib package which implements a preliminary `typography` lib, aiming to replicate typography utilities from govuk-frontend sass
  * used in header component

TODO: Use typography lib throughout govuk-react for font sizes

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
