### PR TITLE
Enhanced withWhiteSpace HOC

### DIFF
--- a/components/error-summary/src/__snapshots__/test.js.snap
+++ b/components/error-summary/src/__snapshots__/test.js.snap
@@ -245,24 +245,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
   }
 }
 
-.emotion-82 {
-  margin-bottom: 0;
-  margin-bottom: 0;
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-82 {
-    margin-bottom: 0;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-82 {
-    margin-bottom: 0;
-  }
-}
-
-.emotion-79 {
+.emotion-78 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -272,23 +255,16 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
   flex-direction: column;
   box-sizing: border-box;
   margin-bottom: 0;
-  margin-bottom: 0;
 }
 
-.emotion-79:after {
+.emotion-78:after {
   content: '';
   display: table;
   clear: both;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-79 {
-    margin-bottom: 0;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-79 {
+  .emotion-78 {
     margin-bottom: 0;
   }
 }
@@ -407,31 +383,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
   }
 }
 
-.emotion-101 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  box-sizing: border-box;
-  margin-bottom: 0;
-}
-
-.emotion-101:after {
-  content: '';
-  display: table;
-  clear: both;
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-101 {
-    margin-bottom: 0;
-  }
-}
-
-.emotion-98 {
+.emotion-91 {
   box-sizing: border-box;
   font-family: "nta",Arial,sans-serif;
   font-weight: 400;
@@ -444,14 +396,14 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-98 {
+  .emotion-91 {
     font-size: 19px;
     line-height: 1.3;
     width: 75%;
   }
 }
 
-.emotion-98:focus {
+.emotion-91:focus {
   outline: 3px solid #ffbf47;
   outline-offset: 0;
 }
@@ -698,89 +650,80 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
         </StyledErrorSummary>
       </ErrorSummary>
     </StyledHoc>
-    <StyledHoc
+    <InputField
       hint="It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
       input={Object {}}
       meta={Object {}}
       name="national-insurance-number"
     >
-      <InputField
-        className="emotion-27 emotion-0"
-        hint="It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
-        input={Object {}}
-        meta={Object {}}
+      <StyledHoc
         name="national-insurance-number"
       >
-        <StyledHoc
+        <Label
           className="emotion-27 emotion-0"
           name="national-insurance-number"
         >
-          <Label
-            className="emotion-0 emotion-82 emotion-0"
+          <StyledLabel
+            className="emotion-27 emotion-0"
             name="national-insurance-number"
           >
-            <StyledLabel
-              className="emotion-0 emotion-82 emotion-0"
+            <label
+              className="emotion-0 emotion-78 emotion-79"
               name="national-insurance-number"
             >
-              <label
-                className="emotion-0 emotion-0 emotion-79 emotion-80"
-                name="national-insurance-number"
+              <StyledHoc>
+                <LabelText
+                  className="emotion-27 emotion-0"
+                >
+                  <StyledLabelText
+                    className="emotion-27 emotion-0"
+                  >
+                    <span
+                      className="emotion-0 emotion-57 emotion-58"
+                    >
+                      National Insurance number
+                    </span>
+                  </StyledLabelText>
+                </LabelText>
+              </StyledHoc>
+              <StyledHoc>
+                <HintText
+                  className="emotion-27 emotion-0"
+                >
+                  <StyledHint
+                    className="emotion-27 emotion-0"
+                  >
+                    <span
+                      className="emotion-0 emotion-64 emotion-65"
+                    >
+                      It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+                    </span>
+                  </StyledHint>
+                </HintText>
+              </StyledHoc>
+              <StyledHoc
+                type="text"
               >
-                <StyledHoc>
-                  <LabelText
-                    className="emotion-27 emotion-0"
-                  >
-                    <StyledLabelText
-                      className="emotion-27 emotion-0"
-                    >
-                      <span
-                        className="emotion-0 emotion-57 emotion-58"
-                      >
-                        National Insurance number
-                      </span>
-                    </StyledLabelText>
-                  </LabelText>
-                </StyledHoc>
-                <StyledHoc>
-                  <HintText
-                    className="emotion-27 emotion-0"
-                  >
-                    <StyledHint
-                      className="emotion-27 emotion-0"
-                    >
-                      <span
-                        className="emotion-0 emotion-64 emotion-65"
-                      >
-                        It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
-                      </span>
-                    </StyledHint>
-                  </HintText>
-                </StyledHoc>
-                <StyledHoc
+                <Input
+                  className="emotion-27 emotion-0"
                   type="text"
                 >
-                  <Input
+                  <StyledInput
                     className="emotion-27 emotion-0"
                     type="text"
                   >
-                    <StyledInput
-                      className="emotion-27 emotion-0"
+                    <input
+                      className="emotion-0 emotion-71 emotion-72"
                       type="text"
-                    >
-                      <input
-                        className="emotion-0 emotion-71 emotion-72"
-                        type="text"
-                      />
-                    </StyledInput>
-                  </Input>
-                </StyledHoc>
-              </label>
-            </StyledLabel>
-          </Label>
-        </StyledHoc>
-      </InputField>
-    </StyledHoc>
+                    />
+                  </StyledInput>
+                </Input>
+              </StyledHoc>
+            </label>
+          </StyledLabel>
+        </Label>
+      </StyledHoc>
+    </InputField>
     <br />
     <TextArea
       input={Object {}}
@@ -799,7 +742,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
             name="description"
           >
             <label
-              className="emotion-0 emotion-101 emotion-80"
+              className="emotion-0 emotion-78 emotion-79"
               name="description"
             >
               <StyledHoc>
@@ -822,7 +765,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
                 type="text"
               >
                 <textarea
-                  className="emotion-98 emotion-99"
+                  className="emotion-91 emotion-92"
                   rows="5"
                   type="text"
                 />

--- a/components/input-field/src/__snapshots__/test.js.snap
+++ b/components/input-field/src/__snapshots__/test.js.snap
@@ -11,23 +11,6 @@ exports[`InputField matches wrapper snapshot: wrapper mount 1`] = `
   }
 }
 
-.emotion-19 {
-  margin-bottom: 0;
-  margin-bottom: 0;
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-19 {
-    margin-bottom: 0;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-19 {
-    margin-bottom: 0;
-  }
-}
-
 .emotion-1 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -55,7 +38,7 @@ exports[`InputField matches wrapper snapshot: wrapper mount 1`] = `
   }
 }
 
-.emotion-16 {
+.emotion-15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -65,23 +48,16 @@ exports[`InputField matches wrapper snapshot: wrapper mount 1`] = `
   flex-direction: column;
   box-sizing: border-box;
   margin-bottom: 0;
-  margin-bottom: 0;
 }
 
-.emotion-16:after {
+.emotion-15:after {
   content: '';
   display: table;
   clear: both;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-16 {
-    margin-bottom: 0;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-16 {
+  .emotion-15 {
     margin-bottom: 0;
   }
 }
@@ -141,64 +117,56 @@ exports[`InputField matches wrapper snapshot: wrapper mount 1`] = `
   }
 }
 
-<StyledHoc
+<InputField
   input={Object {}}
   meta={Object {}}
 >
-  <InputField
-    className="emotion-3 emotion-0"
-    input={Object {}}
-    meta={Object {}}
-  >
-    <StyledHoc
+  <StyledHoc>
+    <Label
       className="emotion-3 emotion-0"
     >
-      <Label
-        className="emotion-0 emotion-19 emotion-0"
+      <StyledLabel
+        className="emotion-3 emotion-0"
       >
-        <StyledLabel
-          className="emotion-0 emotion-19 emotion-0"
+        <label
+          className="emotion-0 emotion-15 emotion-16"
         >
-          <label
-            className="emotion-0 emotion-0 emotion-16 emotion-17"
-          >
-            <StyledHoc>
-              <LabelText
+          <StyledHoc>
+            <LabelText
+              className="emotion-3 emotion-0"
+            >
+              <StyledLabelText
                 className="emotion-3 emotion-0"
               >
-                <StyledLabelText
-                  className="emotion-3 emotion-0"
+                <span
+                  className="emotion-0 emotion-1 emotion-2"
                 >
-                  <span
-                    className="emotion-0 emotion-1 emotion-2"
-                  >
-                    example
-                  </span>
-                </StyledLabelText>
-              </LabelText>
-            </StyledHoc>
-            <StyledHoc
+                  example
+                </span>
+              </StyledLabelText>
+            </LabelText>
+          </StyledHoc>
+          <StyledHoc
+            type="text"
+          >
+            <Input
+              className="emotion-3 emotion-0"
               type="text"
             >
-              <Input
+              <StyledInput
                 className="emotion-3 emotion-0"
                 type="text"
               >
-                <StyledInput
-                  className="emotion-3 emotion-0"
+                <input
+                  className="emotion-0 emotion-8 emotion-9"
                   type="text"
-                >
-                  <input
-                    className="emotion-0 emotion-8 emotion-9"
-                    type="text"
-                  />
-                </StyledInput>
-              </Input>
-            </StyledHoc>
-          </label>
-        </StyledLabel>
-      </Label>
-    </StyledHoc>
-  </InputField>
-</StyledHoc>
+                />
+              </StyledInput>
+            </Input>
+          </StyledHoc>
+        </label>
+      </StyledLabel>
+    </Label>
+  </StyledHoc>
+</InputField>
 `;

--- a/components/input-field/src/index.js
+++ b/components/input-field/src/index.js
@@ -8,7 +8,6 @@ import LabelText from '@govuk-react/label-text';
 import ErrorText from '@govuk-react/error-text';
 import HintText from '@govuk-react/hint-text';
 import Input from '@govuk-react/input';
-import { withWhiteSpace } from '@govuk-react/hoc';
 
 /**
  *
@@ -100,4 +99,7 @@ InputField.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-export default withWhiteSpace({ marginBottom: 0 })(InputField);
+/** Component is not exported withWhitespace because Label
+ *  is also exported withWhitespace and therefore takes precedence.
+ */
+export default InputField;

--- a/packages/hoc/package.json
+++ b/packages/hoc/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.5.0",
     "@govuk-react/icons": "^0.5.0",
+    "@govuk-react/lib": "^0.5.0",
     "govuk-colours": "^1.0.3"
   },
   "peerDependencies": {

--- a/packages/hoc/src/withWhiteSpace/__snapshots__/test.js.snap
+++ b/packages/hoc/src/withWhiteSpace/__snapshots__/test.js.snap
@@ -3,7 +3,6 @@
 exports[`withWhiteSpace matches wrapper snapshot 1`] = `
 .emotion-0 {
   margin-bottom: 15px;
-  margin-bottom: 15px;
 }
 
 @media only screen and (min-width:641px) {
@@ -12,18 +11,10 @@ exports[`withWhiteSpace matches wrapper snapshot 1`] = `
   }
 }
 
-@media only screen and (min-width:641px) {
-  .emotion-0 {
-    margin-bottom: 25px;
-  }
-}
-
-<InputField
+<Component
   className="emotion-0 emotion-1"
-  input={Object {}}
   mb={5}
-  meta={Object {}}
 >
   Example
-</InputField>
+</Component>
 `;

--- a/packages/hoc/src/withWhiteSpace/index.js
+++ b/packages/hoc/src/withWhiteSpace/index.js
@@ -1,26 +1,65 @@
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
-import { SPACING_MAP, SPACING_MAP_INDEX, MEDIA_QUERIES } from '@govuk-react/constants';
+import { SPACING_MAP_INDEX } from '@govuk-react/constants';
+import { spacing } from '@govuk-react/lib';
 
-// TODO add support for other white-space options
-// and also `adjustment` value (e.g. see Button)
+// references for sizing:
 // https://github.com/alphagov/govuk-frontend/blob/master/src/helpers/_spacing.scss
 // https://github.com/alphagov/govuk-frontend/blob/master/src/overrides/_spacing.scss
 // https://github.com/alphagov/govuk-frontend/blob/master/src/settings/_spacing.scss
 
+// `margin` and `padding` are supported as props and config values
+// can be a single number, to indicate scale size to use in all directions
+// can be an object in format `{ size, direction, adjustment }`
+// - see `responsivePadding` and `responsiveMargin` calls
+// can be an array of numbers/objects
+
+const Directions = PropTypes.oneOf(['all', 'top', 'right', 'bottom', 'left']);
+
+const SpacingShape = PropTypes.shape({
+  size: PropTypes.number.isRequired,
+  direction: PropTypes.oneOfType([Directions, PropTypes.arrayOf(Directions)]),
+  adjustment: PropTypes.number,
+});
+
 const withWhiteSpace = (config = {}) => (Component) => {
-  const StyledHoc = styled(Component)(({ mb: marginBottom = config.marginBottom }) => (
-    marginBottom !== undefined ? {
-      marginBottom: marginBottom ? SPACING_MAP[marginBottom].mobile : 0,
-      [MEDIA_QUERIES.LARGESCREEN]: {
-        marginBottom: marginBottom ? SPACING_MAP[marginBottom].tablet : 0,
-      },
-    } : undefined
-  ));
+  const StyledHoc = styled(Component)(
+    ({ margin = config.margin }) => {
+      if (margin !== undefined) {
+        if (Array.isArray(margin)) {
+          return margin.map(val => spacing.responsiveMargin(val));
+        }
+        return spacing.responsiveMargin(margin);
+      }
+      return undefined;
+    },
+    ({ padding = config.padding }) => {
+      if (padding !== undefined) {
+        if (Array.isArray(padding)) {
+          return padding.map(val => spacing.responsivePadding(val));
+        }
+        return spacing.responsivePadding(padding);
+      }
+      return undefined;
+    },
+    ({ mb: marginBottom = config.marginBottom }) => (
+      marginBottom !== undefined ? spacing.responsiveMargin({ size: marginBottom, direction: 'bottom' }) : undefined
+    ),
+  );
 
   // `mb` (Margin Bottom) prop name comes from the naming convention used by https://github.com/jxnblk/grid-styled
   StyledHoc.propTypes = {
     mb: PropTypes.oneOf(SPACING_MAP_INDEX),
+    margin: PropTypes.oneOfType([
+      PropTypes.number,
+      SpacingShape,
+      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, SpacingShape])),
+    ]),
+    padding: PropTypes.oneOfType([
+      PropTypes.number,
+      SpacingShape,
+      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, SpacingShape])),
+    ]),
   };
 
   return StyledHoc;

