### PR TITLE
Update Button styling

### DIFF
--- a/API.md
+++ b/API.md
@@ -105,18 +105,22 @@ import { ButtonArrow } from '@govuk-react/icons';
 ```
 
 ### References:
-- https://govuk-elements.herokuapp.com/buttons/
-- https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/design-patterns/_buttons.scss
+- https://design-system.service.gov.uk/components/button/
 - https://github.com/alphagov/govuk-frontend/blob/master/src/components/button/_button.scss
-- https://github.com/alphagov/govuk_elements/blob/master/packages/govuk-elements-sass/public/sass/elements/_buttons.scss
 
 ### TODO:
-- Use constants for some of the values cssinjs values
-- Remove cascade styling for nested elements such as `svg`
+- Remove cascade styling for nested elements, specifically `svg`
+- Consider ensuring text colour automatically switches between black/white based on WCAG guidance
+  - see https://www.w3.org/TR/WCAG20-TECHS/G18.html
+  - can use Polished's `readableColor` call, but translate their black to govuk's black
 
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
+ `buttonColour` |  | ```undefined``` | string | Override for default button colour
+ `buttonHoverColour` |  | ```undefined``` | string | Override for default button hover colour,<br/>which defaults to `buttonColour` darkened by 5%
+ `buttonShadowColour` |  | ```undefined``` | string | Override for default button shadow colour,<br/>which defaults to `buttonColour` darkened by 15%
+ `buttonTextColour` |  | ```undefined``` | string | Override for default button text colour,<br/>which defaults to govuk white
  `children` |  | ```'Button'``` | node | Button text
  `disabled` |  | ```false``` | bool | Renders a disabled button and removes pointer events if set to true
  `icon` |  | ```undefined``` | node | Button icon

--- a/components/button/README.md
+++ b/components/button/README.md
@@ -22,18 +22,22 @@ import { ButtonArrow } from '@govuk-react/icons';
 ```
 
 ### References:
-- https://govuk-elements.herokuapp.com/buttons/
-- https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/design-patterns/_buttons.scss
+- https://design-system.service.gov.uk/components/button/
 - https://github.com/alphagov/govuk-frontend/blob/master/src/components/button/_button.scss
-- https://github.com/alphagov/govuk_elements/blob/master/packages/govuk-elements-sass/public/sass/elements/_buttons.scss
 
 ### TODO:
-- Use constants for some of the values cssinjs values
-- Remove cascade styling for nested elements such as `svg`
+- Remove cascade styling for nested elements, specifically `svg`
+- Consider ensuring text colour automatically switches between black/white based on WCAG guidance
+  - see https://www.w3.org/TR/WCAG20-TECHS/G18.html
+  - can use Polished's `readableColor` call, but translate their black to govuk's black
 
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
+ `buttonColour` |  | ```undefined``` | string | Override for default button colour
+ `buttonHoverColour` |  | ```undefined``` | string | Override for default button hover colour,<br/>which defaults to `buttonColour` darkened by 5%
+ `buttonShadowColour` |  | ```undefined``` | string | Override for default button shadow colour,<br/>which defaults to `buttonColour` darkened by 15%
+ `buttonTextColour` |  | ```undefined``` | string | Override for default button text colour,<br/>which defaults to govuk white
  `children` |  | ```'Button'``` | node | Button text
  `disabled` |  | ```false``` | bool | Renders a disabled button and removes pointer events if set to true
  `icon` |  | ```undefined``` | node | Button icon

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -9,7 +9,9 @@
     "@govuk-react/constants": "^0.5.0",
     "@govuk-react/hoc": "^0.5.0",
     "@govuk-react/icons": "^0.5.0",
