### PR TITLE
Width settings

### DIFF
--- a/API.md
+++ b/API.md
@@ -539,9 +539,11 @@ import GridCol from '@govuk-react/grid-col';
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
  `children` |  | ```undefined``` | node | GridCol content
+ `columnFull` |  | ```false``` | bool | Dimension setting for the column
  `columnOneHalf` |  | ```false``` | bool | Dimension setting for the column
  `columnOneQuarter` |  | ```false``` | bool | Dimension setting for the column
  `columnOneThird` |  | ```false``` | bool | Dimension setting for the column
+ `columnThreeQuarters` |  | ```false``` | bool | Dimension setting for the column
  `columnTwoThirds` |  | ```false``` | bool | Dimension setting for the column
 
 
@@ -1785,32 +1787,21 @@ const example2Head = (
 </Table>
 ```
 
-NB The govuk-frontend table component describes a way of setting custom column widths
-via width override classes. Currently govuk-react does not provide a direct equivalent of this
-functionality out of the box, however if this behaviour is desired then custom widths
-can be set by re-styling a component.
-
-For example;
+Setting custom column widths
 ```jsx
-import styled from 'styled-components';
-
-const CustomHeader = styled(Table.CellHeader)({
-  width: '50%',
-});
-
 <Table
   caption="Custom header"
   head={
     <Table.Row>
-      <CustomHeader>Wide header</CustomHeader>
-      <Table.CellHeader>Regular</Table.CellHeader>
+      <Table.CellHeader setWidth="one-half>Wide header</Table.CellHeader>
+      <Table.CellHeader setWidth="30%">Regular</Table.CellHeader>
       <Table.CellHeader>Normal</Table.CellHeader>
     </Table.Row>
   }
 >
   <Table.Row>
-    <Table.Cell>Custom header provides a wide column here</Table.Cell>
-    <Table.Cell>Some value</Table.Cell>
+    <Table.Cell>Header makes this column one-half wide</Table.Cell>
+    <Table.Cell>And this one 30%</Table.Cell>
     <Table.Cell>Another</Table.Cell>
   </Table.Row>
 </Table>

--- a/API.md
+++ b/API.md
@@ -491,13 +491,13 @@ GridCol
 ```
 <!-- STORY -->
 
-Should always be wrapped by `GridRow`. Will always render a column at 100% width if
-the browser width is below the `LARGESCREEN` breakpoint.
+Should always be wrapped by `GridRow`. Will always render a column at full width if
+the browser width is below the `TABLET` breakpoint.
+
+NB our grid is based on flex-box, which differs from govuk-frontend, which instead uses
+floats, however it is otherwise similar to use.
 
 ### Usage
-
-Example
-* https://codesandbox.io/s/x917knwm4z
 
 Simple
 ```jsx
@@ -511,20 +511,28 @@ import GridCol from '@govuk-react/grid-col';
     </GridCol>
   </GridRow>
   <GridRow>
-    <GridCol columnOneHalf>
+    <GridCol setWidth="one-half">
       ...
     </GridCol>
-    <GridCol columnOneQuarter>
+    <GridCol setWidth="one-quarter">
       ...
     </GridCol>
-    <GridCol columnOneQuarter>
+    <GridCol setWidth="one-quarter">
       ...
     </GridCol>
   <GridRow>
-    <GridCol columnOneThird>
+    <GridCol setWidth="one-third">
       ...
     </GridCol>
-    <GridCol columnTwoThirds>
+    <GridCol setWidth="two-thirds">
+      ...
+    </GridCol>
+  </GridRow>
+  <GridRow>
+    <GridCol setWidth="one-third" setDesktopWidth="one-quarter">
+      ...
+    </GridCol>
+    <GridCol setWidth="two-thirds" setDesktopWidth="auto">
       ...
     </GridCol>
   </GridRow>
@@ -539,12 +547,14 @@ import GridCol from '@govuk-react/grid-col';
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
  `children` |  | ```undefined``` | node | GridCol content
- `columnFull` |  | ```false``` | bool | Dimension setting for the column
- `columnOneHalf` |  | ```false``` | bool | Dimension setting for the column
- `columnOneQuarter` |  | ```false``` | bool | Dimension setting for the column
- `columnOneThird` |  | ```false``` | bool | Dimension setting for the column
- `columnThreeQuarters` |  | ```false``` | bool | Dimension setting for the column
- `columnTwoThirds` |  | ```false``` | bool | Dimension setting for the column
+ `columnFull` |  | ```false``` | bool | Dimension setting for the column (deprecated)
+ `columnOneHalf` |  | ```false``` | bool | Dimension setting for the column (deprecated)
+ `columnOneQuarter` |  | ```false``` | bool | Dimension setting for the column (deprecated)
+ `columnOneThird` |  | ```false``` | bool | Dimension setting for the column (deprecated)
+ `columnThreeQuarters` |  | ```false``` | bool | Dimension setting for the column (deprecated)
+ `columnTwoThirds` |  | ```false``` | bool | Dimension setting for the column (deprecated)
+ `setDesktopWidth` |  | ```undefined``` | union(string \| number \| enum) | Explicitly set desktop column to width using value or descriptive string<br/>(`one-quarter`, `one-third`, `one-half`, `two-thirds`, `three-quarters`, `full`)
+ `setWidth` |  | ```undefined``` | union(string \| number \| enum) | Explicitly set column to width using value or descriptive string<br/>(`one-quarter`, `one-third`, `one-half`, `two-thirds`, `three-quarters`, `full`)
 
 
 GridRow

--- a/components/grid-col/README.md
+++ b/components/grid-col/README.md
@@ -7,13 +7,13 @@ GridCol
 ```
 <!-- STORY -->
 
-Should always be wrapped by `GridRow`. Will always render a column at 100% width if
-the browser width is below the `LARGESCREEN` breakpoint.
+Should always be wrapped by `GridRow`. Will always render a column at full width if
+the browser width is below the `TABLET` breakpoint.
+
+NB our grid is based on flex-box, which differs from govuk-frontend, which instead uses
+floats, however it is otherwise similar to use.
 
 ### Usage
-
-Example
-* https://codesandbox.io/s/x917knwm4z
 
 Simple
 ```jsx
@@ -27,20 +27,28 @@ import GridCol from '@govuk-react/grid-col';
     </GridCol>
   </GridRow>
   <GridRow>
-    <GridCol columnOneHalf>
+    <GridCol setWidth="one-half">
       ...
     </GridCol>
-    <GridCol columnOneQuarter>
+    <GridCol setWidth="one-quarter">
       ...
     </GridCol>
-    <GridCol columnOneQuarter>
+    <GridCol setWidth="one-quarter">
       ...
     </GridCol>
   <GridRow>
-    <GridCol columnOneThird>
+    <GridCol setWidth="one-third">
       ...
     </GridCol>
-    <GridCol columnTwoThirds>
+    <GridCol setWidth="two-thirds">
+      ...
+    </GridCol>
+  </GridRow>
+  <GridRow>
+    <GridCol setWidth="one-third" setDesktopWidth="one-quarter">
+      ...
+    </GridCol>
+    <GridCol setWidth="two-thirds" setDesktopWidth="auto">
       ...
     </GridCol>
   </GridRow>
@@ -55,11 +63,13 @@ import GridCol from '@govuk-react/grid-col';
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
  `children` |  | ```undefined``` | node | GridCol content
- `columnFull` |  | ```false``` | bool | Dimension setting for the column
- `columnOneHalf` |  | ```false``` | bool | Dimension setting for the column
- `columnOneQuarter` |  | ```false``` | bool | Dimension setting for the column
- `columnOneThird` |  | ```false``` | bool | Dimension setting for the column
- `columnThreeQuarters` |  | ```false``` | bool | Dimension setting for the column
- `columnTwoThirds` |  | ```false``` | bool | Dimension setting for the column
+ `columnFull` |  | ```false``` | bool | Dimension setting for the column (deprecated)
+ `columnOneHalf` |  | ```false``` | bool | Dimension setting for the column (deprecated)
+ `columnOneQuarter` |  | ```false``` | bool | Dimension setting for the column (deprecated)
+ `columnOneThird` |  | ```false``` | bool | Dimension setting for the column (deprecated)
+ `columnThreeQuarters` |  | ```false``` | bool | Dimension setting for the column (deprecated)
+ `columnTwoThirds` |  | ```false``` | bool | Dimension setting for the column (deprecated)
+ `setDesktopWidth` |  | ```undefined``` | union(string \| number \| enum) | Explicitly set desktop column to width using value or descriptive string<br/>(`one-quarter`, `one-third`, `one-half`, `two-thirds`, `three-quarters`, `full`)
+ `setWidth` |  | ```undefined``` | union(string \| number \| enum) | Explicitly set column to width using value or descriptive string<br/>(`one-quarter`, `one-third`, `one-half`, `two-thirds`, `three-quarters`, `full`)
 
 

--- a/components/grid-col/README.md
+++ b/components/grid-col/README.md
@@ -55,9 +55,11 @@ import GridCol from '@govuk-react/grid-col';
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
  `children` |  | ```undefined``` | node | GridCol content
+ `columnFull` |  | ```false``` | bool | Dimension setting for the column
  `columnOneHalf` |  | ```false``` | bool | Dimension setting for the column
  `columnOneQuarter` |  | ```false``` | bool | Dimension setting for the column
  `columnOneThird` |  | ```false``` | bool | Dimension setting for the column
+ `columnThreeQuarters` |  | ```false``` | bool | Dimension setting for the column
  `columnTwoThirds` |  | ```false``` | bool | Dimension setting for the column
 
 

--- a/components/grid-col/package.json
+++ b/components/grid-col/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.0-alpha.4",
   "dependencies": {
     "@govuk-react/constants": "^0.6.0-alpha.4",
+    "@govuk-react/lib": "^0.6.0-alpha.4",
     "govuk-colours": "^1.0.3"
   },
   "peerDependencies": {

--- a/components/grid-col/src/__snapshots__/test.js.snap
+++ b/components/grid-col/src/__snapshots__/test.js.snap
@@ -21,21 +21,27 @@ exports[`GridCol matches snapshot: enzyme.mount 1`] = `
 }
 
 <GridCol
+  columnFull={false}
   columnOneHalf={false}
   columnOneQuarter={false}
   columnOneThird={false}
+  columnThreeQuarters={false}
   columnTwoThirds={false}
 >
   <styled.div
+    columnFull={false}
     columnOneHalf={false}
     columnOneQuarter={false}
     columnOneThird={false}
+    columnThreeQuarters={false}
     columnTwoThirds={false}
   >
     <StyledComponent
+      columnFull={false}
       columnOneHalf={false}
       columnOneQuarter={false}
       columnOneThird={false}
+      columnThreeQuarters={false}
       columnTwoThirds={false}
       forwardedComponent={
         Object {

--- a/components/grid-col/src/__snapshots__/test.js.snap
+++ b/components/grid-col/src/__snapshots__/test.js.snap
@@ -1,6 +1,429 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GridCol matches snapshot: enzyme.mount 1`] = `
+exports[`GridCol renders custom widths matching snapshot: GridCol custom widths example 1`] = `
+Array [
+  .c0 {
+  box-sizing: border-box;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+@media only screen and (min-width:641px) {
+  .c0 {
+    width: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+  }
+}
+
+<GridCol
+    columnFull={false}
+    columnOneHalf={false}
+    columnOneQuarter={false}
+    columnOneThird={false}
+    columnThreeQuarters={false}
+    columnTwoThirds={false}
+    setWidth="one-quarter"
+  >
+    <styled.div
+      columnFull={false}
+      columnOneHalf={false}
+      columnOneQuarter={false}
+      columnOneThird={false}
+      columnThreeQuarters={false}
+      columnTwoThirds={false}
+      setWidth="one-quarter"
+    >
+      <StyledComponent
+        columnFull={false}
+        columnOneHalf={false}
+        columnOneQuarter={false}
+        columnOneThird={false}
+        columnThreeQuarters={false}
+        columnTwoThirds={false}
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "sc-bdVaJa",
+              "isStatic": false,
+              "lastClassName": "hfwjaA",
+              "rules": Array [
+                "box-sizing: border-box; padding-right: 15px; padding-left: 15px;",
+                [Function],
+              ],
+            },
+            "displayName": "styled.div",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "sc-bdVaJa",
+            "target": "div",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+        setWidth="one-quarter"
+      >
+        <div
+          className="c0"
+        >
+          example
+        </div>
+      </StyledComponent>
+    </styled.div>
+  </GridCol>,
+  .c0 {
+  box-sizing: border-box;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+@media only screen and (min-width:641px) {
+  .c0 {
+    width: 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+  }
+}
+
+<GridCol
+    columnFull={false}
+    columnOneHalf={false}
+    columnOneQuarter={false}
+    columnOneThird={false}
+    columnThreeQuarters={false}
+    columnTwoThirds={false}
+    setWidth="three-quarters"
+  >
+    <styled.div
+      columnFull={false}
+      columnOneHalf={false}
+      columnOneQuarter={false}
+      columnOneThird={false}
+      columnThreeQuarters={false}
+      columnTwoThirds={false}
+      setWidth="three-quarters"
+    >
+      <StyledComponent
+        columnFull={false}
+        columnOneHalf={false}
+        columnOneQuarter={false}
+        columnOneThird={false}
+        columnThreeQuarters={false}
+        columnTwoThirds={false}
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "sc-bdVaJa",
+              "isStatic": false,
+              "lastClassName": "hfwjaA",
+              "rules": Array [
+                "box-sizing: border-box; padding-right: 15px; padding-left: 15px;",
+                [Function],
+              ],
+            },
+            "displayName": "styled.div",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "sc-bdVaJa",
+            "target": "div",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+        setWidth="three-quarters"
+      >
+        <div
+          className="c0"
+        >
+          example
+        </div>
+      </StyledComponent>
+    </styled.div>
+  </GridCol>,
+  .c0 {
+  box-sizing: border-box;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+@media only screen and (min-width:641px) {
+  .c0 {
+    width: 90%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+  }
+}
+
+<GridCol
+    columnFull={false}
+    columnOneHalf={false}
+    columnOneQuarter={false}
+    columnOneThird={false}
+    columnThreeQuarters={false}
+    columnTwoThirds={false}
+    setWidth="90%"
+  >
+    <styled.div
+      columnFull={false}
+      columnOneHalf={false}
+      columnOneQuarter={false}
+      columnOneThird={false}
+      columnThreeQuarters={false}
+      columnTwoThirds={false}
+      setWidth="90%"
+    >
+      <StyledComponent
+        columnFull={false}
+        columnOneHalf={false}
+        columnOneQuarter={false}
+        columnOneThird={false}
+        columnThreeQuarters={false}
+        columnTwoThirds={false}
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "sc-bdVaJa",
+              "isStatic": false,
+              "lastClassName": "hfwjaA",
+              "rules": Array [
+                "box-sizing: border-box; padding-right: 15px; padding-left: 15px;",
+                [Function],
+              ],
+            },
+            "displayName": "styled.div",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "sc-bdVaJa",
+            "target": "div",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+        setWidth="90%"
+      >
+        <div
+          className="c0"
+        >
+          example
+        </div>
+      </StyledComponent>
+    </styled.div>
+  </GridCol>,
+  .c0 {
+  box-sizing: border-box;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+@media only screen and (min-width:641px) {
+  .c0 {
+    width: 33.3333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+  }
+}
+
+@media only screen and (min-width:769px) {
+  .c0 {
+    width: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+  }
+}
+
+<GridCol
+    columnFull={false}
+    columnOneHalf={false}
+    columnOneQuarter={false}
+    columnOneThird={false}
+    columnThreeQuarters={false}
+    columnTwoThirds={false}
+    setDesktopWidth="one-quarter"
+    setWidth="one-third"
+  >
+    <styled.div
+      columnFull={false}
+      columnOneHalf={false}
+      columnOneQuarter={false}
+      columnOneThird={false}
+      columnThreeQuarters={false}
+      columnTwoThirds={false}
+      setDesktopWidth="one-quarter"
+      setWidth="one-third"
+    >
+      <StyledComponent
+        columnFull={false}
+        columnOneHalf={false}
+        columnOneQuarter={false}
+        columnOneThird={false}
+        columnThreeQuarters={false}
+        columnTwoThirds={false}
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "sc-bdVaJa",
+              "isStatic": false,
+              "lastClassName": "hfwjaA",
+              "rules": Array [
+                "box-sizing: border-box; padding-right: 15px; padding-left: 15px;",
+                [Function],
+              ],
+            },
+            "displayName": "styled.div",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "sc-bdVaJa",
+            "target": "div",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+        setDesktopWidth="one-quarter"
+        setWidth="one-third"
+      >
+        <div
+          className="c0"
+        >
+          example
+        </div>
+      </StyledComponent>
+    </styled.div>
+  </GridCol>,
+  .c0 {
+  box-sizing: border-box;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+@media only screen and (min-width:641px) {
+  .c0 {
+    -webkit-box-flex: 1;
+    -webkit-flex-grow: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+    -webkit-flex-shrink: 1;
+    -ms-flex-negative: 1;
+    flex-shrink: 1;
+  }
+}
+
+@media only screen and (min-width:769px) {
+  .c0 {
+    width: 33.3333%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+  }
+}
+
+<GridCol
+    columnFull={false}
+    columnOneHalf={false}
+    columnOneQuarter={false}
+    columnOneThird={false}
+    columnThreeQuarters={false}
+    columnTwoThirds={false}
+    setDesktopWidth="one-third"
+  >
+    <styled.div
+      columnFull={false}
+      columnOneHalf={false}
+      columnOneQuarter={false}
+      columnOneThird={false}
+      columnThreeQuarters={false}
+      columnTwoThirds={false}
+      setDesktopWidth="one-third"
+    >
+      <StyledComponent
+        columnFull={false}
+        columnOneHalf={false}
+        columnOneQuarter={false}
+        columnOneThird={false}
+        columnThreeQuarters={false}
+        columnTwoThirds={false}
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "sc-bdVaJa",
+              "isStatic": false,
+              "lastClassName": "c0",
+              "rules": Array [
+                "box-sizing: border-box; padding-right: 15px; padding-left: 15px;",
+                [Function],
+              ],
+            },
+            "displayName": "styled.div",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "sc-bdVaJa",
+            "target": "div",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+        setDesktopWidth="one-third"
+      >
+        <div
+          className="c0"
+        >
+          example
+        </div>
+      </StyledComponent>
+    </styled.div>
+  </GridCol>,
+]
+`;
+
+exports[`GridCol simple render matches snapshot: GridCol simple example 1`] = `
 .c0 {
   box-sizing: border-box;
   padding-right: 15px;
@@ -16,7 +439,6 @@ exports[`GridCol matches snapshot: enzyme.mount 1`] = `
     -webkit-flex-shrink: 1;
     -ms-flex-negative: 1;
     flex-shrink: 1;
-    width: auto;
   }
 }
 

--- a/components/grid-col/src/index.js
+++ b/components/grid-col/src/index.js
@@ -4,11 +4,17 @@ import PropTypes from 'prop-types';
 import { GUTTER_HALF, MEDIA_QUERIES } from '@govuk-react/constants';
 
 const colValues = {
-  columnOneThird: '33.3333%',
-  columnTwoThirds: '66.6667%',
   columnOneQuarter: '25%',
+  columnOneThird: '33.3333%',
   columnOneHalf: '50%',
+  columnTwoThirds: '66.6667%',
+  columnThreeQuarters: '75%',
+  columnFull: '100%',
 };
+
+// TODO: govuk-frontend supports "from-desktop" classes
+// which will apply sizes using MQ for desktop
+// TODO: rethink width props - consider using `withWidth`
 
 const StyledColumn = styled('div')(
   {
@@ -27,7 +33,7 @@ const StyledColumn = styled('div')(
       }
     });
     return ({
-      [MEDIA_QUERIES.LARGESCREEN]: {
+      [MEDIA_QUERIES.TABLET]: {
         flexGrow: hasRequestedWidth ? 0 : 1,
         flexShrink: hasRequestedWidth ? 0 : 1,
         width: widthValue,
@@ -83,41 +89,33 @@ const StyledColumn = styled('div')(
  * - https://github.com/alphagov/govuk_elements/blob/master/assets/sass/elements/_layout.scss
  *
  */
-const GridCol = ({
-  columnOneThird,
-  columnTwoThirds,
-  columnOneQuarter,
-  columnOneHalf,
-  ...props
-}) => (
-  <StyledColumn
-    columnOneThird={columnOneThird}
-    columnTwoThirds={columnTwoThirds}
-    columnOneQuarter={columnOneQuarter}
-    columnOneHalf={columnOneHalf}
-    {...props}
-  />
-);
+const GridCol = props => <StyledColumn {...props} />;
 
 GridCol.propTypes = {
   /** GridCol content */
   children: PropTypes.node,
   /** Dimension setting for the column */
+  columnOneQuarter: PropTypes.bool,
+  /** Dimension setting for the column */
   columnOneThird: PropTypes.bool,
+  /** Dimension setting for the column */
+  columnOneHalf: PropTypes.bool,
   /** Dimension setting for the column */
   columnTwoThirds: PropTypes.bool,
   /** Dimension setting for the column */
-  columnOneQuarter: PropTypes.bool,
+  columnThreeQuarters: PropTypes.bool,
   /** Dimension setting for the column */
-  columnOneHalf: PropTypes.bool,
+  columnFull: PropTypes.bool,
 };
 
 GridCol.defaultProps = {
   children: undefined,
-  columnOneThird: false,
-  columnTwoThirds: false,
   columnOneQuarter: false,
+  columnOneThird: false,
   columnOneHalf: false,
+  columnTwoThirds: false,
+  columnThreeQuarters: false,
+  columnFull: false,
 };
 
 export default GridCol;

--- a/components/grid-col/src/stories.js
+++ b/components/grid-col/src/stories.js
@@ -3,8 +3,6 @@ import styled from 'styled-components';
 import { storiesOf } from '@storybook/react';
 import { WithDocsCustom } from '@govuk-react/storybook-components';
 
-// Can't seem to overcome import/no-extraneous-dependencies with the following line;
-// import { GridRow, H2, Paragraph } from 'govuk-react';
 import GridRow from '@govuk-react/grid-row';
 import { H2 } from '@govuk-react/header';
 import Paragraph from '@govuk-react/paragraph';
@@ -25,7 +23,7 @@ stories.addDecorator(WithDocsCustom(ReadMe));
 
 stories.add('Component default', () => (
   <GridRow>
-    <GridCol columnOneHalf>
+    <GridCol setWidth="one-half">
       <H2>Half column</H2>
       <Paragraph>
         This guide shows how to make your service look consistent with the rest of
@@ -33,7 +31,7 @@ stories.add('Component default', () => (
         colour, images, icons, forms, buttons and data.
       </Paragraph>
     </GridCol>
-    <GridCol columnOneHalf>
+    <GridCol setWidth="one-half">
       <H2>Half column</H2>
       <Paragraph>
         This guide shows how to make your service look consistent with the rest of
@@ -46,10 +44,10 @@ stories.add('Component default', () => (
 
 examples.add('Column Halves', () => (
   <GridRow>
-    <GridCol columnOneHalf>
+    <GridCol setWidth="one-half">
       <Content>content</Content>
     </GridCol>
-    <GridCol columnOneHalf>
+    <GridCol setWidth="one-half">
       <Content>content</Content>
     </GridCol>
   </GridRow>
@@ -57,13 +55,13 @@ examples.add('Column Halves', () => (
 
 examples.add('Column Thirds', () => (
   <GridRow>
-    <GridCol columnOneThird>
+    <GridCol setWidth="one-third">
       <Content>content</Content>
     </GridCol>
-    <GridCol columnOneThird>
+    <GridCol setWidth="one-third">
       <Content>content</Content>
     </GridCol>
-    <GridCol columnOneThird>
+    <GridCol setWidth="one-third">
       <Content>content</Content>
     </GridCol>
   </GridRow>
@@ -71,10 +69,10 @@ examples.add('Column Thirds', () => (
 
 examples.add('Column Two Thirds / One Third', () => (
   <GridRow>
-    <GridCol columnTwoThirds>
+    <GridCol setWidth="two-thirds">
       <Content>content</Content>
     </GridCol>
-    <GridCol columnOneThird>
+    <GridCol setWidth="one-third">
       <Content>content</Content>
     </GridCol>
   </GridRow>
@@ -82,38 +80,63 @@ examples.add('Column Two Thirds / One Third', () => (
 
 examples.add('Column One Third / Two Thirds', () => (
   <GridRow>
-    <GridCol columnOneThird>
+    <GridCol setWidth="one-third">
       <Content>content</Content>
     </GridCol>
-    <GridCol columnTwoThirds>
-      <Content>content</Content>
-    </GridCol>
-  </GridRow>
-));
-
-examples.add('Quarters', () => (
-  <GridRow>
-    <GridCol columnOneQuarter>
-      <Content>content</Content>
-    </GridCol>
-    <GridCol columnOneQuarter>
-      <Content>content</Content>
-    </GridCol>
-    <GridCol columnOneQuarter>
-      <Content>content</Content>
-    </GridCol>
-    <GridCol columnOneQuarter>
+    <GridCol setWidth="two-thirds">
       <Content>content</Content>
     </GridCol>
   </GridRow>
 ));
 
-examples.add('One Quarter and auto-fill', () => (
+examples.add('Column Four Quarters', () => (
   <GridRow>
-    <GridCol columnOneQuarter>
+    <GridCol setWidth="one-quarter">
+      <Content>content</Content>
+    </GridCol>
+    <GridCol setWidth="one-quarter">
+      <Content>content</Content>
+    </GridCol>
+    <GridCol setWidth="one-quarter">
+      <Content>content</Content>
+    </GridCol>
+    <GridCol setWidth="one-quarter">
+      <Content>content</Content>
+    </GridCol>
+  </GridRow>
+));
+
+examples.add('Column One Quarter and auto-fill', () => (
+  <GridRow>
+    <GridCol setWidth="one-quarter">
       <Content>content</Content>
     </GridCol>
     <GridCol>
+      <Content>content</Content>
+    </GridCol>
+  </GridRow>
+));
+
+examples.add('Column widths differing between tablet and desktop', () => (
+  <GridRow>
+    <GridCol setWidth="one-quarter" setDesktopWidth="one-third">
+      <Content>content</Content>
+    </GridCol>
+    <GridCol setWidth="three-quarters" setDesktopWidth="auto">
+      <Content>content</Content>
+    </GridCol>
+  </GridRow>
+));
+
+examples.add('Custom widths, differing between tablet and desktop', () => (
+  <GridRow>
+    <GridCol setWidth="60%" setDesktopWidth="auto">
+      <Content>content</Content>
+    </GridCol>
+    <GridCol setWidth="30%" setDesktopWidth="18%">
+      <Content>content</Content>
+    </GridCol>
+    <GridCol setWidth="auto" setDesktopWidth="400px">
       <Content>content</Content>
     </GridCol>
   </GridRow>

--- a/components/grid-col/src/stories.js
+++ b/components/grid-col/src/stories.js
@@ -108,12 +108,12 @@ examples.add('Quarters', () => (
   </GridRow>
 ));
 
-examples.add('One Quarter and autoFill', () => (
+examples.add('One Quarter and auto-fill', () => (
   <GridRow>
     <GridCol columnOneQuarter>
       <Content>content</Content>
     </GridCol>
-    <GridCol autoFill>
+    <GridCol>
       <Content>content</Content>
     </GridCol>
   </GridRow>

--- a/components/grid-col/src/test.js
+++ b/components/grid-col/src/test.js
@@ -1,32 +1,34 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { Fragment } from 'react';
 import { mount } from 'enzyme';
 
-import GridCol from './';
+import GridCol from '.';
 
 describe('GridCol', () => {
-  let props;
-  const example = 'example';
-  const wrapper = <GridCol>{example}</GridCol>;
-
-  beforeEach(() => {
-    props = {
-      children: example,
-    };
-  });
-
   it('renders without crashing', () => {
-    const div = document.createElement('div');
-    ReactDOM.render(<GridCol columnOneThird>{example}</GridCol>, div);
-    ReactDOM.render(<GridCol columnTwoThirds>{example}</GridCol>, div);
-    ReactDOM.render(<GridCol columnOneQuarter>{example}</GridCol>, div);
+    mount(<GridCol>example</GridCol>);
+    mount(<GridCol columnOneThird>example</GridCol>);
+    mount(<GridCol columnTwoThirds>example</GridCol>);
+    mount(<GridCol columnOneQuarter>example</GridCol>);
   });
 
-  it('passes `props.children` to the rendered `wrapper` as `children`', () => {
-    expect(wrapper.props.children).toBe(props.children);
+  it('simple render matches snapshot', () => {
+    const wrapper = mount(<GridCol>example</GridCol>);
+
+    expect(wrapper).toMatchSnapshot('GridCol simple example');
   });
 
-  it('matches snapshot', () => {
-    expect(mount(wrapper)).toMatchSnapshot('enzyme.mount');
+  it('renders custom widths matching snapshot', () => {
+    const example = (
+      <Fragment>
+        <GridCol setWidth="one-quarter">example</GridCol>
+        <GridCol setWidth="three-quarters">example</GridCol>
+        <GridCol setWidth="90%">example</GridCol>
+        <GridCol setWidth="one-third" setDesktopWidth="one-quarter">example</GridCol>
+        <GridCol setDesktopWidth="one-third">example</GridCol>
+      </Fragment>
+    );
+    const wrapper = mount(example);
+
+    expect(wrapper).toMatchSnapshot('GridCol custom widths example');
   });
 });

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -70,32 +70,21 @@ const example2Head = (
 </Table>
 ```
 
-NB The govuk-frontend table component describes a way of setting custom column widths
-via width override classes. Currently govuk-react does not provide a direct equivalent of this
-functionality out of the box, however if this behaviour is desired then custom widths
-can be set by re-styling a component.
-
-For example;
+Setting custom column widths
 ```jsx
-import styled from 'styled-components';
-
-const CustomHeader = styled(Table.CellHeader)({
-  width: '50%',
-});
-
 <Table
   caption="Custom header"
   head={
     <Table.Row>
-      <CustomHeader>Wide header</CustomHeader>
-      <Table.CellHeader>Regular</Table.CellHeader>
+      <Table.CellHeader setWidth="one-half>Wide header</Table.CellHeader>
+      <Table.CellHeader setWidth="30%">Regular</Table.CellHeader>
       <Table.CellHeader>Normal</Table.CellHeader>
     </Table.Row>
   }
 >
   <Table.Row>
-    <Table.Cell>Custom header provides a wide column here</Table.Cell>
-    <Table.Cell>Some value</Table.Cell>
+    <Table.Cell>Header makes this column one-half wide</Table.Cell>
+    <Table.Cell>And this one 30%</Table.Cell>
     <Table.Cell>Another</Table.Cell>
   </Table.Row>
 </Table>

--- a/components/table/src/__snapshots__/test.js.snap
+++ b/components/table/src/__snapshots__/test.js.snap
@@ -1212,6 +1212,618 @@ exports[`Table renders a table with a caption matching snapshot: table with capt
 </TableWithCaption>
 `;
 
+exports[`Table renders a table with custom widths matching snapshot: table with custom widths 1`] = `
+.c1 {
+  font-weight: 700;
+  display: table-caption;
+  text-align: left;
+}
+
+.c4 {
+  padding: 10px 20px 10px 0;
+  border-bottom: 1px solid #bfc1c3;
+  text-align: left;
+  font-weight: 700;
+}
+
+.c4:last-child {
+  padding-right: 0;
+}
+
+.c5 {
+  padding: 10px 20px 10px 0;
+  border-bottom: 1px solid #bfc1c3;
+  text-align: left;
+}
+
+.c5:last-child {
+  padding-right: 0;
+}
+
+.c2 {
+  padding: 10px 20px 10px 0;
+  border-bottom: 1px solid #bfc1c3;
+  text-align: left;
+  font-weight: 700;
+  width: 100%;
+}
+
+.c2:last-child {
+  padding-right: 0;
+}
+
+.c3 {
+  padding: 10px 20px 10px 0;
+  border-bottom: 1px solid #bfc1c3;
+  text-align: left;
+  font-weight: 700;
+  width: 100%;
+}
+
+.c3:last-child {
+  padding-right: 0;
+}
+
+.c0 {
+  font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  color: #0b0c0c;
+  width: 100%;
+  border-spacing: 0;
+  border-collapse: collapse;
+  margin-bottom: 20px;
+}
+
+@media only screen and (min-width:641px) {
+  .c2 {
+    width: 50%;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c3 {
+    width: 22%;
+  }
+}
+
+@media print {
+  .c0 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c0 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c0 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c0 {
+    margin-bottom: 30px;
+  }
+}
+
+<TableWithCustomWidths>
+  <Table
+    caption="Custom widths"
+    head={
+      <ForwardRef>
+        <CellHeader
+          setWidth="one-half"
+        >
+          one-half
+        </CellHeader>
+        <CellHeader
+          setWidth="22%"
+        >
+          22%
+        </CellHeader>
+        <CellHeader>
+          Normal
+        </CellHeader>
+      </ForwardRef>
+    }
+  >
+    <styled.table>
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "sc-EHOje",
+              "isStatic": false,
+              "lastClassName": "c0",
+              "rules": Array [
+                "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+  font-size: 14px; line-height: 1.15;
+} font-weight: 400; font-size: 16px; line-height: 1.25; @media only screen and (min-width: 641px) {
+  font-size: 19px; line-height: 1.3157894736842106;
+}",
+                "color: #0b0c0c; @media print {
+  color: #000;
+}",
+                "width: 100%; border-spacing: 0; border-collapse: collapse;",
+                [Function],
+              ],
+            },
+            "displayName": "styled.table",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "sc-EHOje",
+            "target": "table",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+      >
+        <table
+          className="c0"
+        >
+          <styled.caption>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-htpNat",
+                    "isStatic": true,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "font-weight: 700; display: table-caption; text-align: left;",
+                    ],
+                  },
+                  "displayName": "styled.caption",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-htpNat",
+                  "target": "caption",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <caption
+                className="c1"
+              >
+                Custom widths
+              </caption>
+            </StyledComponent>
+          </styled.caption>
+          <styled.thead>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-bdVaJa",
+                    "isStatic": true,
+                    "lastClassName": "bDWFJH",
+                    "rules": Array [
+                      "",
+                    ],
+                  },
+                  "displayName": "styled.thead",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-bdVaJa",
+                  "target": "thead",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <thead
+                className=""
+              >
+                <styled.tr>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "sc-ifAKCX",
+                          "isStatic": true,
+                          "lastClassName": "cFlEyZ",
+                          "rules": Array [
+                            "",
+                          ],
+                        },
+                        "displayName": "styled.tr",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "sc-ifAKCX",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className=""
+                    >
+                      <CellHeader
+                        setWidth="one-half"
+                      >
+                        <styled.td
+                          as="th"
+                          bold={true}
+                          isHeader={true}
+                          setWidth="one-half"
+                        >
+                          <StyledComponent
+                            as="th"
+                            bold={true}
+                            forwardedComponent={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "attrs": Array [],
+                                "componentStyle": ComponentStyle {
+                                  "componentId": "sc-bxivhb",
+                                  "isStatic": false,
+                                  "lastClassName": "c5",
+                                  "rules": Array [
+                                    [Function],
+                                    [Function],
+                                    [Function],
+                                  ],
+                                },
+                                "displayName": "styled.td",
+                                "foldedComponentIds": Array [],
+                                "propTypes": Object {
+                                  "alignRight": [Function],
+                                  "children": [Function],
+                                  "isHeader": [Function],
+                                  "numeric": [Function],
+                                },
+                                "render": [Function],
+                                "styledComponentId": "sc-bxivhb",
+                                "target": "td",
+                                "toString": [Function],
+                                "warnTooManyClasses": [Function],
+                                "withComponent": [Function],
+                              }
+                            }
+                            forwardedRef={null}
+                            isHeader={true}
+                            setWidth="one-half"
+                          >
+                            <th
+                              className="c2"
+                            >
+                              one-half
+                            </th>
+                          </StyledComponent>
+                        </styled.td>
+                      </CellHeader>
+                      <CellHeader
+                        setWidth="22%"
+                      >
+                        <styled.td
+                          as="th"
+                          bold={true}
+                          isHeader={true}
+                          setWidth="22%"
+                        >
+                          <StyledComponent
+                            as="th"
+                            bold={true}
+                            forwardedComponent={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "attrs": Array [],
+                                "componentStyle": ComponentStyle {
+                                  "componentId": "sc-bxivhb",
+                                  "isStatic": false,
+                                  "lastClassName": "c5",
+                                  "rules": Array [
+                                    [Function],
+                                    [Function],
+                                    [Function],
+                                  ],
+                                },
+                                "displayName": "styled.td",
+                                "foldedComponentIds": Array [],
+                                "propTypes": Object {
+                                  "alignRight": [Function],
+                                  "children": [Function],
+                                  "isHeader": [Function],
+                                  "numeric": [Function],
+                                },
+                                "render": [Function],
+                                "styledComponentId": "sc-bxivhb",
+                                "target": "td",
+                                "toString": [Function],
+                                "warnTooManyClasses": [Function],
+                                "withComponent": [Function],
+                              }
+                            }
+                            forwardedRef={null}
+                            isHeader={true}
+                            setWidth="22%"
+                          >
+                            <th
+                              className="c3"
+                            >
+                              22%
+                            </th>
+                          </StyledComponent>
+                        </styled.td>
+                      </CellHeader>
+                      <CellHeader>
+                        <styled.td
+                          as="th"
+                          bold={true}
+                          isHeader={true}
+                        >
+                          <StyledComponent
+                            as="th"
+                            bold={true}
+                            forwardedComponent={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "attrs": Array [],
+                                "componentStyle": ComponentStyle {
+                                  "componentId": "sc-bxivhb",
+                                  "isStatic": false,
+                                  "lastClassName": "c5",
+                                  "rules": Array [
+                                    [Function],
+                                    [Function],
+                                    [Function],
+                                  ],
+                                },
+                                "displayName": "styled.td",
+                                "foldedComponentIds": Array [],
+                                "propTypes": Object {
+                                  "alignRight": [Function],
+                                  "children": [Function],
+                                  "isHeader": [Function],
+                                  "numeric": [Function],
+                                },
+                                "render": [Function],
+                                "styledComponentId": "sc-bxivhb",
+                                "target": "td",
+                                "toString": [Function],
+                                "warnTooManyClasses": [Function],
+                                "withComponent": [Function],
+                              }
+                            }
+                            forwardedRef={null}
+                            isHeader={true}
+                          >
+                            <th
+                              className="c4"
+                            >
+                              Normal
+                            </th>
+                          </StyledComponent>
+                        </styled.td>
+                      </CellHeader>
+                    </tr>
+                  </StyledComponent>
+                </styled.tr>
+              </thead>
+            </StyledComponent>
+          </styled.thead>
+          <styled.tbody>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-bwzfXH",
+                    "isStatic": true,
+                    "lastClassName": "uTxCW",
+                    "rules": Array [
+                      "",
+                    ],
+                  },
+                  "displayName": "styled.tbody",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-bwzfXH",
+                  "target": "tbody",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <tbody
+                className=""
+              >
+                <styled.tr>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "sc-ifAKCX",
+                          "isStatic": true,
+                          "lastClassName": "cFlEyZ",
+                          "rules": Array [
+                            "",
+                          ],
+                        },
+                        "displayName": "styled.tr",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "sc-ifAKCX",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className=""
+                    >
+                      <styled.td>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "sc-bxivhb",
+                                "isStatic": false,
+                                "lastClassName": "c5",
+                                "rules": Array [
+                                  [Function],
+                                  [Function],
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "styled.td",
+                              "foldedComponentIds": Array [],
+                              "propTypes": Object {
+                                "alignRight": [Function],
+                                "children": [Function],
+                                "isHeader": [Function],
+                                "numeric": [Function],
+                              },
+                              "render": [Function],
+                              "styledComponentId": "sc-bxivhb",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c5"
+                          >
+                            Column uses setWidth="one-half" in header
+                          </td>
+                        </StyledComponent>
+                      </styled.td>
+                      <styled.td>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "sc-bxivhb",
+                                "isStatic": false,
+                                "lastClassName": "c5",
+                                "rules": Array [
+                                  [Function],
+                                  [Function],
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "styled.td",
+                              "foldedComponentIds": Array [],
+                              "propTypes": Object {
+                                "alignRight": [Function],
+                                "children": [Function],
+                                "isHeader": [Function],
+                                "numeric": [Function],
+                              },
+                              "render": [Function],
+                              "styledComponentId": "sc-bxivhb",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c5"
+                          >
+                            setWidth="22%"
+                          </td>
+                        </StyledComponent>
+                      </styled.td>
+                      <styled.td>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "sc-bxivhb",
+                                "isStatic": false,
+                                "lastClassName": "c5",
+                                "rules": Array [
+                                  [Function],
+                                  [Function],
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "styled.td",
+                              "foldedComponentIds": Array [],
+                              "propTypes": Object {
+                                "alignRight": [Function],
+                                "children": [Function],
+                                "isHeader": [Function],
+                                "numeric": [Function],
+                              },
+                              "render": [Function],
+                              "styledComponentId": "sc-bxivhb",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c5"
+                          >
+                            Not specified
+                          </td>
+                        </StyledComponent>
+                      </styled.td>
+                    </tr>
+                  </StyledComponent>
+                </styled.tr>
+              </tbody>
+            </StyledComponent>
+          </styled.tbody>
+        </table>
+      </StyledComponent>
+    </styled.table>
+  </Table>
+</TableWithCustomWidths>
+`;
+
 exports[`Table renders a table with head and numerics matching snapshot: table with head and numerics 1`] = `
 .c1 {
   font-weight: 700;

--- a/components/table/src/__snapshots__/test.js.snap
+++ b/components/table/src/__snapshots__/test.js.snap
@@ -33,6 +33,7 @@ exports[`Table renders a simple example matching snapshot: simple table 1`] = `
   width: 100%;
   border-spacing: 0;
   border-collapse: collapse;
+  margin-bottom: 20px;
 }
 
 @media print {
@@ -52,6 +53,12 @@ exports[`Table renders a simple example matching snapshot: simple table 1`] = `
 @media print {
   .c0 {
     color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c0 {
+    margin-bottom: 30px;
   }
 }
 
@@ -173,6 +180,7 @@ exports[`Table renders a simple example matching snapshot: simple table 1`] = `
                                   "rules": Array [
                                     [Function],
                                     [Function],
+                                    [Function],
                                   ],
                                 },
                                 "displayName": "styled.td",
@@ -213,6 +221,7 @@ exports[`Table renders a simple example matching snapshot: simple table 1`] = `
                                 "isStatic": false,
                                 "lastClassName": "c2",
                                 "rules": Array [
+                                  [Function],
                                   [Function],
                                   [Function],
                                 ],
@@ -292,6 +301,7 @@ exports[`Table renders a simple example matching snapshot: simple table 1`] = `
                                   "isStatic": false,
                                   "lastClassName": "c2",
                                   "rules": Array [
+                                    [Function],
                                     [Function],
                                     [Function],
                                   ],
@@ -336,6 +346,7 @@ exports[`Table renders a simple example matching snapshot: simple table 1`] = `
                                 "rules": Array [
                                   [Function],
                                   [Function],
+                                  [Function],
                                 ],
                               },
                               "displayName": "styled.td",
@@ -415,6 +426,7 @@ exports[`Table renders a simple example matching snapshot: simple table 1`] = `
                                   "rules": Array [
                                     [Function],
                                     [Function],
+                                    [Function],
                                   ],
                                 },
                                 "displayName": "styled.td",
@@ -455,6 +467,7 @@ exports[`Table renders a simple example matching snapshot: simple table 1`] = `
                                 "isStatic": false,
                                 "lastClassName": "c2",
                                 "rules": Array [
+                                  [Function],
                                   [Function],
                                   [Function],
                                 ],
@@ -536,6 +549,7 @@ exports[`Table renders a simple example matching snapshot: simple table 1`] = `
                                   "rules": Array [
                                     [Function],
                                     [Function],
+                                    [Function],
                                   ],
                                 },
                                 "displayName": "styled.td",
@@ -576,6 +590,7 @@ exports[`Table renders a simple example matching snapshot: simple table 1`] = `
                                 "isStatic": false,
                                 "lastClassName": "c2",
                                 "rules": Array [
+                                  [Function],
                                   [Function],
                                   [Function],
                                 ],
@@ -657,6 +672,7 @@ exports[`Table renders a table with a caption matching snapshot: table with capt
   width: 100%;
   border-spacing: 0;
   border-collapse: collapse;
+  margin-bottom: 20px;
 }
 
 @media print {
@@ -676,6 +692,12 @@ exports[`Table renders a table with a caption matching snapshot: table with capt
 @media print {
   .c0 {
     color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c0 {
+    margin-bottom: 30px;
   }
 }
 
@@ -860,6 +882,7 @@ exports[`Table renders a table with a caption matching snapshot: table with capt
                                   "rules": Array [
                                     [Function],
                                     [Function],
+                                    [Function],
                                   ],
                                 },
                                 "displayName": "styled.td",
@@ -900,6 +923,7 @@ exports[`Table renders a table with a caption matching snapshot: table with capt
                                 "isStatic": false,
                                 "lastClassName": "c3",
                                 "rules": Array [
+                                  [Function],
                                   [Function],
                                   [Function],
                                 ],
@@ -979,6 +1003,7 @@ exports[`Table renders a table with a caption matching snapshot: table with capt
                                   "isStatic": false,
                                   "lastClassName": "c3",
                                   "rules": Array [
+                                    [Function],
                                     [Function],
                                     [Function],
                                   ],
@@ -1023,6 +1048,7 @@ exports[`Table renders a table with a caption matching snapshot: table with capt
                                 "rules": Array [
                                   [Function],
                                   [Function],
+                                  [Function],
                                 ],
                               },
                               "displayName": "styled.td",
@@ -1102,6 +1128,7 @@ exports[`Table renders a table with a caption matching snapshot: table with capt
                                   "rules": Array [
                                     [Function],
                                     [Function],
+                                    [Function],
                                   ],
                                 },
                                 "displayName": "styled.td",
@@ -1142,6 +1169,7 @@ exports[`Table renders a table with a caption matching snapshot: table with capt
                                 "isStatic": false,
                                 "lastClassName": "c3",
                                 "rules": Array [
+                                  [Function],
                                   [Function],
                                   [Function],
                                 ],
@@ -1238,6 +1266,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
   width: 100%;
   border-spacing: 0;
   border-collapse: collapse;
+  margin-bottom: 20px;
 }
 
 @media print {
@@ -1263,6 +1292,12 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
 @media print {
   .c0 {
     color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c0 {
+    margin-bottom: 30px;
   }
 }
 
@@ -1436,6 +1471,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                   "rules": Array [
                                     [Function],
                                     [Function],
+                                    [Function],
                                   ],
                                 },
                                 "displayName": "styled.td",
@@ -1486,6 +1522,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                   "isStatic": false,
                                   "lastClassName": "c4",
                                   "rules": Array [
+                                    [Function],
                                     [Function],
                                     [Function],
                                   ],
@@ -1539,6 +1576,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                   "isStatic": false,
                                   "lastClassName": "c4",
                                   "rules": Array [
+                                    [Function],
                                     [Function],
                                     [Function],
                                   ],
@@ -1655,6 +1693,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                   "rules": Array [
                                     [Function],
                                     [Function],
+                                    [Function],
                                   ],
                                 },
                                 "displayName": "styled.td",
@@ -1699,6 +1738,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                 "rules": Array [
                                   [Function],
                                   [Function],
+                                  [Function],
                                 ],
                               },
                               "displayName": "styled.td",
@@ -1740,6 +1780,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                 "isStatic": false,
                                 "lastClassName": "c4",
                                 "rules": Array [
+                                  [Function],
                                   [Function],
                                   [Function],
                                 ],
@@ -1820,6 +1861,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                   "isStatic": false,
                                   "lastClassName": "c4",
                                   "rules": Array [
+                                    [Function],
                                     [Function],
                                     [Function],
                                   ],
@@ -1866,6 +1908,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                 "rules": Array [
                                   [Function],
                                   [Function],
+                                  [Function],
                                 ],
                               },
                               "displayName": "styled.td",
@@ -1907,6 +1950,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                 "isStatic": false,
                                 "lastClassName": "c4",
                                 "rules": Array [
+                                  [Function],
                                   [Function],
                                   [Function],
                                 ],
@@ -1989,6 +2033,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                   "rules": Array [
                                     [Function],
                                     [Function],
+                                    [Function],
                                   ],
                                 },
                                 "displayName": "styled.td",
@@ -2033,6 +2078,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                 "rules": Array [
                                   [Function],
                                   [Function],
+                                  [Function],
                                 ],
                               },
                               "displayName": "styled.td",
@@ -2074,6 +2120,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                 "isStatic": false,
                                 "lastClassName": "c4",
                                 "rules": Array [
+                                  [Function],
                                   [Function],
                                   [Function],
                                 ],
@@ -2156,6 +2203,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                   "rules": Array [
                                     [Function],
                                     [Function],
+                                    [Function],
                                   ],
                                 },
                                 "displayName": "styled.td",
@@ -2200,6 +2248,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                 "rules": Array [
                                   [Function],
                                   [Function],
+                                  [Function],
                                 ],
                               },
                               "displayName": "styled.td",
@@ -2241,6 +2290,7 @@ exports[`Table renders a table with head and numerics matching snapshot: table w
                                 "isStatic": false,
                                 "lastClassName": "c4",
                                 "rules": Array [
+                                  [Function],
                                   [Function],
                                   [Function],
                                 ],

--- a/components/table/src/atoms/Cell/index.js
+++ b/components/table/src/atoms/Cell/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { BORDER_COLOUR } from 'govuk-colours';
 import { FONT_WEIGHTS, SPACING_POINTS } from '@govuk-react/constants';
-import { typography } from '@govuk-react/lib';
+import { spacing, typography } from '@govuk-react/lib';
 
 const Cell = styled('td')(
   ({
@@ -23,6 +23,7 @@ const Cell = styled('td')(
   ({ numeric, isHeader }) => (
     (numeric && !isHeader) ? typography.font({ tabular: true }) : undefined
   ),
+  spacing.withWidth(),
 );
 
 Cell.propTypes = {

--- a/components/table/src/fixtures.js
+++ b/components/table/src/fixtures.js
@@ -105,11 +105,31 @@ const TableWithCustomHeader = () => (
   </Table>
 );
 
+const TableWithCustomWidths = () => (
+  <Table
+    caption="Custom widths"
+    head={
+      <Table.Row>
+        <Table.CellHeader setWidth="one-half">one-half</Table.CellHeader>
+        <Table.CellHeader setWidth="22%">22%</Table.CellHeader>
+        <Table.CellHeader>Normal</Table.CellHeader>
+      </Table.Row>
+    }
+  >
+    <Table.Row>
+      <Table.Cell>Column uses setWidth=&quot;one-half&quot; in header</Table.Cell>
+      <Table.Cell>setWidth=&quot;22%&quot;</Table.Cell>
+      <Table.Cell>Not specified</Table.Cell>
+    </Table.Row>
+  </Table>
+);
+
 export {
   TableSimple,
   TableWithCaption,
   TableWithHeadAndNumerics,
   TableWithCustomHeader,
+  TableWithCustomWidths,
 };
 
 export default Table;

--- a/components/table/src/fixtures.js
+++ b/components/table/src/fixtures.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from 'styled-components';
 
 import Table from '.';
 
@@ -82,25 +81,19 @@ const TableWithHeadAndNumerics = () => (
   </Table>
 );
 
-const CustomHeader = styled(Table.CellHeader)({
-  width: '50%',
-});
-
-const TableWithCustomHeader = () => (
+const TableThreeQuartersOneQuarter = () => (
   <Table
-    caption="Custom header"
+    caption="Three quarters, one quarter"
     head={
       <Table.Row>
-        <CustomHeader>Wide header</CustomHeader>
-        <Table.CellHeader>Regular</Table.CellHeader>
-        <Table.CellHeader>Normal</Table.CellHeader>
+        <Table.CellHeader setWidth="three-quarters">three-quarters</Table.CellHeader>
+        <Table.CellHeader setWidth="one-quarter">one-quarter</Table.CellHeader>
       </Table.Row>
     }
   >
     <Table.Row>
-      <Table.Cell>Custom header provides a wide column here</Table.Cell>
-      <Table.Cell>Some value</Table.Cell>
-      <Table.Cell>Another</Table.Cell>
+      <Table.Cell>Column uses setWidth=&quot;three-quarters&quot; in header</Table.Cell>
+      <Table.Cell>setWidth=&quot;one-quarter&quot;</Table.Cell>
     </Table.Row>
   </Table>
 );
@@ -128,8 +121,8 @@ export {
   TableSimple,
   TableWithCaption,
   TableWithHeadAndNumerics,
-  TableWithCustomHeader,
   TableWithCustomWidths,
+  TableThreeQuartersOneQuarter,
 };
 
 export default Table;

--- a/components/table/src/index.js
+++ b/components/table/src/index.js
@@ -21,7 +21,7 @@ const StyledTable = styled('table')(
     borderSpacing: 0,
     borderCollapse: 'collapse',
   },
-  spacing.withWhiteSpace({ mb: 6 }),
+  spacing.withWhiteSpace({ marginBottom: 6 }),
 );
 
 /**
@@ -89,32 +89,21 @@ const StyledTable = styled('table')(
  * </Table>
  * ```
  *
- * NB The govuk-frontend table component describes a way of setting custom column widths
- * via width override classes. Currently govuk-react does not provide a direct equivalent of this
- * functionality out of the box, however if this behaviour is desired then custom widths
- * can be set by re-styling a component.
- *
- * For example;
+ * Setting custom column widths
  * ```jsx
- * import styled from 'styled-components';
- *
- * const CustomHeader = styled(Table.CellHeader)({
- *   width: '50%',
- * });
- *
  * <Table
  *   caption="Custom header"
  *   head={
  *     <Table.Row>
- *       <CustomHeader>Wide header</CustomHeader>
- *       <Table.CellHeader>Regular</Table.CellHeader>
+ *       <Table.CellHeader setWidth="one-half>Wide header</Table.CellHeader>
+ *       <Table.CellHeader setWidth="30%">Regular</Table.CellHeader>
  *       <Table.CellHeader>Normal</Table.CellHeader>
  *     </Table.Row>
  *   }
  * >
  *   <Table.Row>
- *     <Table.Cell>Custom header provides a wide column here</Table.Cell>
- *     <Table.Cell>Some value</Table.Cell>
+ *     <Table.Cell>Header makes this column one-half wide</Table.Cell>
+ *     <Table.Cell>And this one 30%</Table.Cell>
  *     <Table.Cell>Another</Table.Cell>
  *   </Table.Row>
  * </Table>

--- a/components/table/src/stories.js
+++ b/components/table/src/stories.js
@@ -7,6 +7,7 @@ import {
   TableWithCaption,
   TableWithCustomHeader,
   TableWithHeadAndNumerics,
+  TableWithCustomWidths,
 } from './fixtures';
 import ReadMe from '../README.md';
 
@@ -29,4 +30,8 @@ examples.add('With a custom header element', () => (
 
 examples.add('With a head row and numeric tabular data', () => (
   <TableWithHeadAndNumerics />
+));
+
+examples.add('With a custom column widths', () => (
+  <TableWithCustomWidths />
 ));

--- a/components/table/src/stories.js
+++ b/components/table/src/stories.js
@@ -5,9 +5,9 @@ import { WithDocsCustom } from '@govuk-react/storybook-components';
 import {
   TableSimple,
   TableWithCaption,
-  TableWithCustomHeader,
   TableWithHeadAndNumerics,
   TableWithCustomWidths,
+  TableThreeQuartersOneQuarter,
 } from './fixtures';
 import ReadMe from '../README.md';
 
@@ -24,14 +24,14 @@ examples.add('With a caption', () => (
   <TableWithCaption />
 ));
 
-examples.add('With a custom header element', () => (
-  <TableWithCustomHeader />
-));
-
 examples.add('With a head row and numeric tabular data', () => (
   <TableWithHeadAndNumerics />
 ));
 
-examples.add('With a custom column widths', () => (
+examples.add('With a three quarter-width column and one quarter', () => (
+  <TableThreeQuartersOneQuarter />
+));
+
+examples.add('With custom column widths', () => (
   <TableWithCustomWidths />
 ));

--- a/components/table/src/test.js
+++ b/components/table/src/test.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import Table, { TableSimple, TableWithCaption, TableWithHeadAndNumerics } from './fixtures';
+import Table, {
+  TableSimple,
+  TableWithCaption,
+  TableWithHeadAndNumerics,
+  TableWithCustomWidths,
+} from './fixtures';
 
 describe('Table', () => {
   it('renders without crashing', () => {
@@ -14,6 +19,10 @@ describe('Table', () => {
 
   it('renders a table with a caption matching snapshot', () => {
     expect(mount(<TableWithCaption />)).toMatchSnapshot('table with caption');
+  });
+
+  it('renders a table with custom widths matching snapshot', () => {
+    expect(mount(<TableWithCustomWidths />)).toMatchSnapshot('table with custom widths');
   });
 
   it('renders a table with head and numerics matching snapshot', () => {

--- a/packages/constants/src/index.js
+++ b/packages/constants/src/index.js
@@ -44,6 +44,7 @@ export const MEDIA_QUERIES = {
   MAX: `@media only screen and (min-width: ${SITE_WIDTH_PLUS_GUTTERS})`,
   PRINT: '@media print',
   TABLET: `@media only screen and (min-width: ${BREAKPOINTS.TABLET})`,
+  DESKTOP: `@media only screen and (min-width: ${BREAKPOINTS.DESKTOP})`,
 };
 
 // TODO: figure out how to optionally include locally installed font, e.g. "GDS Transport Website"

--- a/packages/constants/src/spacing.js
+++ b/packages/constants/src/spacing.js
@@ -77,3 +77,12 @@ export const SPACING_POINTS = {
   8: 50,
   9: 60,
 };
+
+export const WIDTHS = {
+  'one-quarter': '25%',
+  'one-third': '33.3333%',
+  'one-half': '50%',
+  'two-thirds': '66.6666%',
+  'three-quarters': '75%',
+  full: '100%',
+};

--- a/packages/constants/src/spacing.js
+++ b/packages/constants/src/spacing.js
@@ -78,6 +78,7 @@ export const SPACING_POINTS = {
   9: 60,
 };
 
+// Ref: https://github.com/alphagov/govuk-frontend/blob/68bd09bb3e54b7ef4b4084ad2b3336858923a041/src/settings/_measurements.scss#L23
 export const WIDTHS = {
   'one-quarter': '25%',
   'one-third': '33.3333%',

--- a/packages/lib/src/spacing/index.js
+++ b/packages/lib/src/spacing/index.js
@@ -11,6 +11,7 @@ import {
   SPACING_MAP,
   SPACING_MAP_INDEX,
   SPACING_POINTS,
+  WIDTHS,
 } from '@govuk-react/constants';
 
 export function simple(size) {
@@ -159,3 +160,22 @@ withWhiteSpace.propTypes = {
     PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, SpacingShape])),
   ]),
 };
+
+export function withWidth(config = {}) {
+  return ({
+    setWidth = config.width,
+  } = {}) => {
+    if (setWidth) {
+      const width = WIDTHS[setWidth] || setWidth;
+
+      return {
+        width: '100%',
+        [MEDIA_QUERIES.TABLET]: {
+          width,
+        },
+      };
+    }
+
+    return undefined;
+  };
+}

--- a/packages/lib/src/spacing/index.js
+++ b/packages/lib/src/spacing/index.js
@@ -167,10 +167,11 @@ export function withWidth(config = {}) {
   } = {}) => {
     if (setWidth) {
       const width = WIDTHS[setWidth] || setWidth;
+      const { mediaQuery = MEDIA_QUERIES.TABLET, noDefault } = config;
 
       return {
-        width: '100%',
-        [MEDIA_QUERIES.TABLET]: {
+        width: noDefault ? undefined : '100%',
+        [mediaQuery]: {
           width,
         },
       };

--- a/packages/lib/src/spacing/test.js
+++ b/packages/lib/src/spacing/test.js
@@ -293,5 +293,25 @@ describe('spacing lib', () => {
         }));
       });
     });
+
+    it('accepts a noDefault config which removes default 100% width', () => {
+      const widthFunc = spacing.withWidth({ noDefault: true });
+
+      ['95%', '200px'].forEach((setWidth) => {
+        const widthStyle = widthFunc({ setWidth });
+
+        expect(widthStyle).not.toEqual(expect.objectContaining({
+          width: '100%',
+        }));
+      });
+
+      Object.values(WIDTHS).forEach((setWidth) => {
+        const widthStyle = widthFunc({ setWidth });
+
+        expect(widthStyle).not.toEqual(expect.objectContaining({
+          width: '100%',
+        }));
+      });
+    });
   });
 });

--- a/packages/lib/src/spacing/test.js
+++ b/packages/lib/src/spacing/test.js
@@ -3,6 +3,7 @@ import {
   SPACING_MAP,
   SPACING_MAP_INDEX,
   SPACING_POINTS,
+  WIDTHS,
 } from '@govuk-react/constants';
 
 import * as spacing from '.';
@@ -215,6 +216,81 @@ describe('spacing lib', () => {
         expect(result).toEqual(expect.arrayContaining([
           expect.objectContaining({ 'padding-top': SPACING_MAP[3].mobile }),
         ]));
+      });
+    });
+  });
+
+  describe('withWidth', () => {
+    it('generates an executable styling function with no config', () => {
+      const widthFunc = spacing.withWidth();
+
+      expect(() => widthFunc()).not.toThrow();
+    });
+
+    it('creates no style when config/prop not provided', () => {
+      const widthFunc = spacing.withWidth();
+
+      expect(widthFunc()).toBeUndefined();
+    });
+
+    it('accepts a width config value of a size string', () => {
+      Object.entries(WIDTHS).forEach(([width, value]) => {
+        const widthFunc = spacing.withWidth({ width });
+        const widthStyle = widthFunc();
+
+        expect(widthStyle).toEqual(expect.objectContaining({
+          width: '100%',
+          [MEDIA_QUERIES.TABLET]: { width: value },
+        }));
+      });
+    });
+
+    it('accepts a setWidth prop', () => {
+      const widthFunc = spacing.withWidth();
+
+      ['95%', '200px'].forEach((setWidth) => {
+        const widthStyle = widthFunc({ setWidth });
+
+        expect(widthStyle).toEqual(expect.objectContaining({
+          width: '100%',
+          [MEDIA_QUERIES.TABLET]: { width: setWidth },
+        }));
+      });
+
+      Object.entries(WIDTHS).forEach(([setWidth, value]) => {
+        const widthStyle = widthFunc({ setWidth });
+
+        expect(widthStyle).toEqual(expect.objectContaining({
+          width: '100%',
+          [MEDIA_QUERIES.TABLET]: { width: value },
+        }));
+      });
+    });
+
+    it('accepts a setWidth prop to override a width config', () => {
+      const widthFunc = spacing.withWidth({ width: Object.keys(WIDTHS)[0] });
+
+      expect(widthFunc()).toEqual(expect.objectContaining({
+        width: '100%',
+        [MEDIA_QUERIES.TABLET]: { width: Object.values(WIDTHS)[0] },
+      }));
+
+      ['95%', '200px'].forEach((setWidth) => {
+        const widthStyle = widthFunc({ setWidth });
+
+        expect(widthStyle).toEqual(expect.objectContaining({
+          width: '100%',
+          [MEDIA_QUERIES.TABLET]: { width: setWidth },
+        }));
+      });
+
+      Object.entries(WIDTHS).forEach(([setWidth, value]) => {
+        const widthStyle = widthFunc({ setWidth });
+
+        expect(widthStyle).toEqual(expect.objectContaining({
+          width: '100%',
+          [MEDIA_QUERIES.TABLET]: { width: value },
+        }));
       });
     });
   });


### PR DESCRIPTION
* `WIDTHS` constant object added
* `withWidth` added to spacing lib
  - produces a responsive width style
    - 100% width, with specified width for tablet or greater
    - no style if no config/prop provided
  - accepts a `width` config value
  - accepts a `setWidth` prop
  - config/prop accepts key from `WIDTHS` config, or any value
  - config also supports `mediaQuery` (to pick a different query) and `noDefault` (to omit 100% width)
* `Table.Cell` now uses `withWidth`
  - `Table` examples and docs updated to demo use
* `GridCol` updated
  - `columnThreeQuarters` and `columnFull` added
  - `column*` props however now deprecated in favour of...
  - `setWidth` prop, provided with the aid of `spacing.withWidth`
  - `setDesktopWidth` prop allows desktop breakpoints for column widths

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
