### PR TITLE
Add `withWhiteSpace` to spacing lib

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,15 @@ We want to be router agnostic. We want to support parent projects using React Ro
 
 ### White Space
 
-Components are built to have no white space around them, and are then wrapped with the withWhiteSpace HOC where we can provide some default values. This allows the parent application to override the defaults with e.g. an `mb` prop.
+Historically components were build to have no white space around them. They were then wrapped with the `withWhiteSpace` HOC to set the default spacing below the component and also provide support for an `mb` prop to allow the parent application to override this spacing.
+
+We have found that the use of the `withWhiteSpace` HOC can be problematic when it comes to applying complex styling rules involving descendent selectors, and thus it's use is now deprecated. Instead equivalent and enhanced facilities have been added to the `spacing` library in `@govuk-react/lib`.
+
+At the time of writing we are at the beginning of the process of transitioning to this new spacing method.
+
+Components are built to have white space around them to match their equivalents in [govuk-frontend](https://github.com/alphagov/govuk-frontend). To assist with this, styling utility function are provided in the `spacing` library in `@govuk-react/lib`. Typically a component will use the `withWhiteSpace` function within a component to generate a styling function to apply to a styled component.
+
+The `withWhiteSpace` function accepts default values for both `padding` and `margin`, and also provides support for overriding those defaults with equivalently named props. Spacing styles created are responsive and adjust for mobile/tablet sizes. For backward compatibility with the `withWhiteSpace` HOC it also supports a `marginBottom` config and `mb` prop.
 
 More details in https://github.com/govuk-react/govuk-react/issues/173
+and https://github.com/govuk-react/govuk-react/pull/523

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bundlesize": "bundlesize",
     "test": "cross-env CI=true yarn test:unit && yarn eslint && yarn flow",
     "test:unit": "jest --env=jsdom",
-    "test:debug": "node --inspect-brk ./node_modules/.bin/jest --env=jsdom",
+    "test:debug": "node --inspect-brk ./node_modules/.bin/jest --env=jsdom --runInBand",
     "test:snapshot": "yarn test:unit -- -u",
     "create-component": "node ./scripts/createComponent.js",
     "chromatic-test": "cd packages/storybook && yarn chromatic-test"

--- a/packages/hoc/src/withWhiteSpace/index.js
+++ b/packages/hoc/src/withWhiteSpace/index.js
@@ -1,65 +1,14 @@
-import PropTypes from 'prop-types';
 import styled from 'react-emotion';
-import { SPACING_MAP_INDEX } from '@govuk-react/constants';
 import { spacing } from '@govuk-react/lib';
 
-// references for sizing:
-// https://github.com/alphagov/govuk-frontend/blob/master/src/helpers/_spacing.scss
-// https://github.com/alphagov/govuk-frontend/blob/master/src/overrides/_spacing.scss
-// https://github.com/alphagov/govuk-frontend/blob/master/src/settings/_spacing.scss
+// NB withWhiteSpace HOC is DEPRECATED
+// Please use `spacing.withWhiteSpace(config)` instead in styled components
 
-// `margin` and `padding` are supported as props and config values
-// can be a single number, to indicate scale size to use in all directions
-// can be an object in format `{ size, direction, adjustment }`
-// - see `responsivePadding` and `responsiveMargin` calls
-// can be an array of numbers/objects
+const withWhiteSpace = config => (Component) => {
+  const StyledHoc = styled(Component)(spacing.withWhiteSpace(config));
 
-const Directions = PropTypes.oneOf(['all', 'top', 'right', 'bottom', 'left']);
-
-const SpacingShape = PropTypes.shape({
-  size: PropTypes.number.isRequired,
-  direction: PropTypes.oneOfType([Directions, PropTypes.arrayOf(Directions)]),
-  adjustment: PropTypes.number,
-});
-
-const withWhiteSpace = (config = {}) => (Component) => {
-  const StyledHoc = styled(Component)(
-    ({ margin = config.margin }) => {
-      if (margin !== undefined) {
-        if (Array.isArray(margin)) {
-          return margin.map(val => spacing.responsiveMargin(val));
-        }
-        return spacing.responsiveMargin(margin);
-      }
-      return undefined;
-    },
-    ({ padding = config.padding }) => {
-      if (padding !== undefined) {
-        if (Array.isArray(padding)) {
-          return padding.map(val => spacing.responsivePadding(val));
-        }
-        return spacing.responsivePadding(padding);
-      }
-      return undefined;
-    },
-    ({ mb: marginBottom = config.marginBottom }) => (
-      marginBottom !== undefined ? spacing.responsiveMargin({ size: marginBottom, direction: 'bottom' }) : undefined
-    ),
-  );
-
-  // `mb` (Margin Bottom) prop name comes from the naming convention used by https://github.com/jxnblk/grid-styled
   StyledHoc.propTypes = {
-    mb: PropTypes.oneOf(SPACING_MAP_INDEX),
-    margin: PropTypes.oneOfType([
-      PropTypes.number,
-      SpacingShape,
-      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, SpacingShape])),
-    ]),
-    padding: PropTypes.oneOfType([
-      PropTypes.number,
-      SpacingShape,
-      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, SpacingShape])),
-    ]),
+    ...spacing.withWhiteSpace.propTypes,
   };
 
   return StyledHoc;