-    "govuk-colours": "^1.0.3"
+    "@govuk-react/lib": "^0.5.0",
+    "govuk-colours": "^1.0.3",
+    "polished": "^2.3.3"
   },
   "peerDependencies": {
     "emotion": ">=9",

--- a/components/button/src/__snapshots__/test.js.snap
+++ b/components/button/src/__snapshots__/test.js.snap
@@ -2,69 +2,121 @@
 
 exports[`button matches snapshot 1`] = `
 .emotion-3 {
-  margin-bottom: 15px;
+  margin-bottom: 20px;
 }
 
 @media only screen and (min-width:641px) {
   .emotion-3 {
-    margin-bottom: 20px;
+    margin-bottom: 30px;
   }
 }
 
 .emotion-1 {
-  background-color: #00823b;
-  border: none;
-  box-shadow: 0 2px 0 #003618;
-  color: #ffffff;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
   font-family: "nta",Arial,sans-serif;
-  font-weight: 400;
-  font-size: 1em;
-  line-height: 1.25;
-  outline-offset: -1px;
-  outline: 1px solid transparent;
-  padding: .526315em .789473em .263157em;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-appearance: none;
   -webkit-font-smoothing: antialiased;
-  opacity: 1;
-  pointer-events: auto;
-  padding-right: .84211em;
-  margin-bottom: 15px;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 19px;
+  box-sizing: border-box;
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  margin-top: 0;
+  padding: 7px 10px;
+  border: 2px solid transparent;
+  border-radius: 0;
+  color: #ffffff;
+  background-color: #00823b;
+  box-shadow: 0 2px 0 #003518;
+  text-align: center;
+  vertical-align: top;
+  cursor: pointer;
+  -webkit-appearance: none;
+  margin-bottom: 20px;
 }
 
-.emotion-1:hover {
-  background-color: #00692f;
-  color: #ffffff;
+@media print {
+  .emotion-1 {
+    font-size: 14px;
+    line-height: 19px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-1 {
+    font-size: 19px;
+    line-height: 19px;
+  }
 }
 
 .emotion-1:focus {
-  color: #ffffff;
-  background-color: #00692f;
   outline: 3px solid #ffbf47;
+  outline-offset: 0;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-1 {
+    width: auto;
+  }
+}
+
+.emotion-1:link,
+.emotion-1:visited,
+.emotion-1:active,
+.emotion-1:hover {
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-1::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+
+.emotion-1:hover,
+.emotion-1:focus {
+  background-color: #00692f;
 }
 
 .emotion-1:active {
-  position: relative;
   top: 2px;
-  box-shadow: 0 0 0 #003618;
+  box-shadow: none;
 }
 
-.emotion-1:visited {
-  color: #00823b;
+.emotion-1::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  bottom: -4px;
+  left: -2px;
+  background: transparent;
+}
+
+.emotion-1:active::before {
+  top: -4px;
+}
+
+.emotion-1:disabled {
+  opacity: 0.5;
+  background: #00823b;
+}
+
+.emotion-1:disabled:hover {
+  background-color: #00823b;
+  cursor: default;
+}
+
+.emotion-1:disabled:focus {
+  outline: none;
+}
+
+.emotion-1:disabled:active {
+  top: 0;
+  box-shadow: 0 2px 0 #003518;
 }
 
 .emotion-1 svg {
@@ -74,7 +126,7 @@ exports[`button matches snapshot 1`] = `
 
 @media only screen and (min-width:641px) {
   .emotion-1 {
-    margin-bottom: 20px;
+    margin-bottom: 30px;
   }
 }
 
@@ -105,21 +157,37 @@ exports[`button matches snapshot 1`] = `
 
 exports[`button with icon matches snapshot 1`] = `
 .emotion-3 {
-  margin-bottom: 15px;
+  margin-bottom: 20px;
 }
 
 @media only screen and (min-width:641px) {
   .emotion-3 {
-    margin-bottom: 20px;
+    margin-bottom: 30px;
   }
 }
 
 .emotion-1 {
-  background-color: #00823b;
-  border: none;
-  box-shadow: 0 2px 0 #003618;
+  font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1;
+  box-sizing: border-box;
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  margin-top: 0;
+  padding: 7px 10px;
+  border: 2px solid transparent;
+  border-radius: 0;
   color: #ffffff;
+  background-color: #00823b;
+  box-shadow: 0 2px 0 #003518;
+  text-align: center;
+  vertical-align: top;
   cursor: pointer;
+  -webkit-appearance: none;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -132,46 +200,90 @@ exports[`button with icon matches snapshot 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  font-family: "nta",Arial,sans-serif;
-  font-weight: 400;
-  font-size: 1em;
-  line-height: 1.25;
-  outline-offset: -1px;
-  outline: 1px solid transparent;
-  padding: .526315em .789473em .263157em;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-appearance: none;
-  -webkit-font-smoothing: antialiased;
-  opacity: 1;
-  pointer-events: auto;
-  font-weight: 700;
-  font-size: 24px;
-  line-height: 1.25;
-  padding: .36842em .84211em .21053em;
-  padding-right: .54211em;
-  margin-bottom: 15px;
+  margin-bottom: 20px;
 }
 
-.emotion-1:hover {
-  background-color: #00692f;
-  color: #ffffff;
+@media print {
+  .emotion-1 {
+    font-size: 18px;
+    line-height: 1;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-1 {
+    font-size: 24px;
+    line-height: 1;
+  }
 }
 
 .emotion-1:focus {
-  color: #ffffff;
-  background-color: #00692f;
   outline: 3px solid #ffbf47;
+  outline-offset: 0;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-1 {
+    width: auto;
+  }
+}
+
+.emotion-1:link,
+.emotion-1:visited,
+.emotion-1:active,
+.emotion-1:hover {
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-1::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+
+.emotion-1:hover,
+.emotion-1:focus {
+  background-color: #00692f;
 }
 
 .emotion-1:active {
-  position: relative;
   top: 2px;
-  box-shadow: 0 0 0 #003618;
+  box-shadow: none;
 }
 
-.emotion-1:visited {
-  color: #00823b;
+.emotion-1::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  bottom: -4px;
+  left: -2px;
+  background: transparent;
+}
+
+.emotion-1:active::before {
+  top: -4px;
+}
+
+.emotion-1:disabled {
+  opacity: 0.5;
+  background: #00823b;
+}
+
+.emotion-1:disabled:hover {
+  background-color: #00823b;
+  cursor: default;
+}
+
+.emotion-1:disabled:focus {
+  outline: none;
+}
+
+.emotion-1:disabled:active {
+  top: 0;
+  box-shadow: 0 2px 0 #003518;
 }
 
 .emotion-1 svg {
@@ -181,7 +293,7 @@ exports[`button with icon matches snapshot 1`] = `
 
 @media only screen and (min-width:641px) {
   .emotion-1 {
-    margin-bottom: 20px;
+    margin-bottom: 30px;
   }
 }
 
@@ -268,69 +380,121 @@ exports[`button with icon matches snapshot 1`] = `
 
 exports[`disabled button matches snapshot 1`] = `
 .emotion-3 {
-  margin-bottom: 15px;
+  margin-bottom: 20px;
 }
 
 @media only screen and (min-width:641px) {
   .emotion-3 {
-    margin-bottom: 20px;
+    margin-bottom: 30px;
   }
 }
 
 .emotion-1 {
-  background-color: #00823b;
-  border: none;
-  box-shadow: 0 2px 0 #003618;
-  color: #ffffff;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
   font-family: "nta",Arial,sans-serif;
-  font-weight: 400;
-  font-size: 1em;
-  line-height: 1.25;
-  outline-offset: -1px;
-  outline: 1px solid transparent;
-  padding: .526315em .789473em .263157em;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-appearance: none;
   -webkit-font-smoothing: antialiased;
-  opacity: .5;
-  pointer-events: none;
-  padding-right: .84211em;
-  margin-bottom: 15px;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 19px;
+  box-sizing: border-box;
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  margin-top: 0;
+  padding: 7px 10px;
+  border: 2px solid transparent;
+  border-radius: 0;
+  color: #ffffff;
+  background-color: #00823b;
+  box-shadow: 0 2px 0 #003518;
+  text-align: center;
+  vertical-align: top;
+  cursor: pointer;
+  -webkit-appearance: none;
+  margin-bottom: 20px;
 }
 
-.emotion-1:hover {
-  background-color: #00692f;
-  color: #ffffff;
+@media print {
+  .emotion-1 {
+    font-size: 14px;
+    line-height: 19px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-1 {
+    font-size: 19px;
+    line-height: 19px;
+  }
 }
 
 .emotion-1:focus {
-  color: #ffffff;
-  background-color: #00692f;
   outline: 3px solid #ffbf47;
+  outline-offset: 0;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-1 {
+    width: auto;
+  }
+}
+
+.emotion-1:link,
+.emotion-1:visited,
+.emotion-1:active,
+.emotion-1:hover {
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-1::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+
+.emotion-1:hover,
+.emotion-1:focus {
+  background-color: #00692f;
 }
 
 .emotion-1:active {
-  position: relative;
   top: 2px;
-  box-shadow: 0 0 0 #003618;
+  box-shadow: none;
 }
 
-.emotion-1:visited {
-  color: #00823b;
+.emotion-1::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  bottom: -4px;
+  left: -2px;
+  background: transparent;
+}
+
+.emotion-1:active::before {
+  top: -4px;
+}
+
+.emotion-1:disabled {
+  opacity: 0.5;
+  background: #00823b;
+}
+
+.emotion-1:disabled:hover {
+  background-color: #00823b;
+  cursor: default;
+}
+
+.emotion-1:disabled:focus {
+  outline: none;
+}
+
+.emotion-1:disabled:active {
+  top: 0;
+  box-shadow: 0 2px 0 #003518;
 }
 
 .emotion-1 svg {
@@ -340,7 +504,7 @@ exports[`disabled button matches snapshot 1`] = `
 
 @media only screen and (min-width:641px) {
   .emotion-1 {
-    margin-bottom: 20px;
+    margin-bottom: 30px;
   }
 }
 
@@ -373,73 +537,121 @@ exports[`disabled button matches snapshot 1`] = `
 
 exports[`start button matches snapshot 1`] = `
 .emotion-3 {
-  margin-bottom: 15px;
+  margin-bottom: 20px;
 }
 
 @media only screen and (min-width:641px) {
   .emotion-3 {
-    margin-bottom: 20px;
+    margin-bottom: 30px;
   }
 }
 
 .emotion-1 {
-  background-color: #00823b;
-  border: none;
-  box-shadow: 0 2px 0 #003618;
-  color: #ffffff;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
   font-family: "nta",Arial,sans-serif;
-  font-weight: 400;
-  font-size: 1em;
-  line-height: 1.25;
-  outline-offset: -1px;
-  outline: 1px solid transparent;
-  padding: .526315em .789473em .263157em;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-appearance: none;
   -webkit-font-smoothing: antialiased;
-  opacity: 1;
-  pointer-events: auto;
-  font-weight: 700;
-  font-size: 24px;
-  line-height: 1.25;
-  padding: .36842em .84211em .21053em;
-  padding-right: .84211em;
-  margin-bottom: 15px;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1;
+  box-sizing: border-box;
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  margin-top: 0;
+  padding: 7px 10px;
+  border: 2px solid transparent;
+  border-radius: 0;
+  color: #ffffff;
+  background-color: #00823b;
+  box-shadow: 0 2px 0 #003518;
+  text-align: center;
+  vertical-align: top;
+  cursor: pointer;
+  -webkit-appearance: none;
+  margin-bottom: 20px;
 }
 
-.emotion-1:hover {
-  background-color: #00692f;
-  color: #ffffff;
+@media print {
+  .emotion-1 {
+    font-size: 18px;
+    line-height: 1;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-1 {
+    font-size: 24px;
+    line-height: 1;
+  }
 }
 
 .emotion-1:focus {
-  color: #ffffff;
-  background-color: #00692f;
   outline: 3px solid #ffbf47;
+  outline-offset: 0;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-1 {
+    width: auto;
+  }
+}
+
+.emotion-1:link,
+.emotion-1:visited,
+.emotion-1:active,
+.emotion-1:hover {
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-1::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+
+.emotion-1:hover,
+.emotion-1:focus {
+  background-color: #00692f;
 }
 
 .emotion-1:active {
-  position: relative;
   top: 2px;
-  box-shadow: 0 0 0 #003618;
+  box-shadow: none;
 }
 
-.emotion-1:visited {
-  color: #00823b;
+.emotion-1::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  bottom: -4px;
+  left: -2px;
+  background: transparent;
+}
+
+.emotion-1:active::before {
+  top: -4px;
+}
+
+.emotion-1:disabled {
+  opacity: 0.5;
+  background: #00823b;
+}
+
+.emotion-1:disabled:hover {
+  background-color: #00823b;
+  cursor: default;
+}
+
+.emotion-1:disabled:focus {
+  outline: none;
+}
+
+.emotion-1:disabled:active {
+  top: 0;
+  box-shadow: 0 2px 0 #003518;
 }
 
 .emotion-1 svg {
@@ -449,7 +661,7 @@ exports[`start button matches snapshot 1`] = `
 
 @media only screen and (min-width:641px) {
   .emotion-1 {
-    margin-bottom: 20px;
+    margin-bottom: 30px;
   }
 }
 

--- a/components/button/src/__snapshots__/test.js.snap
+++ b/components/button/src/__snapshots__/test.js.snap
@@ -121,7 +121,12 @@ exports[`button matches snapshot 1`] = `
 
 .emotion-1 svg {
   max-width: 15px;
-  margin-left: 20px;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-1 svg {
+    margin-left: 10px;
+  }
 }
 
 @media only screen and (min-width:641px) {
@@ -156,17 +161,17 @@ exports[`button matches snapshot 1`] = `
 `;
 
 exports[`button with icon matches snapshot 1`] = `
-.emotion-3 {
+.emotion-5 {
   margin-bottom: 20px;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-3 {
+  .emotion-5 {
     margin-bottom: 30px;
   }
 }
 
-.emotion-1 {
+.emotion-3 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -204,55 +209,55 @@ exports[`button with icon matches snapshot 1`] = `
 }
 
 @media print {
-  .emotion-1 {
+  .emotion-3 {
     font-size: 18px;
     line-height: 1;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-1 {
+  .emotion-3 {
     font-size: 24px;
     line-height: 1;
   }
 }
 
-.emotion-1:focus {
+.emotion-3:focus {
   outline: 3px solid #ffbf47;
   outline-offset: 0;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-1 {
+  .emotion-3 {
     width: auto;
   }
 }
 
-.emotion-1:link,
-.emotion-1:visited,
-.emotion-1:active,
-.emotion-1:hover {
+.emotion-3:link,
+.emotion-3:visited,
+.emotion-3:active,
+.emotion-3:hover {
   color: #ffffff;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-1::-moz-focus-inner {
+.emotion-3::-moz-focus-inner {
   padding: 0;
   border: 0;
 }
 
-.emotion-1:hover,
-.emotion-1:focus {
+.emotion-3:hover,
+.emotion-3:focus {
   background-color: #00692f;
 }
 
-.emotion-1:active {
+.emotion-3:active {
   top: 2px;
   box-shadow: none;
 }
 
-.emotion-1::before {
+.emotion-3::before {
   content: "";
   display: block;
   position: absolute;
@@ -263,38 +268,50 @@ exports[`button with icon matches snapshot 1`] = `
   background: transparent;
 }
 
-.emotion-1:active::before {
+.emotion-3:active::before {
   top: -4px;
 }
 
-.emotion-1:disabled {
+.emotion-3:disabled {
   opacity: 0.5;
   background: #00823b;
 }
 
-.emotion-1:disabled:hover {
+.emotion-3:disabled:hover {
   background-color: #00823b;
   cursor: default;
 }
 
-.emotion-1:disabled:focus {
+.emotion-3:disabled:focus {
   outline: none;
 }
 
-.emotion-1:disabled:active {
+.emotion-3:disabled:active {
   top: 0;
   box-shadow: 0 2px 0 #003518;
 }
 
-.emotion-1 svg {
+.emotion-3 svg {
   max-width: 15px;
-  margin-left: 20px;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-1 {
+  .emotion-3 svg {
+    margin-left: 10px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-3 {
     margin-bottom: 30px;
   }
+}
+
+.emotion-0 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 <ButtonStartIcon>
@@ -309,7 +326,7 @@ exports[`button with icon matches snapshot 1`] = `
     start={true}
   >
     <Button
-      className="emotion-3 emotion-0"
+      className="emotion-5 emotion-2"
       disabled={false}
       icon={
         <ButtonArrow
@@ -320,7 +337,7 @@ exports[`button with icon matches snapshot 1`] = `
       start={true}
     >
       <StyledButton
-        className="emotion-3 emotion-0"
+        className="emotion-5 emotion-2"
         disabled={false}
         icon={
           <ButtonArrow
@@ -331,10 +348,16 @@ exports[`button with icon matches snapshot 1`] = `
         isStart={true}
       >
         <button
-          className="emotion-0 emotion-1 emotion-2"
+          className="emotion-2 emotion-3 emotion-4"
           disabled={false}
         >
-          Start now
+          <ButtonContents>
+            <span
+              className="emotion-0 emotion-1"
+            >
+              Start now
+            </span>
+          </ButtonContents>
           <ButtonArrow
             fill="currentColor"
             title="ButtonArrow"
@@ -499,7 +522,12 @@ exports[`disabled button matches snapshot 1`] = `
 
 .emotion-1 svg {
   max-width: 15px;
-  margin-left: 20px;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-1 svg {
+    margin-left: 10px;
+  }
 }
 
 @media only screen and (min-width:641px) {
@@ -656,7 +684,12 @@ exports[`start button matches snapshot 1`] = `
 
 .emotion-1 svg {
   max-width: 15px;
-  margin-left: 20px;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-1 svg {
+    margin-left: 10px;
+  }
 }
 
 @media only screen and (min-width:641px) {

--- a/components/button/src/__snapshots__/test.js.snap
+++ b/components/button/src/__snapshots__/test.js.snap
@@ -178,7 +178,7 @@ exports[`button with icon matches snapshot 1`] = `
   position: relative;
   width: 100%;
   margin-top: 0;
-  padding: 7px 10px;
+  padding: 8px 15px;
   border: 2px solid transparent;
   border-radius: 0;
   color: #ffffff;
@@ -558,7 +558,7 @@ exports[`start button matches snapshot 1`] = `
   position: relative;
   width: 100%;
   margin-top: 0;
-  padding: 7px 10px;
+  padding: 8px 15px;
   border: 2px solid transparent;
   border-radius: 0;
   color: #ffffff;

--- a/components/button/src/__snapshots__/test.js.snap
+++ b/components/button/src/__snapshots__/test.js.snap
@@ -170,7 +170,7 @@ exports[`button with icon matches snapshot 1`] = `
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  font-weight: 400;
+  font-weight: 700;
   font-size: 18px;
   line-height: 1;
   box-sizing: border-box;
@@ -550,7 +550,7 @@ exports[`start button matches snapshot 1`] = `
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  font-weight: 400;
+  font-weight: 700;
   font-size: 18px;
   line-height: 1;
   box-sizing: border-box;

--- a/components/button/src/fixtures.js
+++ b/components/button/src/fixtures.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { boolean, text } from '@storybook/addon-knobs/react';
 import { ButtonArrow } from '@govuk-react/icons';
+import { BLUE, TEXT_COLOUR, YELLOW, GREY_3, ORANGE } from 'govuk-colours';
 
 import Button from '.';
 
@@ -30,6 +31,19 @@ const ButtonDisabledStartIcon = () => (
   </Button>
 );
 
+const ButtonBlue = () => <Button buttonColour={BLUE}>Blue button</Button>;
+
+const ButtonWacky = () => (
+  <Button
+    buttonColour={GREY_3}
+    buttonHoverColour={YELLOW}
+    buttonShadowColour={ORANGE}
+    buttonTextColour={TEXT_COLOUR}
+  >
+    Wacky colours
+  </Button>
+);
+
 export default Button;
 
 export {
@@ -38,4 +52,6 @@ export {
   ButtonStartIcon,
   ButtonDisabled,
   ButtonDisabledStartIcon,
+  ButtonBlue,
+  ButtonWacky,
 };

--- a/components/button/src/index.js
+++ b/components/button/src/index.js
@@ -114,7 +114,9 @@ const StyledButton = styled('button')(
 
     ' svg': {
       maxWidth: '15px',
-      marginLeft: SPACING_POINTS[4],
+      [MEDIA_QUERIES.TABLET]: {
+        marginLeft: SPACING_POINTS[2],
+      },
     },
   }),
 
@@ -131,6 +133,10 @@ const StyledButton = styled('button')(
     return undefined;
   },
 );
+
+const ButtonContents = styled('span')({
+  flexGrow: 1,
+});
 
 /**
  *
@@ -165,7 +171,7 @@ const Button = ({
   ...props
 }) => (
   <StyledButton isStart={start} icon={icon} {...props}>
-    {children}
+    {icon ? <ButtonContents>{children}</ButtonContents> : children}
     {icon}
   </StyledButton>
 );

--- a/components/button/src/index.js
+++ b/components/button/src/index.js
@@ -16,6 +16,11 @@ import {
 import { darken, stripUnit } from 'polished';
 
 const BUTTON_SHADOW_SIZE = BORDER_WIDTH_FORM_ELEMENT;
+const RAW_SPACING_2 = stripUnit(SPACING_POINTS[2]);
+const RAW_BORDER_WIDTH = stripUnit(BORDER_WIDTH_FORM_ELEMENT);
+const RAW_SHADOW = stripUnit(BUTTON_SHADOW_SIZE);
+const HALF_SHADOW = RAW_SHADOW / 2;
+const BASE_PAD = RAW_SPACING_2 - RAW_BORDER_WIDTH;
 
 const StyledButton = styled('button')(
   ({ isStart }) => typography.font({
@@ -30,17 +35,16 @@ const StyledButton = styled('button')(
     buttonHoverColour = darken(0.05, buttonColour),
     buttonShadowColour = darken(0.15, buttonColour),
     buttonTextColour = WHITE,
+    isStart,
   }) => ({
     boxSizing: 'border-box',
     display: 'inline-block',
     position: 'relative',
     width: '100%',
     marginTop: 0,
-    padding: `${
-      stripUnit(SPACING_POINTS[2])
-      - stripUnit(BORDER_WIDTH_FORM_ELEMENT)
-      - (stripUnit(BUTTON_SHADOW_SIZE) / 2)
-    }px ${SPACING_POINTS[2]}`,
+    padding: isStart ? // differs from govuk-frontend owing to how icons displayed
+      `${BASE_PAD}px ${SPACING_POINTS[3]}`
+      : `${BASE_PAD - HALF_SHADOW}px ${SPACING_POINTS[2]}`,
     border: `${BORDER_WIDTH_FORM_ELEMENT} solid transparent`,
     borderRadius: 0,
     color: buttonTextColour,
@@ -83,13 +87,13 @@ const StyledButton = styled('button')(
       position: 'absolute',
       top: `-${BORDER_WIDTH_FORM_ELEMENT}`,
       right: `-${BORDER_WIDTH_FORM_ELEMENT}`,
-      bottom: `-${stripUnit(BORDER_WIDTH_FORM_ELEMENT) + stripUnit(BUTTON_SHADOW_SIZE)}px`,
+      bottom: `-${RAW_BORDER_WIDTH + RAW_SHADOW}px`,
       left: `-${BORDER_WIDTH_FORM_ELEMENT}`,
       background: 'transparent',
     },
 
     '&:active::before': {
-      top: `-${stripUnit(BORDER_WIDTH_FORM_ELEMENT) + stripUnit(BUTTON_SHADOW_SIZE)}px`,
+      top: `-${RAW_BORDER_WIDTH + RAW_SHADOW}px`,
     },
 
     ':disabled': {

--- a/components/button/src/index.js
+++ b/components/button/src/index.js
@@ -2,67 +2,129 @@ import styled from 'react-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { withWhiteSpace } from '@govuk-react/hoc';
-import { NTA_LIGHT, SPACING } from '@govuk-react/constants';
+import {
+  BORDER_WIDTH_FORM_ELEMENT,
+  FOCUSABLE,
+  MEDIA_QUERIES,
+  SPACING_POINTS,
+} from '@govuk-react/constants';
+import { typography } from '@govuk-react/lib';
 import {
   BUTTON_COLOUR,
-  BUTTON_COLOUR_DARKEN_15,
   WHITE,
-  YELLOW,
 } from 'govuk-colours';
+import { darken, stripUnit } from 'polished';
 
-const BUTTON_COLOUR_DARKEN_5 = '#00692f'; // darken(#00823b, 5%)
+const BUTTON_SHADOW_SIZE = BORDER_WIDTH_FORM_ELEMENT;
 
 const StyledButton = styled('button')(
-  {
-    backgroundColor: BUTTON_COLOUR,
-    border: 'none',
-    boxShadow: `0 2px 0 ${BUTTON_COLOUR_DARKEN_15}`,
-    color: WHITE,
+  ({ isStart }) => typography.font({
+    size: isStart ? 24 : 19,
+    lineHeight: isStart ? '1' : '19px',
+  }),
+  FOCUSABLE,
+
+  ({
+    buttonColour = BUTTON_COLOUR,
+    buttonHoverColour = darken(0.05, buttonColour),
+    buttonShadowColour = darken(0.15, buttonColour),
+    buttonTextColour = WHITE,
+  }) => ({
+    boxSizing: 'border-box',
+    display: 'inline-block',
+    position: 'relative',
+    width: '100%',
+    marginTop: 0,
+    padding: `${
+      stripUnit(SPACING_POINTS[2])
+      - stripUnit(BORDER_WIDTH_FORM_ELEMENT)
+      - (stripUnit(BUTTON_SHADOW_SIZE) / 2)
+    }px ${SPACING_POINTS[2]}`,
+    border: `${BORDER_WIDTH_FORM_ELEMENT} solid transparent`,
+    borderRadius: 0,
+    color: buttonTextColour,
+    backgroundColor: buttonColour,
+    boxShadow: `0 ${BUTTON_SHADOW_SIZE} 0 ${buttonShadowColour}`,
+    textAlign: 'center',
+    verticalAlign: 'top',
     cursor: 'pointer',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    fontFamily: NTA_LIGHT,
-    fontWeight: 400,
-    fontSize: '1em',
-    lineHeight: '1.25',
-    outlineOffset: '-1px',
-    outline: '1px solid transparent',
-    padding: '.526315em .789473em .263157em',
-    textDecoration: 'none',
     WebkitAppearance: 'none',
-    WebkitFontSmoothing: 'antialiased',
-    ':hover': {
-      backgroundColor: BUTTON_COLOUR_DARKEN_5,
-      color: WHITE,
+
+    [MEDIA_QUERIES.TABLET]: {
+      width: 'auto',
     },
-    ':focus': {
-      color: WHITE,
-      backgroundColor: BUTTON_COLOUR_DARKEN_5,
-      outline: `3px solid ${YELLOW}`,
+
+    '&:link, &:visited, &:active, &:hover': {
+      color: buttonTextColour,
+      textDecoration: 'none',
     },
+
+    '&::-moz-focus-inner': {
+      padding: 0,
+      border: 0,
+    },
+
+    '&:hover, &:focus': {
+      backgroundColor: buttonHoverColour,
+    },
+
     ':active': {
-      position: 'relative',
-      top: '2px',
-      boxShadow: `0 0 0 ${BUTTON_COLOUR_DARKEN_15}`,
+      top: BUTTON_SHADOW_SIZE,
+      boxShadow: 'none',
     },
-    ':visited': {
-      color: BUTTON_COLOUR,
+
+    // NB this is from govuk-frontend
+    // Use a pseudo element to expand the click target area to include the
+    // button's shadow as well, in case users try to click it.
+    '::before': {
+      content: '""',
+      display: 'block',
+      position: 'absolute',
+      top: `-${BORDER_WIDTH_FORM_ELEMENT}`,
+      right: `-${BORDER_WIDTH_FORM_ELEMENT}`,
+      bottom: `-${stripUnit(BORDER_WIDTH_FORM_ELEMENT) + stripUnit(BUTTON_SHADOW_SIZE)}px`,
+      left: `-${BORDER_WIDTH_FORM_ELEMENT}`,
+      background: 'transparent',
     },
+
+    '&:active::before': {
+      top: `-${stripUnit(BORDER_WIDTH_FORM_ELEMENT) + stripUnit(BUTTON_SHADOW_SIZE)}px`,
+    },
+
+    ':disabled': {
+      opacity: 0.5,
+      background: buttonColour,
+      ':hover': {
+        backgroundColor: buttonColour,
+        cursor: 'default',
+      },
+      ':focus': {
+        outline: 'none',
+      },
+      ':active': {
+        top: 0,
+        boxShadow: `0 ${BUTTON_SHADOW_SIZE} 0 ${buttonShadowColour}`,
+      },
+    },
+
     ' svg': {
       maxWidth: '15px',
-      marginLeft: SPACING.SCALE_4,
+      marginLeft: SPACING_POINTS[4],
     },
-  },
-  ({ isStart, disabled, icon }) => ({
-    opacity: disabled ? '.5' : '1',
-    pointerEvents: disabled ? 'none' : 'auto',
-    fontWeight: isStart ? '700' : undefined,
-    fontSize: isStart ? '24px' : undefined,
-    lineHeight: isStart ? '1.25' : undefined,
-    padding: isStart ? '.36842em .84211em .21053em' : undefined,
-    paddingRight: icon ? '.54211em' : '.84211em',
   }),
+
+  // NB we drift from govuk-frontend here in how we display icons
+  ({ icon }) => {
+    if (icon) {
+      return {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+      };
+    }
+
+    return undefined;
+  },
 );
 
 /**
@@ -82,14 +144,14 @@ const StyledButton = styled('button')(
  * ```
  *
  * ### References:
- * - https://govuk-elements.herokuapp.com/buttons/
- * - https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/design-patterns/_buttons.scss
+ * - https://design-system.service.gov.uk/components/button/
  * - https://github.com/alphagov/govuk-frontend/blob/master/src/components/button/_button.scss
- * - https://github.com/alphagov/govuk_elements/blob/master/packages/govuk-elements-sass/public/sass/elements/_buttons.scss
  *
  * ### TODO:
- * - Use constants for some of the values cssinjs values
- * - Remove cascade styling for nested elements such as `svg`
+ * - Remove cascade styling for nested elements, specifically `svg`
+ * - Consider ensuring text colour automatically switches between black/white based on WCAG guidance
+ *   - see https://www.w3.org/TR/WCAG20-TECHS/G18.html
+ *   - can use Polished's `readableColor` call, but translate their black to govuk's black
  */
 const Button = ({
   start,
@@ -120,6 +182,25 @@ Button.propTypes = {
    * Renders a disabled button and removes pointer events if set to true
    */
   disabled: PropTypes.bool,
+  /**
+   * Override for default button colour
+   */
+  buttonColour: PropTypes.string,
+  /**
+   * Override for default button hover colour,
+   * which defaults to `buttonColour` darkened by 5%
+   */
+  buttonHoverColour: PropTypes.string,
+  /**
+   * Override for default button shadow colour,
+   * which defaults to `buttonColour` darkened by 15%
+   */
+  buttonShadowColour: PropTypes.string,
+  /**
+   * Override for default button text colour,
+   * which defaults to govuk white
+   */
+  buttonTextColour: PropTypes.string,
 };
 
 Button.defaultProps = {
@@ -127,6 +208,10 @@ Button.defaultProps = {
   icon: undefined,
   disabled: false,
   start: false,
+  buttonColour: undefined,
+  buttonHoverColour: undefined,
+  buttonShadowColour: undefined,
+  buttonTextColour: undefined,
 };
 
-export default withWhiteSpace({ marginBottom: 4 })(Button);
+export default withWhiteSpace({ marginBottom: 6, adjustment: BUTTON_SHADOW_SIZE })(Button);

--- a/components/button/src/index.js
+++ b/components/button/src/index.js
@@ -21,6 +21,7 @@ const StyledButton = styled('button')(
   ({ isStart }) => typography.font({
     size: isStart ? 24 : 19,
     lineHeight: isStart ? '1' : '19px',
+    weight: isStart ? 'bold' : undefined,
   }),
   FOCUSABLE,
 

--- a/components/button/src/stories.js
+++ b/components/button/src/stories.js
@@ -8,6 +8,8 @@ import {
   ButtonStartIcon,
   ButtonDisabled,
   ButtonDisabledStartIcon,
+  ButtonBlue,
+  ButtonWacky,
 } from './fixtures';
 import ReadMe from '../README.md';
 
@@ -26,3 +28,7 @@ examples.add('Start with icon', ButtonStartIcon);
 examples.add('Disabled', ButtonDisabled);
 
 examples.add('Disabled start with icon', ButtonDisabledStartIcon);
+
+examples.add('Custom colour', ButtonBlue);
+
+examples.add('Custom colours (all options)', ButtonWacky);

--- a/packages/hoc/src/withWhiteSpace/index.js
+++ b/packages/hoc/src/withWhiteSpace/index.js
@@ -2,6 +2,12 @@ import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 import { SPACING_MAP, SPACING_MAP_INDEX, MEDIA_QUERIES } from '@govuk-react/constants';
 
+// TODO add support for other white-space options
+// and also `adjustment` value (e.g. see Button)
+// https://github.com/alphagov/govuk-frontend/blob/master/src/helpers/_spacing.scss
+// https://github.com/alphagov/govuk-frontend/blob/master/src/overrides/_spacing.scss
+// https://github.com/alphagov/govuk-frontend/blob/master/src/settings/_spacing.scss
+
 const withWhiteSpace = (config = {}) => (Component) => {
   const StyledHoc = styled(Component)(({ mb: marginBottom = config.marginBottom }) => (
     marginBottom !== undefined ? {
@@ -21,4 +27,3 @@ const withWhiteSpace = (config = {}) => (Component) => {
 };
 
 export default withWhiteSpace;
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,6 +676,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.2.0":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
+  integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@^7.1.0", "@babel/template@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
@@ -9169,6 +9176,13 @@ pn@^1.1.0:
 pngjs@^3.0.0:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.3.3.tgz#85173703bde3edac8998757b96e5821d0966a21b"
+
+polished@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-2.3.3.tgz#bdbaba962ba8271b0e11aa287f2befd4c87be99a"
+  integrity sha512-59V4fDbdxtH4I1m9TWxFsoGJbC8nnOpUYo5uFmvMfKp9Qh+6suo4VMUle1TGIIUZIGxfkW+Rs485zPk0wcwR2Q==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
`Button` component now styled more consistently with govuk-frontend
Supports following additional new props:
* `buttonColour` to override default button colour
* `buttonHoverColour` which defaults to `buttonColour` darkened by 5%
* `buttonShadowColour` which defaults to `buttonColour` darkened by 15%
* `buttonTextColour` which defaults to govuk white

TODO:
`withWhiteSpace` HOC does not yet support `adjustment` value, which `Button` now attempts to use, so this needs to be added - however that can be done in a later PR

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
