### PR TITLE
Fix responsive spacing size 5

### DIFF
--- a/components/lead-paragraph/package.json
+++ b/components/lead-paragraph/package.json
@@ -2,8 +2,8 @@
   "name": "@govuk-react/lead-paragraph",
   "version": "0.4.0",
   "dependencies": {
-    "@govuk-react/constants": "^0.4.0",
     "@govuk-react/hoc": "^0.4.0",
+    "@govuk-react/lib": "^0.4.0",
     "govuk-colours": "^1.0.3"
   },
   "peerDependencies": {

--- a/components/lead-paragraph/src/__snapshots__/test.js.snap
+++ b/components/lead-paragraph/src/__snapshots__/test.js.snap
@@ -2,33 +2,50 @@
 
 exports[`Styled matches wrapper snapshot: wrapper mount 1`] = `
 .emotion-3 {
-  margin-bottom: 15px;
+  margin-bottom: 20px;
 }
 
 @media only screen and (min-width:641px) {
   .emotion-3 {
-    margin-bottom: 45px;
+    margin-bottom: 30px;
   }
 }
 
 .emotion-1 {
+  color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
   font-size: 18px;
-  line-height: 1.3;
+  line-height: 1.1111111111111112;
   margin-top: 0;
-  margin-bottom: 15px;
+  margin-bottom: 20px;
+}
+
+@media print {
+  .emotion-1 {
+    color: #000;
+  }
+}
+
+@media print {
+  .emotion-1 {
+    font-size: 18px;
+    line-height: 1.15;
+  }
 }
 
 @media only screen and (min-width:641px) {
   .emotion-1 {
     font-size: 24px;
-    line-height: 1.35;
+    line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
   .emotion-1 {
-    margin-bottom: 45px;
+    margin-bottom: 30px;
   }
 }
 

--- a/components/lead-paragraph/src/index.js
+++ b/components/lead-paragraph/src/index.js
@@ -2,24 +2,13 @@ import React from 'react';
 import styled from 'react-emotion';
 import PropTypes from 'prop-types';
 import { withWhiteSpace } from '@govuk-react/hoc';
+import { typography } from '@govuk-react/lib';
 
-import {
-  FONT_SIZE,
-  LINE_HEIGHT,
-  MEDIA_QUERIES,
-  NTA_LIGHT,
-} from '@govuk-react/constants';
-
-const StyledParagraph = styled('p')({
-  fontFamily: NTA_LIGHT,
-  fontSize: FONT_SIZE.SIZE_18,
-  lineHeight: LINE_HEIGHT.SIZE_18,
-  marginTop: 0,
-  [MEDIA_QUERIES.LARGESCREEN]: {
-    fontSize: FONT_SIZE.SIZE_24,
-    lineHeight: LINE_HEIGHT.SIZE_24,
-  },
-});
+const StyledParagraph = styled('p')(
+  typography.textColour,
+  typography.font({ size: 24 }),
+  { marginTop: 0 },
+);
 
 /**
  *
@@ -32,7 +21,7 @@ const StyledParagraph = styled('p')({
  * ```
  *
  * ### References
- * - https://govuk-static.herokuapp.com/component-guide/lead_paragraph
+ * - https://design-system.service.gov.uk/styles/typography/#paragraphs
  */
 const LeadParagraph = props => <StyledParagraph {...props} />;
 
@@ -41,4 +30,4 @@ LeadParagraph.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-export default withWhiteSpace({ marginBottom: 5 })(LeadParagraph);
+export default withWhiteSpace({ marginBottom: 6 })(LeadParagraph);

--- a/components/radio/src/stories.js
+++ b/components/radio/src/stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Field } from 'react-final-form';
 import { storiesOf } from '@storybook/react';
 import PropTypes from 'prop-types';
-import { withKnobs, text } from '@storybook/addon-knobs/react';
+import { withKnobs } from '@storybook/addon-knobs/react';
 import { FinalFormWrapper, WithDocsCustom } from '@govuk-react/storybook-components';
 
 import MultiChoice from '@govuk-react/multi-choice';

--- a/packages/constants/src/spacing.js
+++ b/packages/constants/src/spacing.js
@@ -27,7 +27,7 @@ export const RESPONSIVE_4 = {
 
 export const RESPONSIVE_5 = {
   mobile: 15,
-  tablet: 45,
+  tablet: 25,
 };
 
 export const RESPONSIVE_6 = {

--- a/packages/hoc/src/withWhiteSpace/__snapshots__/test.js.snap
+++ b/packages/hoc/src/withWhiteSpace/__snapshots__/test.js.snap
@@ -8,13 +8,13 @@ exports[`withWhiteSpace matches wrapper snapshot 1`] = `
 
 @media only screen and (min-width:641px) {
   .emotion-0 {
-    margin-bottom: 45px;
+    margin-bottom: 25px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .emotion-0 {
-    margin-bottom: 45px;
+    margin-bottom: 25px;
   }
 }
 


### PR DESCRIPTION
As per #492, fix `RESPONSIVE_5` size definition

Fix snapshot tests affected

Also adjust `LeadParagraph` to use correct spacing, and new typography definitions

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