--- a/packages/lib/src/spacing/index.js
+++ b/packages/lib/src/spacing/index.js
@@ -1,10 +1,15 @@
 // This lib is effectively a port of govuk-frontend's spacing sass helpers
 // Tracking:
 // https://github.com/alphagov/govuk-frontend/blob/master/src/helpers/_spacing.scss
+// Further references:
+// https://github.com/alphagov/govuk-frontend/blob/master/src/overrides/_spacing.scss
+// https://github.com/alphagov/govuk-frontend/blob/master/src/settings/_spacing.scss
 
+import PropTypes from 'prop-types';
 import {
   MEDIA_QUERIES,
   SPACING_MAP,
+  SPACING_MAP_INDEX,
   SPACING_POINTS,
 } from '@govuk-react/constants';
 
@@ -87,3 +92,70 @@ export function responsivePadding(value) {
     size, property: 'padding', direction, adjustment,
   });
 }
+
+// withWhiteSpace lib styling function
+// does not form part of govuk-frontend
+
+// `withWhiteSpace(config)`
+// generates a styling function, based on config, which can be used when styling a component
+
+// `margin` and `padding` are supported as props and config values
+// can be a single number, to indicate scale size to use in all directions
+// can be an object in format `{ size, direction, adjustment }`
+// - see `responsivePadding` and `responsiveMargin` calls
+// can be an array of numbers/objects
+
+export function withWhiteSpace(config = {}) {
+  return ({
+    margin = config.margin,
+    padding = config.padding,
+    mb: marginBottom = config.marginBottom,
+  } = {}) => {
+    const styles = [];
+
+    if (margin !== undefined) {
+      if (Array.isArray(margin)) {
+        styles.push(margin.map(val => responsiveMargin(val)));
+      } else {
+        styles.push(responsiveMargin(margin));
+      }
+    }
+
+    if (padding !== undefined) {
+      if (Array.isArray(padding)) {
+        styles.push(padding.map(val => responsivePadding(val)));
+      } else {
+        styles.push(responsivePadding(padding));
+      }
+    }
+
+    if (marginBottom !== undefined) {
+      styles.push(responsiveMargin({ size: marginBottom, direction: 'bottom' }));
+    }
+
+    return styles;
+  };
+}
+
+const Directions = PropTypes.oneOf(['all', 'top', 'right', 'bottom', 'left']);
+
+const SpacingShape = PropTypes.shape({
+  size: PropTypes.number.isRequired,
+  direction: PropTypes.oneOfType([Directions, PropTypes.arrayOf(Directions)]),
+  adjustment: PropTypes.number,
+});
+
+// `mb` (Margin Bottom) prop name comes from the naming convention used by https://github.com/jxnblk/grid-styled
+withWhiteSpace.propTypes = {
+  mb: PropTypes.oneOf(SPACING_MAP_INDEX),
+  margin: PropTypes.oneOfType([
+    PropTypes.number,
+    SpacingShape,
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, SpacingShape])),
+  ]),
+  padding: PropTypes.oneOfType([
+    PropTypes.number,
+    SpacingShape,
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, SpacingShape])),
+  ]),
+};

--- a/packages/lib/src/spacing/test.js
+++ b/packages/lib/src/spacing/test.js
@@ -118,4 +118,104 @@ describe('spacing lib', () => {
       });
     });
   });
