### PR TITLE
Add new Caption component

### DIFF
--- a/API.md
+++ b/API.md
@@ -119,6 +119,41 @@ Prop | Required | Default | Type | Description
  `start` |  | ```false``` | bool | Renders a large button if set to true
 
 
+Caption
+=======
+
+### Import
+```js
+  import Caption from '@govuk-react/caption';
+```
+<!-- STORY -->
+
+### Usage
+
+Simple
+```jsx
+<Caption>Caption heading text</Caption>
+```
+
+With another header
+```jsx
+import { H1 } from '@govuk-react/header';
+
+<Caption size="XL">Supporting header text</Caption>
+<H1>Main header text</H1>
+```
+
+### References
+- https://github.com/alphagov/govuk-frontend/blob/master/src/core/_typography.scss
+- https://design-system.service.gov.uk/styles/typography/#headings
+
+### Properties
+Prop | Required | Default | Type | Description
+:--- | :------- | :------ | :--- | :----------
+ `children` | true | `````` | string | Text to be rendered as a caption
+ `size` |  | ```'XL'``` | enum(...Object.keys(CAPTION_SIZES) \| ...Object.keys(TYPOGRAPHY_SCALE)) | Visual size level, accepts:<br/>   `XLARGE`, `LARGE`, `MEDIUM`, `XL`, `L`, `M`<br/>   or a numeric size that fits in the GDS font scale list
+
+
 Checkbox
 ========
 

--- a/components/caption/README.md
+++ b/components/caption/README.md
@@ -1,0 +1,35 @@
+Caption
+=======
+
+### Import
+```js
+  import Caption from '@govuk-react/caption';
+```
+<!-- STORY -->
+
+### Usage
+
+Simple
+```jsx
+<Caption>Caption heading text</Caption>
+```
+
+With another header
+```jsx
+import { H1 } from '@govuk-react/header';
+
+<Caption size="XL">Supporting header text</Caption>
+<H1>Main header text</H1>
+```
+
+### References
+- https://github.com/alphagov/govuk-frontend/blob/master/src/core/_typography.scss
+- https://design-system.service.gov.uk/styles/typography/#headings
+
+### Properties
+Prop | Required | Default | Type | Description
+:--- | :------- | :------ | :--- | :----------
+ `children` | true | `````` | string | Text to be rendered as a caption
+ `size` |  | ```'XL'``` | enum(...Object.keys(CAPTION_SIZES) \| ...Object.keys(TYPOGRAPHY_SCALE)) | Visual size level, accepts:<br/>   `XLARGE`, `LARGE`, `MEDIUM`, `XL`, `L`, `M`<br/>   or a numeric size that fits in the GDS font scale list
+
+

