### PR TITLE
CI bugfix - don't auto accept changes from external PRs

### DIFF
--- a/scripts/chromatic.sh
+++ b/scripts/chromatic.sh
@@ -1,6 +1,9 @@
+# Travis offers two type of builds for commits on pull requests: so called pr and push builds. It only makes sense to run Chromatic once per PR, so we suggest disabling Chromatic on pr builds for internal PRs (i.e. PRs that aren’t from forks)
+# http://docs.chromaticqa.com/setup_ci
 if [[ $TRAVIS_EVENT_TYPE != 'pull_request' || $TRAVIS_PULL_REQUEST_SLUG != $TRAVIS_REPO_SLUG ]];
+# For external PRs (PRs from forks of your repo), the above code will ensure Chromatic does run on the pr build, because Travis does not trigger push builds in such cases.
 then
-   if [ "${TRAVIS_BRANCH}" != "master" ];
+   if [[ $TRAVIS_BRANCH != 'master' || $TRAVIS_PULL_REQUEST_SLUG != $TRAVIS_REPO_SLUG ]];
    then
      yarn chromatic-test;
    else


### PR DESCRIPTION
CI bugfix - don't auto accept changes from external PRs.

This resolves the CI issue we had on https://github.com/govuk-react/govuk-react/pull/497

@jsrobertson 


> TRAVIS_BRANCH:
for builds triggered by a pull request this is the name of the branch targeted by the pull request.

https://docs.travis-ci.com/user/environment-variables/#default-environment-variables