--- a/packages/hoc/src/withWhiteSpace/stories.js
+++ b/packages/hoc/src/withWhiteSpace/stories.js
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { Fragment } from 'react';
+import styled from 'react-emotion';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, number } from '@storybook/addon-knobs/react';
+import { withKnobs, number, object, text } from '@storybook/addon-knobs/react';
+
 import BackLink from '@govuk-react/back-link';
 import Breadcrumb from '@govuk-react/breadcrumb';
 import Button from '@govuk-react/button';
@@ -12,7 +14,6 @@ import Header from '@govuk-react/header';
 import HintText from '@govuk-react/hint-text';
 import Input from '@govuk-react/input';
 import InputField from '@govuk-react/input-field';
-
 import Label from '@govuk-react/label';
 import LabelText from '@govuk-react/label-text';
 import ListItem from '@govuk-react/list-item';
@@ -35,81 +36,114 @@ import withWhiteSpace from '.';
 const stories = storiesOf('Utilities/withWhiteSpace', module);
 stories.addDecorator(withKnobs);
 
-const BackLinkWhiteSpace = withWhiteSpace({ marginBottom: 1 })(BackLink);
-const BreadcrumbWhiteSpace = withWhiteSpace({ marginBottom: 1 })(Breadcrumb);
-const ButtonWhiteSpace = withWhiteSpace({ marginBottom: 1 })(Button);
-const CheckboxWhiteSpace = withWhiteSpace({ marginBottom: 1 })(Checkbox);
-const DateFieldWhiteSpace = withWhiteSpace({ marginBottom: 1 })(DateField);
-const ErrorTextWhiteSpace = withWhiteSpace({ marginBottom: 1 })(ErrorText);
-const FileUploadWhiteSpace = withWhiteSpace({ marginBottom: 1 })(FileUpload);
-const HeaderWhiteSpace = withWhiteSpace({ marginBottom: 1 })(Header);
-const HintTextWhiteSpace = withWhiteSpace({ marginBottom: 1 })(HintText);
-const InputWhiteSpace = withWhiteSpace({ marginBottom: 1 })(Input);
-const InputFieldWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(InputField);
+const DemoComponent = withWhiteSpace()(styled('div')({
+  border: '2px solid red',
+}));
 