--- a/components/caption/package.json
+++ b/components/caption/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@govuk-react/caption",
+  "version": "0.6.0-alpha.4",
+  "dependencies": {
+    "@govuk-react/constants": "^0.6.0-alpha.4",
+    "@govuk-react/lib": "^0.6.0-alpha.4",
+    "govuk-colours": "^1.0.3"
+  },
+  "peerDependencies": {
+    "react": ">=16.2.0",
+    "styled-components": ">=4"
+  },
+  "scripts": {
+    "build": "yarn build:lib && yarn build:es",
+    "build:lib": "rimraf lib && babel src -d lib --source-maps --config-file ../../babel.config.js",
+    "build:es": "rimraf es && cross-env BABEL_ENV=es babel src -d es --source-maps --config-file ../../babel.config.js",
+    "docs": "doc-component ./lib/index.js ./README.md"
+  },
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "author": "Steve Sims",
+  "license": "MIT",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/caption",
+  "description": "Renders children passed inside a styled span element.",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/caption/src/__snapshots__/test.js.snap
+++ b/components/caption/src/__snapshots__/test.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Caption matches wrapper snapshot 1`] = `
+.c0 {
+  font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.1111111111111112;
+  margin-bottom: 5px;
+  color: #6f777b;
+}
+
+@media print {
+  .c0 {
+    font-size: 18px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c0 {
+    font-size: 27px;
+    line-height: 1.1111111111111112;
+  }
+}
+
+<Caption
+  size="XL"
+>
+  <styled.span
+    size="XL"
+  >
+    <StyledComponent
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "sc-bdVaJa",
+            "isStatic": false,
+            "lastClassName": "c0",
+            "rules": Array [
+              [Function],
+              [Function],
+              "color: #6f777b;",
+              [Function],
+            ],
+          },
+          "displayName": "styled.span",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "sc-bdVaJa",
+          "target": "span",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+      size="XL"
+    >
+      <span
+        className="c0"
+        size="XL"
+      >
+        Heading text
+      </span>
+    </StyledComponent>
+  </styled.span>
+</Caption>
+`;

--- a/components/caption/src/fixtures.js
+++ b/components/caption/src/fixtures.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { text } from '@storybook/addon-knobs/react';
+
+import Caption from '.';
+
+const CaptionWithKnobs = () => (
+  <Caption size={text('size', 'XL')}>{text('children', 'Heading text')}</Caption>
+);
+
+export default Caption;
+
+export { CaptionWithKnobs };

--- a/components/caption/src/index.js
+++ b/components/caption/src/index.js
@@ -1,0 +1,76 @@
+import styled from 'styled-components';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { SECONDARY_TEXT_COLOUR } from 'govuk-colours';
+import { spacing, typography } from '@govuk-react/lib';
+import { CAPTION_SIZES, MEDIA_QUERIES, SPACING_POINTS, TYPOGRAPHY_SCALE } from '@govuk-react/constants';
+
+const StyledCaption = styled('span')(
+  ({ size }) => {
+    const actualSize = Number.isNaN(Number(size)) ? CAPTION_SIZES[size] : size;
+
+    if (!actualSize) {
+      throw Error(`Unknown size ${size} used for header.`);
+    }
+
+    return typography.font({ size: actualSize });
+  },
+  ({ size }) => {
+    const actualSize = Number.isNaN(Number(size)) ? CAPTION_SIZES[size] : size;
+
+    // bottom margin - hard-coded values because they're a bit odd
+    const marginStyle = actualSize > 19 ? { marginBottom: SPACING_POINTS[1] } : undefined;
+    const marginResponsiveStyle = actualSize === 24 ?
+      { [MEDIA_QUERIES.TABLET]: { marginBottom: 0 } } : undefined;
+
+    return Object.assign(
+      {},
+      marginStyle,
+      marginResponsiveStyle,
+    );
+  },
+  {
+    color: SECONDARY_TEXT_COLOUR,
+  },
+  spacing.withWhiteSpace(),
+);
+
+/**
+ *
+ * ### Usage
+ *
+ * Simple
+ * ```jsx
+ * <Caption>Caption heading text</Caption>
+ * ```
+ *
+ * With another header
+ * ```jsx
+ * import { H1 } from '@govuk-react/header';
+ *
+ * <Caption size="XL">Supporting header text</Caption>
+ * <H1>Main header text</H1>
+ * ```
+ *
+ * ### References
+ * - https://github.com/alphagov/govuk-frontend/blob/master/src/core/_typography.scss
+ * - https://design-system.service.gov.uk/styles/typography/#headings
+ */
+const Caption = props => <StyledCaption {...props} />;
+
+Caption.propTypes = {
+  /** Text to be rendered as a caption */
+  children: PropTypes.string.isRequired,
+  /**
+   * Visual size level, accepts:
+   *    `XLARGE`, `LARGE`, `MEDIUM`, `XL`, `L`, `M`
+   *    or a numeric size that fits in the GDS font scale list
+   */
+  size: PropTypes.oneOf([...Object.keys(CAPTION_SIZES), ...Object.keys(TYPOGRAPHY_SCALE)]),
+};
+
+Caption.defaultProps = {
+  size: 'XL',
+};
+
+export default Caption;

--- a/components/caption/src/index.js
+++ b/components/caption/src/index.js
@@ -23,11 +23,10 @@ const StyledCaption = styled('span')(
     const marginResponsiveStyle = actualSize === 24 ?
       { [MEDIA_QUERIES.TABLET]: { marginBottom: 0 } } : undefined;
 
-    return Object.assign(
-      {},
-      marginStyle,
-      marginResponsiveStyle,
-    );
+    return {
+      ...marginStyle,
+      ...marginResponsiveStyle,
+    };
   },
   {
     color: SECONDARY_TEXT_COLOUR,

--- a/components/caption/src/stories.js
+++ b/components/caption/src/stories.js
@@ -1,0 +1,38 @@
+import React, { Fragment } from 'react';
+import { storiesOf } from '@storybook/react';
+import { text, withKnobs } from '@storybook/addon-knobs/react';
+import { WithDocsCustom } from '@govuk-react/storybook-components';
+
+import Header from '@govuk-react/header';
+
+import Caption, { CaptionWithKnobs } from './fixtures';
+import ReadMe from '../README.md';
+
+const stories = storiesOf('Typography/Caption', module);
+const examples = storiesOf('Typography/Caption/Examples', module);
+
+stories.addDecorator(withKnobs);
+stories.addDecorator(WithDocsCustom(ReadMe));
+examples.addDecorator(withKnobs);
+
+stories.add('Component default', () => (
+  <CaptionWithKnobs />
+));
+
+examples.add('Placed with a heading component', () => (
+  <Fragment>
+    <Caption size={text('size', 'XL')}>{text('children', 'Supporting header text')}</Caption>
+    <Header size={text('header size', 'XL')}>{text('children', 'Main header text')}</Header>
+  </Fragment>
+));
+
+examples.add('Showing all standard caption sizes, with headings', () => (
+  <Fragment>
+    <Caption size="XL">Supporting header size XL</Caption>
+    <Header size="XL">Main header size XL</Header>
+    <Caption size="L">Supporting header size L</Caption>
+    <Header size="L">Main header size L</Header>
+    <Caption size="M">Supporting header size M</Caption>
+    <Header size="M">Main header size M</Header>
+  </Fragment>
+));

--- a/components/caption/src/stories.js
+++ b/components/caption/src/stories.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { text, withKnobs } from '@storybook/addon-knobs/react';
 import { WithDocsCustom } from '@govuk-react/storybook-components';
@@ -20,19 +20,19 @@ stories.add('Component default', () => (
 ));
 
 examples.add('Placed with a heading component', () => (
-  <Fragment>
+  <div>
     <Caption size={text('size', 'XL')}>{text('children', 'Supporting header text')}</Caption>
     <Header size={text('header size', 'XL')}>{text('children', 'Main header text')}</Header>
-  </Fragment>
+  </div>
 ));
 
 examples.add('Showing all standard caption sizes, with headings', () => (
-  <Fragment>
+  <div>
     <Caption size="XL">Supporting header size XL</Caption>
     <Header size="XL">Main header size XL</Header>
     <Caption size="L">Supporting header size L</Caption>
     <Header size="L">Main header size L</Header>
     <Caption size="M">Supporting header size M</Caption>
     <Header size="M">Main header size M</Header>
-  </Fragment>
+  </div>
 ));

--- a/components/caption/src/test.js
+++ b/components/caption/src/test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import Caption from './fixtures';
+
+describe('Caption', () => {
+  it('allows custom string-based font size without crashing', () => {
+    const sizes = ['XL', 'XLARGE', 'L', 'LARGE', 'M', 'MEDIUM'];
+    sizes.forEach((size) => {
+      expect(mount(<Caption size={size}>Tests</Caption>).exists()).toBeTruthy();
+    });
+  });
+
+  it('allows custom numeric GDS font size without crashing', () => {
+    mount(<Caption size={16}>Test</Caption>);
+  });
+
+  it('throws an error if an unsupported size is used', () => {
+    expect(() => { mount(<Caption size={0}>example</Caption>); }).toThrow();
+    expect(() => { mount(<Caption size={1}>example</Caption>); }).toThrow();
+    expect(() => { mount(<Caption size={99999}>example</Caption>); }).toThrow();
+    expect(() => { mount(<Caption size="test">example</Caption>); }).toThrow();
+  });
+
+  it('matches wrapper snapshot', () => {
+    expect(mount(<Caption>Heading text</Caption>)).toMatchSnapshot();
+  });
+});

--- a/packages/govuk-react/package.json
+++ b/packages/govuk-react/package.json
@@ -5,6 +5,7 @@
     "@govuk-react/back-link": "^0.6.0-alpha.4",
     "@govuk-react/breadcrumb": "^0.6.0-alpha.4",
     "@govuk-react/button": "^0.6.0-alpha.4",
+    "@govuk-react/caption": "^0.6.0-alpha.4",
     "@govuk-react/checkbox": "^0.6.0-alpha.4",
     "@govuk-react/constants": "^0.6.0-alpha.4",
     "@govuk-react/date-field": "^0.6.0-alpha.4",

--- a/packages/govuk-react/src/index.js
+++ b/packages/govuk-react/src/index.js
@@ -1,10 +1,8 @@
-// TODO: eslint needs to be configured to pick up exports that aren't in package.json
-// see https://github.com/benmosher/eslint-plugin-import/issues/1049
-
 // Components
 export { default as BackLink } from '@govuk-react/back-link';
 export { default as Breadcrumb } from '@govuk-react/breadcrumb';
 export { default as Button } from '@govuk-react/button';
+export { default as Caption } from '@govuk-react/caption';
 export { default as Checkbox } from '@govuk-react/checkbox';
 export { default as DateField } from '@govuk-react/date-field';
 export { default as Details } from '@govuk-react/details';

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -5,6 +5,7 @@
     "@govuk-react/back-link": "^0.6.0-alpha.4",
     "@govuk-react/breadcrumb": "^0.6.0-alpha.4",
     "@govuk-react/button": "^0.6.0-alpha.4",
+    "@govuk-react/caption": "^0.6.0-alpha.4",
     "@govuk-react/checkbox": "^0.6.0-alpha.4",
     "@govuk-react/date-field": "^0.6.0-alpha.4",
     "@govuk-react/details": "^0.6.0-alpha.4",


### PR DESCRIPTION
Caption component added, as per govuk-frontend typography
Works in a similar manner to `Header`, accepting a `size` prop that's either a string or numeric fitting in the GDS font scale list

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

![](https://s3-us-west-2.amazonaws.com/chromatic-snapshots/snapshots/5c6e89025cd0f000248fed77/capture.png)