+
+  describe('withWhiteSpace', () => {
+    it('generates an executable white-space styling function with no config', () => {
+      const whiteSpaceFunc = spacing.withWhiteSpace();
+
+      expect(() => whiteSpaceFunc()).not.toThrow();
+    });
+
+    describe('marginBottom/mb config and props', () => {
+      it('works with marginBottom config', () => {
+        const whiteSpaceFunc = spacing.withWhiteSpace({ marginBottom: 2 });
+
+        expect(whiteSpaceFunc()).toEqual(expect.arrayContaining([
+          expect.objectContaining({ 'margin-bottom': SPACING_MAP[2].mobile }),
+        ]));
+      });
+
+      it('when marginBottom config set, mb prop changes marginBottom', () => {
+        const whiteSpaceFunc = spacing.withWhiteSpace({ marginBottom: 2 });
+
+        expect(whiteSpaceFunc({ mb: 4 })).toEqual(expect.arrayContaining([
+          expect.objectContaining({ 'margin-bottom': SPACING_MAP[4].mobile }),
+        ]));
+      });
+
+      it('when no marginBottom config set, mb prop changes marginBottom', () => {
+        const whiteSpaceFunc = spacing.withWhiteSpace();
+
+        expect(whiteSpaceFunc({ mb: 4 })).toEqual(expect.arrayContaining([
+          expect.objectContaining({ 'margin-bottom': SPACING_MAP[4].mobile }),
+        ]));
+      });
+    });
+
+    describe('margin config/props', () => {
+      it('works with simple margin config value', () => {
+        const whiteSpaceFunc = spacing.withWhiteSpace({ margin: 4 });
+
+        expect(whiteSpaceFunc()).toEqual(expect.arrayContaining([
+          expect.objectContaining({ margin: SPACING_MAP[4].mobile }),
+        ]));
+      });
+
+      it('accepts a margin prop to override config', () => {
+        const whiteSpaceFunc = spacing.withWhiteSpace({ margin: 1 });
+
+        expect(whiteSpaceFunc({ margin: 4 })).toEqual(expect.arrayContaining([
+          expect.objectContaining({ margin: SPACING_MAP[4].mobile }),
+        ]));
+      });
+
+      it('accepts an array of margins', () => {
+        const whiteSpaceFunc = spacing.withWhiteSpace({ margin: [1, { direction: 'top', size: 3 }] });
+
+        // styles need to be flattened for checking
+        const result = [].concat(...whiteSpaceFunc());
+
+        expect(result).toEqual(expect.arrayContaining([
+          expect.objectContaining({ margin: SPACING_MAP[1].mobile }),
+        ]));
+
+        expect(result).toEqual(expect.arrayContaining([
+          expect.objectContaining({ 'margin-top': SPACING_MAP[3].mobile }),
+        ]));
+      });
+    });
+
+    describe('padding config/props', () => {
+      it('works with simple padding config value', () => {
+        const whiteSpaceFunc = spacing.withWhiteSpace({ padding: 4 });
+
+        expect(whiteSpaceFunc()).toEqual(expect.arrayContaining([
+          expect.objectContaining({ padding: SPACING_MAP[4].mobile }),
+        ]));
+      });
+
+      it('accepts a padding prop to override config', () => {
+        const whiteSpaceFunc = spacing.withWhiteSpace({ padding: 1 });
+
+        expect(whiteSpaceFunc({ padding: 4 })).toEqual(expect.arrayContaining([
+          expect.objectContaining({ padding: SPACING_MAP[4].mobile }),
+        ]));
+      });
+
+      it('accepts an array of paddings', () => {
+        const whiteSpaceFunc = spacing.withWhiteSpace({ padding: [1, { direction: 'top', size: 3 }] });
+
+        // styles need to be flattened for checking
+        const result = [].concat(...whiteSpaceFunc());
+
+        expect(result).toEqual(expect.arrayContaining([
+          expect.objectContaining({ padding: SPACING_MAP[1].mobile }),
+        ]));
+
+        expect(result).toEqual(expect.arrayContaining([
+          expect.objectContaining({ 'padding-top': SPACING_MAP[3].mobile }),
+        ]));
+      });
+    });
+  });
 });


### PR DESCRIPTION
* adds new `withWhiteSpace` function to spacing lib
  - generates spacing styles, accepting `margin`, `padding` and `mb` props
  - intended for use within styled component definitions

`withWhiteSpace` HOC refactored to use function, but is now deprecated

Aims to provide a solution to #522

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
