### PR TITLE
Button shadow colour tweak

### DIFF
--- a/components/button/src/__snapshots__/test.js.snap
+++ b/components/button/src/__snapshots__/test.js.snap
@@ -28,7 +28,7 @@ exports[`button matches snapshot 1`] = `
   border-radius: 0;
   color: #ffffff;
   background-color: #00823b;
-  box-shadow: 0 2px 0 #003518;
+  box-shadow: 0 2px 0 #003618;
   text-align: center;
   vertical-align: top;
   cursor: pointer;
@@ -116,7 +116,7 @@ exports[`button matches snapshot 1`] = `
 
 .emotion-1:disabled:active {
   top: 0;
-  box-shadow: 0 2px 0 #003518;
+  box-shadow: 0 2px 0 #003618;
 }
 
 .emotion-1 svg {
@@ -188,7 +188,7 @@ exports[`button with icon matches snapshot 1`] = `
   border-radius: 0;
   color: #ffffff;
   background-color: #00823b;
-  box-shadow: 0 2px 0 #003518;
+  box-shadow: 0 2px 0 #003618;
   text-align: center;
   vertical-align: top;
   cursor: pointer;
@@ -288,7 +288,7 @@ exports[`button with icon matches snapshot 1`] = `
 
 .emotion-3:disabled:active {
   top: 0;
-  box-shadow: 0 2px 0 #003518;
+  box-shadow: 0 2px 0 #003618;
 }
 
 .emotion-3 svg {
@@ -429,7 +429,7 @@ exports[`disabled button matches snapshot 1`] = `
   border-radius: 0;
   color: #ffffff;
   background-color: #00823b;
-  box-shadow: 0 2px 0 #003518;
+  box-shadow: 0 2px 0 #003618;
   text-align: center;
   vertical-align: top;
   cursor: pointer;
@@ -517,7 +517,7 @@ exports[`disabled button matches snapshot 1`] = `
 
 .emotion-1:disabled:active {
   top: 0;
-  box-shadow: 0 2px 0 #003518;
+  box-shadow: 0 2px 0 #003618;
 }
 
 .emotion-1 svg {
@@ -591,7 +591,7 @@ exports[`start button matches snapshot 1`] = `
   border-radius: 0;
   color: #ffffff;
   background-color: #00823b;
-  box-shadow: 0 2px 0 #003518;
+  box-shadow: 0 2px 0 #003618;
   text-align: center;
   vertical-align: top;
   cursor: pointer;
@@ -679,7 +679,7 @@ exports[`start button matches snapshot 1`] = `
 
 .emotion-1:disabled:active {
   top: 0;
-  box-shadow: 0 2px 0 #003518;
+  box-shadow: 0 2px 0 #003618;
 }
 
 .emotion-1 svg {

--- a/components/button/src/index.js
+++ b/components/button/src/index.js
@@ -11,6 +11,7 @@ import {
 import { typography } from '@govuk-react/lib';
 import {
   BUTTON_COLOUR,
+  BUTTON_COLOUR_DARKEN_15,
   WHITE,
 } from 'govuk-colours';
 import { darken, stripUnit } from 'polished';
@@ -33,7 +34,8 @@ const StyledButton = styled('button')(
   ({
     buttonColour = BUTTON_COLOUR,
     buttonHoverColour = darken(0.05, buttonColour),
-    buttonShadowColour = darken(0.15, buttonColour),
+    buttonShadowColour = (buttonColour === BUTTON_COLOUR) ?
+      BUTTON_COLOUR_DARKEN_15 : darken(0.15, buttonColour),
     buttonTextColour = WHITE,
     isStart,
   }) => ({


### PR DESCRIPTION
Ensure our (default) button shadow colour exactly matches govuk-frontend
(using `darken(0.15, buttonColour)` from polished is producing a colour with a value that's 1 darker in the green channel vs govuk-frontend's sass `darken($govuk-button-colour, 15%)`)

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