-const LabelWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(Label);
-const LabelTextWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(LabelText);
-const ListItemWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(ListItem);
-const ListNavigationWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(ListNavigation);
-const MultiChoiceWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(MultiChoice);
-const OrderedListWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(OrderedList);
-const PaginationWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(Pagination);
-const PanelWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(Panel);
-const PhaseBadgeWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(PhaseBadge);
-const PhaseBannerWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(PhaseBanner);
-const RadioWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(Radio);
-const RelatedItemsWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(RelatedItems);
-const SearchBoxWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(SearchBox);
-const SelectWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(Select);
-const TextAreaWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(TextArea);
-const UnorderedListWithWhiteSpace = withWhiteSpace({ marginBottom: 1 })(UnorderedList);
-
-stories.add('with spacing default size 1', () => (
-  <React.Fragment>
-    <InputFieldWithWhiteSpace mb={number('marginBottom', 1)} name="group1" hint="Change whitespace value with knobs">Example 1</InputFieldWithWhiteSpace>
-    <Button>Finish</Button>
-  </React.Fragment>
+stories.add('demo component, simple single margins and padding', () => (
+  <Fragment>
+    <DemoComponent
+      margin={number('margin', 2, { range: true, min: 0, max: 9 })}
+      padding={number('padding', 2, { range: true, min: 0, max: 9 })}
+    >
+      Component with styles - use knobs to adjust
+    </DemoComponent>
+    <DemoComponent>Component without styles</DemoComponent>
+  </Fragment>
 ));
 
-stories.add('with various spacing sizes', () => (
-  <React.Fragment>
-    <InputFieldWithWhiteSpace mb={number('marginBottom1', 1)} name="group1" hint="hi">Example 1</InputFieldWithWhiteSpace>
-    <InputFieldWithWhiteSpace mb={number('marginBottom2', 4)} name="group1" hint="hi">Example 2</InputFieldWithWhiteSpace>
-    <InputFieldWithWhiteSpace mb={number('marginBottom3', 7)} name="group1" hint="hi">Example 3</InputFieldWithWhiteSpace>
-    <InputFieldWithWhiteSpace mb={number('marginBottom4', 9)} name="group1" hint="okay">Example 4</InputFieldWithWhiteSpace>
-    <Button>Finish</Button>
-  </React.Fragment>
+stories.add('demo component, single margins and padding (complex)', () => (
+  <Fragment>
+    <DemoComponent
+      margin={{
+        size: number('margin.size', 2, { range: true, min: 0, max: 9 }),
+        direction: text('margin.direction', 'all'),
+        adjustment: number('margin.adjustment', undefined),
+      }}
+      padding={{
+        size: number('padding.size', 2, { range: true, min: 0, max: 9 }),
+        direction: text('padding.direction', 'all'),
+        adjustment: number('padding.adjustment', undefined),
+      }}
+    >
+      Component with styles - use knobs to adjust
+    </DemoComponent>
+    <DemoComponent>Component without styles</DemoComponent>
+  </Fragment>
 ));
 
-stories.add('with multiple components', () => (
-  <React.Fragment>
-    <BackLinkWhiteSpace mb={number('BackLink marginBottom', 9)}>Example</BackLinkWhiteSpace>
-    <BreadcrumbWhiteSpace mb={number('Breadcrumb marginBottom', 9)}>Example</BreadcrumbWhiteSpace>
-    <ButtonWhiteSpace mb={number('Button marginBottom', 9)}>Example</ButtonWhiteSpace>
-    <CheckboxWhiteSpace mb={number('Checkbox marginBottom', 9)}>Example</CheckboxWhiteSpace>
-    <DateFieldWhiteSpace mb={number('DateField marginBottom', 9)}>Example</DateFieldWhiteSpace>
-    <ErrorTextWhiteSpace mb={number('ErrorText marginBottom', 9)}>Example</ErrorTextWhiteSpace>
-    <FileUploadWhiteSpace mb={number('File Upload marginBottom', 9)}>Example</FileUploadWhiteSpace>
-    <HeaderWhiteSpace mb={number('Header marginBottom', 9)}>Example</HeaderWhiteSpace>
-    <HintTextWhiteSpace mb={number('HintText marginBottom', 9)}>Example</HintTextWhiteSpace>
-    <InputWhiteSpace mb={number('Input marginBottom', 9)} />
-    <InputFieldWithWhiteSpace mb={number('Input-text marginBottom', 9)}>Example</InputFieldWithWhiteSpace>
+stories.add('demo component, multiple margins and padding (complex)', () => (
+  <Fragment>
+    <DemoComponent
+      margin={[
+        number('margin (all)', 2, { range: true, min: 0, max: 9 }),
+        object('margin (first object)', {
+          size: 2,
+          direction: 'bottom',
+          adjustment: -5,
+        }),
+      ]}
+      padding={[
+        number('padding (all)', 2, { range: true, min: 0, max: 9 }),
+        object('padding (first object)', {
+          size: 4,
+          direction: ['top', 'bottom'],
+          adjustment: 11,
+        }),
+      ]}
+    >
+      Component with styles - use knobs to adjust
+    </DemoComponent>
+    <DemoComponent>Component without styles</DemoComponent>
+  </Fragment>
+));
 
-    <LabelWithWhiteSpace mb={number('Label marginBottom', 9)}>Label Example</LabelWithWhiteSpace>
-    <LabelTextWithWhiteSpace mb={number('LabelText marginBottom', 9)}>LabelText Example</LabelTextWithWhiteSpace>
-    <ListItemWithWhiteSpace mb={number('ListItem marginBottom', 9)}>ListItem Example</ListItemWithWhiteSpace>
-    <ListNavigationWithWhiteSpace mb={number('ListNavigation marginBottom', 9)}>ListNavigation Example</ListNavigationWithWhiteSpace>
-    <MultiChoiceWithWhiteSpace label="example" mb={number('MultiChoice marginBottom', 9)}>MultiChoice Example</MultiChoiceWithWhiteSpace>
-    <OrderedListWithWhiteSpace mb={number('OrderedList marginBottom', 9)}>OrderedList Example</OrderedListWithWhiteSpace>
-    <PaginationWithWhiteSpace mb={number('Pagination marginBottom', 9)}>Pagination Example</PaginationWithWhiteSpace>
-    <PanelWithWhiteSpace panelTitle="Example" mb={number('Panel marginBottom', 9)}>Panel Example</PanelWithWhiteSpace>
-    <PhaseBadgeWithWhiteSpace mb={number('PhaseBadge marginBottom', 9)}>PhaseBadge</PhaseBadgeWithWhiteSpace>
-    <PhaseBannerWithWhiteSpace level="EXAMPLE" mb={number('PhaseBanner marginBottom', 9)}>PhaseBanner Example</PhaseBannerWithWhiteSpace>
-    <RadioWithWhiteSpace mb={number('Radio marginBottom', 9)}>Radio Example</RadioWithWhiteSpace>
-    <RelatedItemsWithWhiteSpace mb={number('RelatedItems marginBottom', 9)}>RelatedItems Example</RelatedItemsWithWhiteSpace>
-    <SearchBoxWithWhiteSpace mb={number('SearchBox marginBottom', 9)}>SearchBox Example</SearchBoxWithWhiteSpace>
-    <SelectWithWhiteSpace label="example" mb={number('Select marginBottom', 9)}>Select Example</SelectWithWhiteSpace>
-    <TextAreaWithWhiteSpace mb={number('TextArea marginBottom', 9)}>TextArea Example</TextAreaWithWhiteSpace>
-    <UnorderedListWithWhiteSpace mb={number('UnorderedList marginBottom', 9)}>UnorderedList Example</UnorderedListWithWhiteSpace>
-  </React.Fragment>
+
+stories.add('existing InputField with spacing size 1', () => (
+  <Fragment>
+    <InputField mb={number('marginBottom', 1)} name="group1" hint="Change whitespace value with knobs">Example 1</InputField>
+    <Button>Finish</Button>
+  </Fragment>
+));
+
+stories.add('existing InputField with various spacing sizes', () => (
+  <Fragment>
+    <InputField mb={number('marginBottom1', 1)} name="group1" hint="hi">Example 1</InputField>
+    <InputField mb={number('marginBottom2', 4)} name="group1" hint="hi">Example 2</InputField>
+    <InputField mb={number('marginBottom3', 7)} name="group1" hint="hi">Example 3</InputField>
+    <InputField mb={number('marginBottom4', 9)} name="group1" hint="okay">Example 4</InputField>
+    <Button>Finish</Button>
+  </Fragment>
+));
+
+stories.add('multiple existing components', () => (
+  <Fragment>
+    <BackLink mb={number('BackLink marginBottom', 9)}>Example</BackLink>
+    <Breadcrumb mb={number('Breadcrumb marginBottom', 9)}>Example</Breadcrumb>
+    <Button mb={number('Button marginBottom', 9)}>Example</Button>
+    <Checkbox mb={number('Checkbox marginBottom', 9)}>Example</Checkbox>
+    <DateField mb={number('DateField marginBottom', 9)}>Example</DateField>
+    <ErrorText mb={number('ErrorText marginBottom', 9)}>Example</ErrorText>
+    <FileUpload mb={number('File Upload marginBottom', 9)}>Example</FileUpload>
+    <Header mb={number('Header marginBottom', 9)}>Example</Header>
+    <HintText mb={number('HintText marginBottom', 9)}>Example</HintText>
+    <Input mb={number('Input marginBottom', 9)} />
+    <InputField mb={number('Input-text marginBottom', 9)}>Example</InputField>
+    <Label mb={number('Label marginBottom', 9)}>Label Example</Label>
+    <LabelText mb={number('LabelText marginBottom', 9)}>LabelText Example</LabelText>
+    <ListItem mb={number('ListItem marginBottom', 9)}>ListItem Example</ListItem>
+    <ListNavigation mb={number('ListNavigation marginBottom', 9)}>ListNavigation Example</ListNavigation>
+    <MultiChoice label="example" mb={number('MultiChoice marginBottom', 9)}>MultiChoice Example</MultiChoice>
+    <OrderedList mb={number('OrderedList marginBottom', 9)}>OrderedList Example</OrderedList>
+    <Pagination mb={number('Pagination marginBottom', 9)}>Pagination Example</Pagination>
+    <Panel panelTitle="Example" mb={number('Panel marginBottom', 9)}>Panel Example</Panel>
+    <PhaseBadge mb={number('PhaseBadge marginBottom', 9)}>PhaseBadge</PhaseBadge>
+    <PhaseBanner level="EXAMPLE" mb={number('PhaseBanner marginBottom', 9)}>PhaseBanner Example</PhaseBanner>
+    <Radio mb={number('Radio marginBottom', 9)}>Radio Example</Radio>
+    <RelatedItems mb={number('RelatedItems marginBottom', 9)}>RelatedItems Example</RelatedItems>
+    <SearchBox mb={number('SearchBox marginBottom', 9)}>SearchBox Example</SearchBox>
+    <Select label="example" mb={number('Select marginBottom', 9)}>Select Example</Select>
+    <TextArea mb={number('TextArea marginBottom', 9)}>TextArea Example</TextArea>
+    <UnorderedList mb={number('UnorderedList marginBottom', 9)}>UnorderedList Example</UnorderedList>
+  </Fragment>
 ));

--- a/packages/hoc/src/withWhiteSpace/test.js
+++ b/packages/hoc/src/withWhiteSpace/test.js
@@ -1,11 +1,10 @@
 import React from 'react';
+import styled from 'react-emotion';
 import { shallow } from 'enzyme';
-import InputField from '@govuk-react/input-field';
-import withWhiteSpace from './';
+import withWhiteSpace from '.';
 
-const WithoutConfig = withWhiteSpace()(InputField);
-const WithConfig = withWhiteSpace({ marginBottom: 0 })(InputField);
-let wrapper;
+const WithoutConfig = withWhiteSpace()(styled('div'));
+const WithConfig = withWhiteSpace({ marginBottom: 0 })(styled('div'));
 
 describe('withWhiteSpace', () => {
   it('renders without config without crashing', () => {
@@ -16,15 +15,24 @@ describe('withWhiteSpace', () => {
     shallow(<WithConfig>Example</WithConfig>);
   });
 
-  it('renders with props without crashing', () => {
-    wrapper = shallow(<WithConfig mb={5}>Example</WithConfig>);
+  it('renders with simple mb prop without crashing', () => {
+    shallow(<WithConfig mb={5}>Example</WithConfig>);
   });
 
-  it('renders an InputField', () => {
-    expect(wrapper.find('InputField').exists()).toBe(true);
+  it('renders with a margin prop without crashing', () => {
+    shallow(<WithConfig margin={{ size: 5 }}>Example</WithConfig>);
+    shallow(<WithConfig margin={5}>Example</WithConfig>);
+    shallow(<WithConfig margin={[5, { size: 2, direction: 'top' }]}>Example</WithConfig>);
+  });
+
+  it('renders with a padding prop without crashing', () => {
+    shallow(<WithConfig padding={{ size: 5 }}>Example</WithConfig>);
+    shallow(<WithConfig padding={5}>Example</WithConfig>);
+    shallow(<WithConfig padding={[5, { size: 2, direction: 'top' }]}>Example</WithConfig>);
   });
 
   it('matches wrapper snapshot', () => {
+    const wrapper = shallow(<WithConfig mb={5}>Example</WithConfig>);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/lib/src/spacing/index.js
+++ b/packages/lib/src/spacing/index.js
@@ -19,8 +19,9 @@ export function simple(size) {
 }
 
 function styleForDirection(size, property, direction) {
+  // NB emotion automatically sets style to include `px` if needed
   return {
-    [(direction && direction !== 'all') ? `${property}-${direction}` : property]: `${size}px`,
+    [(direction && direction !== 'all') ? `${property}-${direction}` : property]: size,
   };
 }
 
@@ -63,13 +64,25 @@ export function responsive({
   );
 }
 
-export function responsiveMargin({ size, direction, adjustment }) {
+export function responsiveMargin(value) {
+  if (Number.isInteger(value)) {
+    return responsive({ size: value, property: 'margin' });
+  }
+
+  const { size, direction, adjustment } = value;
+
   return responsive({
     size, property: 'margin', direction, adjustment,
   });
 }
 
-export function responsivePadding({ size, direction, adjustment }) {
+export function responsivePadding(value) {
+  if (Number.isInteger(value)) {
+    return responsive({ size: value, property: 'padding' });
+  }
+
+  const { size, direction, adjustment } = value;
+
   return responsive({
     size, property: 'padding', direction, adjustment,
   });

--- a/packages/lib/src/spacing/test.js
+++ b/packages/lib/src/spacing/test.js
@@ -30,9 +30,9 @@ describe('spacing lib', () => {
       SPACING_MAP_INDEX.forEach((size) => {
         const style = spacing.responsive({ size, property: 'test' });
 
-        expect(style).toEqual(expect.objectContaining({ test: `${SPACING_MAP[size].mobile}px` }));
+        expect(style).toEqual(expect.objectContaining({ test: SPACING_MAP[size].mobile }));
         expect(style[MEDIA_QUERIES.TABLET])
-          .toEqual(expect.objectContaining({ test: `${SPACING_MAP[size].tablet}px` }));
+          .toEqual(expect.objectContaining({ test: SPACING_MAP[size].tablet }));
       });
     });
 
@@ -51,43 +51,43 @@ describe('spacing lib', () => {
 
     it('returns spacing style for a given direction', () => {
       expect(spacing.responsive({ size: 0, property: 'test', direction: 'east' }))
-        .toEqual(expect.objectContaining({ 'test-east': `${SPACING_MAP[0].mobile}px` }));
+        .toEqual(expect.objectContaining({ 'test-east': SPACING_MAP[0].mobile }));
     });
 
     it('returns spacing style for a given array of direction', () => {
       const style = spacing.responsive({ size: 0, property: 'test', direction: ['east', 'west'] });
 
       expect(style).toEqual(expect.objectContaining({
-        'test-east': `${SPACING_MAP[0].mobile}px`,
-        'test-west': `${SPACING_MAP[0].mobile}px`,
+        'test-east': SPACING_MAP[0].mobile,
+        'test-west': SPACING_MAP[0].mobile,
       }));
       expect(style[MEDIA_QUERIES.TABLET]).toEqual(expect.objectContaining({
-        'test-east': `${SPACING_MAP[0].tablet}px`,
-        'test-west': `${SPACING_MAP[0].tablet}px`,
+        'test-east': SPACING_MAP[0].tablet,
+        'test-west': SPACING_MAP[0].tablet,
       }));
     });
 
     it('treats all direction as no direction', () => {
       expect(spacing.responsive({ size: 0, property: 'test', direction: 'all' }))
-        .toEqual(expect.objectContaining({ test: `${SPACING_MAP[0].mobile}px` }));
+        .toEqual(expect.objectContaining({ test: SPACING_MAP[0].mobile }));
     });
 
     it('treats all direction in a direction array as no direction', () => {
       const style = spacing.responsive({ size: 0, property: 'test', direction: ['all', 'west'] });
 
       expect(style).toEqual(expect.objectContaining({
-        test: `${SPACING_MAP[0].mobile}px`,
-        'test-west': `${SPACING_MAP[0].mobile}px`,
+        test: SPACING_MAP[0].mobile,
+        'test-west': SPACING_MAP[0].mobile,
       }));
       expect(style[MEDIA_QUERIES.TABLET]).toEqual(expect.objectContaining({
-        test: `${SPACING_MAP[0].tablet}px`,
-        'test-west': `${SPACING_MAP[0].tablet}px`,
+        test: SPACING_MAP[0].tablet,
+        'test-west': SPACING_MAP[0].tablet,
       }));
     });
 
     it('adjusts a spacing by the adjustment amount', () => {
       expect(spacing.responsive({ size: 0, property: 'test', adjustment: 7 }))
-        .toEqual(expect.objectContaining({ test: `${SPACING_MAP[0].mobile + 7}px` }));
+        .toEqual(expect.objectContaining({ test: SPACING_MAP[0].mobile + 7 }));
     });
   });
 
@@ -97,12 +97,24 @@ describe('spacing lib', () => {
         expect(spacing.responsiveMargin({ size })).toEqual(spacing.responsive({ size, property: 'margin' }));
       });
     });
+
+    it('returns margin styles for given sizes on the spacing scale using simple numeric value', () => {
+      SPACING_MAP_INDEX.forEach((size) => {
+        expect(spacing.responsiveMargin(size)).toEqual(spacing.responsive({ size, property: 'margin' }));
+      });
+    });
   });
 
   describe('responsivePadding', () => {
     it('returns padding styles for given sizes on the spacing scale', () => {
       SPACING_MAP_INDEX.forEach((size) => {
         expect(spacing.responsivePadding({ size })).toEqual(spacing.responsive({ size, property: 'padding' }));
+      });
+    });
+
+    it('returns padding styles for given sizes on the spacing scale using simple numeric value', () => {
+      SPACING_MAP_INDEX.forEach((size) => {
+        expect(spacing.responsivePadding(size)).toEqual(spacing.responsive({ size, property: 'padding' }));
       });
     });
   });


### PR DESCRIPTION
* `withWhiteSpace` HOC updated
  - supports `margin` and `padding` props and config
  - values can be:
    - single number (size to use in all directions)
    - object in format `{ size, direction, adjustment }` (as per `responsivePadding` etc lib call)
    - array of numbers/objects
  - `mb`/`marginBottom` still supported for backward compatibility
  - example stories cleaned up
    - no need to double-wrap `withWhiteSpace`
    - examples for new options added against a demo component
* `spacing` lib enhanced
  - styles no longer set as `px` strings, as emotion does that automatically
  - `responsiveMargin` and `responsivePadding` now support single integer size value
* fix: `InputField` no longer double-wraps `withWhiteSpace`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
