### PR TITLE
Add Heading component to replace header

### DIFF
--- a/API.md
+++ b/API.md
@@ -641,15 +641,37 @@ Header
 
 ### Usage
 
+This component is DEPRECATED.
+
+Please use the Heading component instead.
+
+### Properties
+Prop | Required | Default | Type | Description
+:--- | :------- | :------ | :--- | :----------
+ `level` |  | ```1``` | number | Semantic heading level value between 1 and 6
+ `size` |  | ```undefined``` | enum(...Object.keys(HEADING_SIZES) \| ...Object.keys(TYPOGRAPHY_SCALE)) | Visual size level, accepts:<br/>   `XLARGE`, `LARGE`, `MEDIUM`, `SMALL`, `XL`, `L`, `M`, `S`<br/>   or a numeric size that fits in the GDS font scale list
+
+
+Heading
+=======
+
+### Import
+```js
+  import Heading from '@govuk-react/heading';
+```
+<!-- STORY -->
+
+### Usage
+
 
 Simple
 ```jsx
-<Header level={1}>Heading text</Header>
+<Heading level={1}>Heading text</Heading>
 ```
 
 Using shortcuts
 ```jsx
-import { H1, H2, H3, H4, H5, H6 } from "@govuk-react/header";
+import { H1, H2, H3, H4, H5, H6 } from "@govuk-react/heading";
 
 <H1>h1</H1>
 <H2>h2</H2>
@@ -661,18 +683,18 @@ import { H1, H2, H3, H4, H5, H6 } from "@govuk-react/header";
 
 Differing sizes
 ```jsx
-<Header level={6} size={80}>
+<Heading level={6} size={80}>
   h6 with font size 80
-</Header>
-<Header level={2} size="SMALL">
+</Heading>
+<Heading level={2} size="SMALL">
   h2 with SMALL size
-</Header>
+</Heading>
 <H3 size="LARGE">h3 with LARGE size</H3>
 ```
 
 Props pass through
 ```jsx
-<Header onClick={() => { console.log('clicked'); }}>Click me</Header>
+<Heading onClick={() => { console.log('clicked'); }}>Click me</Heading>
 ```
 
 ### References:

--- a/API.md
+++ b/API.md
@@ -137,7 +137,7 @@ Simple
 
 With another header
 ```jsx
-import { H1 } from '@govuk-react/header';
+import { H1 } from '@govuk-react/heading';
 
 <Caption size="XL">Supporting header text</Caption>
 <H1>Main header text</H1>

--- a/API.md
+++ b/API.md
@@ -1574,13 +1574,13 @@ RelatedItems
 
 Simple
 ```jsx
-import Header from '@govuk-react/header';
+import Heading from '@govuk-react/heading';
 import UnorderedList from '@govuk-react/unordered-list';
 import Link from '@govuk-react/link';
 import ListItem from '@govuk-react/list-item';
 
 <RelatedItems>
-  <Header level={3}>Example header</Header>
+  <Heading level={3}>Example heading</Heading>
   <UnorderedList listStyleType="none">
     <ListItem>
       <Link href="https://example.com">Link A</Link>
@@ -1767,7 +1767,7 @@ Simple
 
 With another header
 ```jsx
-import { H1 } from '@govuk-react/header';
+import { H1 } from '@govuk-react/heading';
 
 <SupportingHeader>Supporting header text</SupportingHeader>
 <H1>Main header text</H1>

--- a/components/caption/README.md
+++ b/components/caption/README.md
@@ -16,7 +16,7 @@ Simple
 
 With another header
 ```jsx
-import { H1 } from '@govuk-react/header';
+import { H1 } from '@govuk-react/heading';
 
 <Caption size="XL">Supporting header text</Caption>
 <H1>Main header text</H1>

--- a/components/caption/src/__snapshots__/test.js.snap
+++ b/components/caption/src/__snapshots__/test.js.snap
@@ -9,6 +9,7 @@ exports[`Caption matches wrapper snapshot 1`] = `
   font-size: 18px;
   line-height: 1.1111111111111112;
   margin-bottom: 5px;
+  display: block;
   color: #6f777b;
 }
 
@@ -44,7 +45,7 @@ exports[`Caption matches wrapper snapshot 1`] = `
             "rules": Array [
               [Function],
               [Function],
-              "color: #6f777b;",
+              "display: block; color: #6f777b;",
               [Function],
             ],
           },

--- a/components/caption/src/index.js
+++ b/components/caption/src/index.js
@@ -29,6 +29,7 @@ const StyledCaption = styled('span')(
     };
   },
   {
+    display: 'block',
     color: SECONDARY_TEXT_COLOUR,
   },
   spacing.withWhiteSpace(),
@@ -45,7 +46,7 @@ const StyledCaption = styled('span')(
  *
  * With another header
  * ```jsx
- * import { H1 } from '@govuk-react/header';
+ * import { H1 } from '@govuk-react/heading';
  *
  * <Caption size="XL">Supporting header text</Caption>
  * <H1>Main header text</H1>

--- a/components/caption/src/stories.js
+++ b/components/caption/src/stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { text, withKnobs } from '@storybook/addon-knobs/react';
 import { WithDocsCustom } from '@govuk-react/storybook-components';
 
-import Header from '@govuk-react/header';
+import Heading from '@govuk-react/heading';
 
 import Caption, { CaptionWithKnobs } from './fixtures';
 import ReadMe from '../README.md';
@@ -21,18 +21,27 @@ stories.add('Component default', () => (
 
 examples.add('Placed with a heading component', () => (
   <div>
-    <Caption size={text('size', 'XL')}>{text('children', 'Supporting header text')}</Caption>
-    <Header size={text('header size', 'XL')}>{text('children', 'Main header text')}</Header>
+    <Caption size={text('size', 'XL')}>{text('children', 'Supporting heading text')}</Caption>
+    <Heading size={text('heading size', 'XL')}>{text('heading', 'Main heading text')}</Heading>
+  </div>
+));
+
+examples.add('Placed inside a heading component', () => (
+  <div>
+    <Heading size={text('heading size', 'XL')}>
+      <Caption size={text('size', 'XL')}>{text('children', 'Supporting heading text')}</Caption>
+      {text('heading', 'Main heading text')}
+    </Heading>
   </div>
 ));
 
 examples.add('Showing all standard caption sizes, with headings', () => (
   <div>
-    <Caption size="XL">Supporting header size XL</Caption>
-    <Header size="XL">Main header size XL</Header>
-    <Caption size="L">Supporting header size L</Caption>
-    <Header size="L">Main header size L</Header>
-    <Caption size="M">Supporting header size M</Caption>
-    <Header size="M">Main header size M</Header>
+    <Caption size="XL">Supporting heading size XL</Caption>
+    <Heading size="XL">Main heading size XL</Heading>
+    <Caption size="L">Supporting heading size L</Caption>
+    <Heading size="L">Main heading size L</Heading>
+    <Caption size="M">Supporting heading size M</Caption>
+    <Heading size="M">Main heading size M</Heading>
   </div>
 ));

--- a/components/error-summary/package.json
+++ b/components/error-summary/package.json
@@ -3,7 +3,7 @@
   "version": "0.6.0-alpha.4",
   "dependencies": {
     "@govuk-react/constants": "^0.6.0-alpha.4",
-    "@govuk-react/header": "^0.6.0-alpha.4",
+    "@govuk-react/heading": "^0.6.0-alpha.4",
     "@govuk-react/input-field": "^0.6.0-alpha.4",
     "@govuk-react/lib": "^0.6.0-alpha.4",
     "@govuk-react/link": "^0.6.0-alpha.4",

--- a/components/error-summary/src/__snapshots__/test.js.snap
+++ b/components/error-summary/src/__snapshots__/test.js.snap
@@ -508,7 +508,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
             className="c0"
             tabIndex={-1}
           >
-            <Header
+            <Heading
               level={2}
             >
               <Styled(Component)
@@ -559,7 +559,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
                   </Component>
                 </StyledComponent>
               </Styled(Component)>
-            </Header>
+            </Heading>
             <Paragraph
               linkRenderer={[Function]}
               mb={3}

--- a/components/error-summary/src/index.js
+++ b/components/error-summary/src/index.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { TEXT_COLOUR, ERROR_COLOUR, FOCUS_COLOUR } from 'govuk-colours';
 
-import Header from '@govuk-react/header';
+import Heading from '@govuk-react/heading';
 import Paragraph from '@govuk-react/paragraph';
 import UnorderedList from '@govuk-react/unordered-list';
 import Link from '@govuk-react/link';
@@ -118,7 +118,7 @@ const ErrorSummary = ({
   onHandleErrorClick, heading, description, errors, ...props
 }) => (
   <StyledErrorSummary tabIndex={-1} {...props}>
-    <Header level={2}>{ heading }</Header>
+    <Heading level={2}>{ heading }</Heading>
     { description && <Paragraph mb={3}>{ description }</Paragraph> }
     { errors.length > 0 &&
       <UnorderedList mb={0} listStyleType="none">

--- a/components/error-summary/src/test.js
+++ b/components/error-summary/src/test.js
@@ -18,7 +18,7 @@ describe('error summary', () => {
   // Some tests have been disabled
 
   it.skip('should render the ErrorSummary component', () => {
-    expect(wrapperErrorSummary.find('Header').exists()).toBe(true);
+    expect(wrapperErrorSummary.find('Heading').exists()).toBe(true);
     expect(wrapperErrorSummary.find('Paragraph').exists()).toBe(true);
     // NB This fails with latest UnorderedList, and is testing implement
     expect(wrapperErrorSummary.find('UnorderedList').exists()).toBe(true);
@@ -27,7 +27,7 @@ describe('error summary', () => {
   });
 
   it('should render the heading', () => {
-    expect(wrapperErrorSummary.find('Header').text()).toEqual(heading);
+    expect(wrapperErrorSummary.find('Heading').text()).toEqual(heading);
   });
 
   it('should render the optional description', () => {

--- a/components/grid-col/src/stories.js
+++ b/components/grid-col/src/stories.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react';
 import { WithDocsCustom } from '@govuk-react/storybook-components';
 
 import GridRow from '@govuk-react/grid-row';
-import { H2 } from '@govuk-react/header';
+import { H2 } from '@govuk-react/heading';
 import Paragraph from '@govuk-react/paragraph';
 
 import GridCol from '.';

--- a/components/header/README.md
+++ b/components/header/README.md
@@ -9,44 +9,9 @@ Header
 
 ### Usage
 
+This component is DEPRECATED.
 
-Simple
-```jsx
-<Header level={1}>Heading text</Header>
-```
-
-Using shortcuts
-```jsx
-import { H1, H2, H3, H4, H5, H6 } from "@govuk-react/header";
-
-<H1>h1</H1>
-<H2>h2</H2>
-<H3>h3</H3>
-<H4>h4</H4>
-<H5>h5</H5>
-<H6>h6</H6>
-```
-
-Differing sizes
-```jsx
-<Header level={6} size={80}>
-  h6 with font size 80
-</Header>
-<Header level={2} size="SMALL">
-  h2 with SMALL size
-</Header>
-<H3 size="LARGE">h3 with LARGE size</H3>
-```
-
-Props pass through
-```jsx
-<Header onClick={() => { console.log('clicked'); }}>Click me</Header>
-```
-
-### References:
-- https://design-system.service.gov.uk/styles/typography/#headings
-- https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_typography.scss
-- https://github.com/alphagov/govuk-frontend/blob/master/src/core/_typography.scss
+Please use the Heading component instead.
 
 ### Properties
 Prop | Required | Default | Type | Description

--- a/components/header/src/stories.js
+++ b/components/header/src/stories.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 import { withKnobs, text, number } from '@storybook/addon-knobs/react';
 import { WithDocsCustom } from '@govuk-react/storybook-components';
 
-import Header, { H1, H2, H3, H4, H5, H6 } from '.';
+import Header from '.';
 import ReadMe from '../README.md';
 
 const stories = storiesOf('Typography/Header', module);
-const examples = storiesOf('Typography/Header/Examples', module);
 const headingRanges = {
   range: true,
   min: 1,
@@ -20,40 +18,3 @@ stories.addDecorator(withKnobs);
 stories.addDecorator(WithDocsCustom(ReadMe));
 
 stories.add('Component default', () => (<Header level={number('level', 2, headingRanges)}>{text('Children', 'Heading text')}</Header>));
-
-examples.add('Levels 1-6', () => (
-  <div>
-    <Header level={1}>A 48px Bold heading</Header>
-    <Header level={2}>A 36px Bold heading</Header>
-    <Header level={3}>A 24px Bold heading</Header>
-    <Header level={4}>A 19px Bold heading</Header>
-    <Header level={5}>h5</Header>
-    <Header level={6}>h6</Header>
-  </div>
-));
-examples.add('Shortcuts 1-6', () => (
-  <div>
-    <H1>h1</H1>
-    <H2>h2</H2>
-    <H3>h3</H3>
-    <H4>h4</H4>
-    <H5>h5</H5>
-    <H6>h6</H6>
-  </div>
-));
-examples.add('Differing sizes', () => (
-  <div>
-    <Header level={6} size={80}>
-      h6 with XXLARGE style
-    </Header>
-    <Header level={2} size={16}>
-      h2 with XSMALL style
-    </Header>
-    <H3 size="LARGE">h3 with size large</H3>
-  </div>
-));
-examples.add('Props pass through', () => (
-  <div>
-    <Header onClick={action('header-click')}>Click me</Header>
-  </div>
-));

--- a/components/heading/README.md
+++ b/components/heading/README.md
@@ -1,0 +1,57 @@
+Heading
+=======
+
+### Import
+```js
+  import Heading from '@govuk-react/heading';
+```
+<!-- STORY -->
+
+### Usage
+
+
+Simple
+```jsx
+<Heading level={1}>Heading text</Heading>
+```
+
+Using shortcuts
+```jsx
+import { H1, H2, H3, H4, H5, H6 } from "@govuk-react/heading";
+
+<H1>h1</H1>
+<H2>h2</H2>
+<H3>h3</H3>
+<H4>h4</H4>
+<H5>h5</H5>
+<H6>h6</H6>
+```
+
+Differing sizes
+```jsx
+<Heading level={6} size={80}>
+  h6 with font size 80
+</Heading>
+<Heading level={2} size="SMALL">
+  h2 with SMALL size
+</Heading>
+<H3 size="LARGE">h3 with LARGE size</H3>
+```
+
+Props pass through
+```jsx
+<Heading onClick={() => { console.log('clicked'); }}>Click me</Heading>
+```
+
+### References:
+- https://design-system.service.gov.uk/styles/typography/#headings
+- https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_typography.scss
+- https://github.com/alphagov/govuk-frontend/blob/master/src/core/_typography.scss
+
+### Properties
+Prop | Required | Default | Type | Description
+:--- | :------- | :------ | :--- | :----------
+ `level` |  | ```1``` | number | Semantic heading level value between 1 and 6
+ `size` |  | ```undefined``` | enum(...Object.keys(HEADING_SIZES) \| ...Object.keys(TYPOGRAPHY_SCALE)) | Visual size level, accepts:<br/>   `XLARGE`, `LARGE`, `MEDIUM`, `SMALL`, `XL`, `L`, `M`, `S`<br/>   or a numeric size that fits in the GDS font scale list
+
+

--- a/components/heading/package.json
+++ b/components/heading/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@govuk-react/heading",
+  "version": "0.6.0-alpha.4",
+  "dependencies": {
+    "@govuk-react/constants": "^0.6.0-alpha.4",
+    "@govuk-react/lib": "^0.6.0-alpha.4"
+  },
+  "peerDependencies": {
+    "react": ">=16.2.0",
+    "styled-components": ">=4"
+  },
+  "scripts": {
+    "build": "yarn build:lib && yarn build:es",
+    "build:lib": "rimraf lib && babel src -d lib --source-maps --config-file ../../babel.config.js",
+    "build:es": "rimraf es && cross-env BABEL_ENV=es babel src -d es --source-maps --config-file ../../babel.config.js",
+    "docs": "doc-component ./lib/index.js ./README.md"
+  },
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "author": "Alasdair McLeay",
+  "license": "MIT",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/heading",
+  "description": "Outputs a styled heading tag of provided level, rendering children as contents.",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/heading/src/__snapshots__/test.js.snap
+++ b/components/heading/src/__snapshots__/test.js.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Heading matches wrapper snapshot: wrapper mount 1`] = `
+.c0 {
+  color: #0b0c0c;
+  font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 32px;
+  line-height: 1.09375;
+  display: block;
+  margin-top: 0;
+  margin-bottom: 30px;
+}
+
+@media print {
+  .c0 {
+    color: #000;
+  }
+}
+
+@media print {
+  .c0 {
+    font-size: 32px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c0 {
+    font-size: 48px;
+    line-height: 1.0416666666666667;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c0 {
+    margin-bottom: 50px;
+  }
+}
+
+<Heading
+  level={1}
+>
+  <Styled(Component)
+    level={1}
+  >
+    <StyledComponent
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "sc-bdVaJa",
+            "isStatic": false,
+            "lastClassName": "c0",
+            "rules": Array [
+              "color: #0b0c0c; @media print {
+  color: #000;
+}",
+              [Function],
+              "display: block; margin-top: 0;",
+              [Function],
+              [Function],
+            ],
+          },
+          "displayName": "Styled(Component)",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "sc-bdVaJa",
+          "target": [Function],
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+          Symbol(Symbol.hasInstance): [Function],
+        }
+      }
+      forwardedRef={null}
+      level={1}
+    >
+      <Component
+        className="c0"
+        level={1}
+      >
+        <h1
+          className="c0"
+        >
+          example
+        </h1>
+      </Component>
+    </StyledComponent>
+  </Styled(Component)>
+</Heading>
+`;

--- a/components/heading/src/index.js
+++ b/components/heading/src/index.js
@@ -14,7 +14,7 @@ import { spacing, typography } from '@govuk-react/lib';
 // so if `size` is a string, we find a numeric size based off `HEADING_SIZES`
 // but if `size` is a number we just send through that number
 
-const StyledHeader = styled(({
+const StyledHeading = styled(({
   level, children, size, ...props
 }) =>
   createElement(LEVEL_TAG[level], props, children))(
@@ -23,7 +23,7 @@ const StyledHeader = styled(({
     const actualSize = Number.isNaN(Number(size)) ? HEADING_SIZES[size] : size;
 
     if (!actualSize) {
-      throw Error(`Unknown size ${size} used for header.`);
+      throw Error(`Unknown size ${size} used for heading.`);
     }
 
     return Object.assign(
@@ -56,19 +56,53 @@ const StyledHeader = styled(({
  *
  * ### Usage
  *
- * This component is DEPRECATED.
  *
- * Please use the Heading component instead.
+ * Simple
+ * ```jsx
+ * <Heading level={1}>Heading text</Heading>
+ * ```
  *
+ * Using shortcuts
+ * ```jsx
+ * import { H1, H2, H3, H4, H5, H6 } from "@govuk-react/heading";
+ *
+ * <H1>h1</H1>
+ * <H2>h2</H2>
+ * <H3>h3</H3>
+ * <H4>h4</H4>
+ * <H5>h5</H5>
+ * <H6>h6</H6>
+ * ```
+ *
+ * Differing sizes
+ * ```jsx
+ * <Heading level={6} size={80}>
+ *   h6 with font size 80
+ * </Heading>
+ * <Heading level={2} size="SMALL">
+ *   h2 with SMALL size
+ * </Heading>
+ * <H3 size="LARGE">h3 with LARGE size</H3>
+ * ```
+ *
+ * Props pass through
+ * ```jsx
+ * <Heading onClick={() => { console.log('clicked'); }}>Click me</Heading>
+ * ```
+ *
+ * ### References:
+ * - https://design-system.service.gov.uk/styles/typography/#headings
+ * - https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_typography.scss
+ * - https://github.com/alphagov/govuk-frontend/blob/master/src/core/_typography.scss
  */
-const Header = props => <StyledHeader {...props} />;
+const Heading = props => <StyledHeading {...props} />;
 
-Header.defaultProps = {
+Heading.defaultProps = {
   level: 1,
   size: undefined,
 };
 
-Header.propTypes = {
+Heading.propTypes = {
   /**
    * Semantic heading level value between 1 and 6
    */
@@ -81,6 +115,6 @@ Header.propTypes = {
   size: PropTypes.oneOf([...Object.keys(HEADING_SIZES), ...Object.keys(TYPOGRAPHY_SCALE)]),
 };
 
-export default Header;
+export default Heading;
 
 export { H1, H2, H3, H4, H5, H6 } from './presets';

--- a/components/heading/src/presets.js
+++ b/components/heading/src/presets.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { LEVEL_SIZE } from '@govuk-react/constants';
+import Heading from '.';
+
+export const H1 = props => <Heading level={1} size={LEVEL_SIZE[1]} {...props} />;
+export const H2 = props => <Heading level={2} size={LEVEL_SIZE[2]} {...props} />;
+export const H3 = props => <Heading level={3} size={LEVEL_SIZE[3]} {...props} />;
+export const H4 = props => <Heading level={4} size={LEVEL_SIZE[4]} {...props} />;
+export const H5 = props => <Heading level={5} size={LEVEL_SIZE[5]} {...props} />;
+export const H6 = props => <Heading level={6} size={LEVEL_SIZE[6]} {...props} />;

--- a/components/heading/src/stories.js
+++ b/components/heading/src/stories.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, text, number } from '@storybook/addon-knobs/react';
+import { WithDocsCustom } from '@govuk-react/storybook-components';
+
+import Heading, { H1, H2, H3, H4, H5, H6 } from '.';
+import ReadMe from '../README.md';
+
+const stories = storiesOf('Typography/Heading', module);
+const examples = storiesOf('Typography/Heading/Examples', module);
+const headingRanges = {
+  range: true,
+  min: 1,
+  max: 6,
+  step: 1,
+};
+
+stories.addDecorator(withKnobs);
+stories.addDecorator(WithDocsCustom(ReadMe));
+
+stories.add('Component default', () => (<Heading level={number('level', 2, headingRanges)}>{text('Children', 'Heading text')}</Heading>));
+
+examples.add('Levels 1-6', () => (
+  <div>
+    <Heading level={1}>A 48px Bold heading</Heading>
+    <Heading level={2}>A 36px Bold heading</Heading>
+    <Heading level={3}>A 24px Bold heading</Heading>
+    <Heading level={4}>A 19px Bold heading</Heading>
+    <Heading level={5}>h5</Heading>
+    <Heading level={6}>h6</Heading>
+  </div>
+));
+examples.add('Shortcuts 1-6', () => (
+  <div>
+    <H1>h1</H1>
+    <H2>h2</H2>
+    <H3>h3</H3>
+    <H4>h4</H4>
+    <H5>h5</H5>
+    <H6>h6</H6>
+  </div>
+));
+examples.add('Differing sizes', () => (
+  <div>
+    <Heading level={6} size={80}>
+      h6 with XXLARGE style
+    </Heading>
+    <Heading level={2} size={16}>
+      h2 with XSMALL style
+    </Heading>
+    <H3 size="LARGE">h3 with size large</H3>
+  </div>
+));
+examples.add('Props pass through', () => (
+  <div>
+    <Heading onClick={action('heading-click')}>Click me</Heading>
+  </div>
+));

--- a/components/heading/src/test.js
+++ b/components/heading/src/test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { mount } from 'enzyme';
+
+import Heading from '.';
+import { H1, H2, H3, H4, H5, H6 } from './presets';
+
+describe('Heading', () => {
+  it('renders a Heading and all the H-level tags without crashing', () => {
+    const example = 'example';
+    const wrapper = <Heading>{example}</Heading>;
+    const div = document.createElement('div');
+
+    ReactDOM.render(wrapper, div);
+    ReactDOM.render(<H1>{example}</H1>, div);
+    ReactDOM.render(<H2>{example}</H2>, div);
+    ReactDOM.render(<H3>{example}</H3>, div);
+    ReactDOM.render(<H4>{example}</H4>, div);
+    ReactDOM.render(<H5>{example}</H5>, div);
+    ReactDOM.render(<H6>{example}</H6>, div);
+  });
+
+  it('allows custom string-based font size without crashing', () => {
+    ReactDOM.render(<Heading size="SMALL">Test</Heading>, document.createElement('div'));
+  });
+
+  it('allows custom numeric GDS font size without crashing', () => {
+    ReactDOM.render(<Heading size={16}>Test</Heading>, document.createElement('div'));
+  });
+
+  it('throws an error if an unsupported size is used', () => {
+    const example = 'example';
+    const div = document.createElement('div');
+
+    expect(() => { ReactDOM.render(<Heading size={0}>{example}</Heading>, div); }).toThrow();
+    expect(() => { ReactDOM.render(<Heading size={1}>{example}</Heading>, div); }).toThrow();
+    expect(() => { ReactDOM.render(<Heading size={99999}>{example}</Heading>, div); }).toThrow();
+    expect(() => { ReactDOM.render(<Heading size="test">{example}</Heading>, div); }).toThrow();
+  });
+
+  it('matches wrapper snapshot', () => {
+    const example = 'example';
+    const wrapper = <Heading>{example}</Heading>;
+
+    expect(mount(wrapper)).toMatchSnapshot('wrapper mount');
+  });
+});

--- a/components/loading-box/src/stories.js
+++ b/components/loading-box/src/stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, text, number, boolean } from '@storybook/addon-knobs/react';
-import Header, { H1, H2 } from '@govuk-react/header';
+import Heading, { H1, H2 } from '@govuk-react/heading';
 import InputField from '@govuk-react/input-field';
 import Button from '@govuk-react/button';
 import LabelText from '@govuk-react/label-text';
@@ -37,7 +37,7 @@ stories.add('Component default', () => (
         <Link href="https://example.com">find out what that means</Link>
       </PhaseBanner>
       {spacer}
-      <Header level={2}>Toggle loading settings under `knobs`</Header>
+      <Heading level={2}>Toggle loading settings under `knobs`</Heading>
       <InputField>
       Email address
       </InputField>
@@ -62,7 +62,7 @@ examples.add('preset to loading', () => (
         <Link href="https://example.com">find out what that means</Link>
       </PhaseBanner>
       {spacer}
-      <Header level={2}>Toggle loading settings under `knobs`</Header>
+      <Heading level={2}>Toggle loading settings under `knobs`</Heading>
       <InputField>
       Email address
       </InputField>
@@ -87,7 +87,7 @@ examples.add('LoadingBox (long)', () => (
         <Link href="https://example.com">find out what that means</Link>
       </PhaseBanner>
       {spacer}
-      <Header level={2}>Toggle loading settings under `knobs`</Header>
+      <Heading level={2}>Toggle loading settings under `knobs`</Heading>
       <InputField>
         First name
       </InputField>

--- a/components/related-items/README.md
+++ b/components/related-items/README.md
@@ -11,13 +11,13 @@ RelatedItems
 
 Simple
 ```jsx
-import Header from '@govuk-react/header';
+import Heading from '@govuk-react/heading';
 import UnorderedList from '@govuk-react/unordered-list';
 import Link from '@govuk-react/link';
 import ListItem from '@govuk-react/list-item';
 
 <RelatedItems>
-  <Header level={3}>Example header</Header>
+  <Heading level={3}>Example heading</Heading>
   <UnorderedList listStyleType="none">
     <ListItem>
       <Link href="https://example.com">Link A</Link>

--- a/components/related-items/src/__snapshots__/test.js.snap
+++ b/components/related-items/src/__snapshots__/test.js.snap
@@ -231,7 +231,7 @@ exports[`RelatedItems matches wrapper snapshot: wrapper mount 1`] = `
       <div
         className="c0"
       >
-        <Header
+        <Heading
           level={3}
         >
           <Styled(Component)
@@ -282,7 +282,7 @@ exports[`RelatedItems matches wrapper snapshot: wrapper mount 1`] = `
               </Component>
             </StyledComponent>
           </Styled(Component)>
-        </Header>
+        </Heading>
         <UnorderedList
           listStyleType="none"
         >

--- a/components/related-items/src/index.js
+++ b/components/related-items/src/index.js
@@ -39,13 +39,13 @@ const StyledRelatedItems = styled('div')(
  *
  * Simple
  * ```jsx
- * import Header from '@govuk-react/header';
+ * import Heading from '@govuk-react/heading';
  * import UnorderedList from '@govuk-react/unordered-list';
  * import Link from '@govuk-react/link';
  * import ListItem from '@govuk-react/list-item';
  *
  * <RelatedItems>
- *   <Header level={3}>Example header</Header>
+ *   <Heading level={3}>Example heading</Heading>
  *   <UnorderedList listStyleType="none">
  *     <ListItem>
  *       <Link href="https://example.com">Link A</Link>

--- a/components/related-items/src/stories.js
+++ b/components/related-items/src/stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import Header from '@govuk-react/header';
+import Heading from '@govuk-react/heading';
 import UnorderedList from '@govuk-react/unordered-list';
 import Link from '@govuk-react/link';
 import ListItem from '@govuk-react/list-item';
@@ -15,7 +15,7 @@ stories.addDecorator(WithDocsCustom(ReadMe));
 
 stories.add('Component default', () => (
   <RelatedItems>
-    <Header level={3}>Travel abroad</Header>
+    <Heading level={3}>Travel abroad</Heading>
     <UnorderedList listStyleType="none">
       <ListItem>
         <Link href="https://example.com">Link A</Link>
@@ -27,7 +27,7 @@ stories.add('Component default', () => (
         <Link href="https://example.com"><strong>more</strong></Link>
       </ListItem>
     </UnorderedList>
-    <Header level={3}>Travel</Header>
+    <Heading level={3}>Travel</Heading>
     <UnorderedList listStyleType="none">
       <ListItem>
         <Link href="https://example.com">Link A</Link>

--- a/components/related-items/src/test.js
+++ b/components/related-items/src/test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { mount } from 'enzyme';
-import Header from '@govuk-react/header';
+import Heading from '@govuk-react/heading';
 import UnorderedList from '@govuk-react/unordered-list';
 import Link from '@govuk-react/link';
 import ListItem from '@govuk-react/list-item';
@@ -10,7 +10,7 @@ import RelatedItems from './';
 
 const wrapper = (
   <RelatedItems>
-    <Header level={3}>Travel abroad</Header>
+    <Heading level={3}>Travel abroad</Heading>
     <UnorderedList listStyleType="none">
       <ListItem>
         <Link href="https://example.com">Link A</Link>

--- a/components/supporting-header/README.md
+++ b/components/supporting-header/README.md
@@ -16,7 +16,7 @@ Simple
 
 With another header
 ```jsx
-import { H1 } from '@govuk-react/header';
+import { H1 } from '@govuk-react/heading';
 
 <SupportingHeader>Supporting header text</SupportingHeader>
 <H1>Main header text</H1>

--- a/components/supporting-header/src/index.js
+++ b/components/supporting-header/src/index.js
@@ -29,7 +29,7 @@ const StyledHeader = styled('span')(
  *
  * With another header
  * ```jsx
- * import { H1 } from '@govuk-react/header';
+ * import { H1 } from '@govuk-react/heading';
  *
  * <SupportingHeader>Supporting header text</SupportingHeader>
  * <H1>Main header text</H1>

--- a/components/supporting-header/src/stories.js
+++ b/components/supporting-header/src/stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs/react';
 import { WithDocsCustom } from '@govuk-react/storybook-components';
 
-import { H1 } from '@govuk-react/header';
+import { H1 } from '@govuk-react/heading';
 
 import SupportingHeader, { SupportingHeaderWithKnobs } from './fixtures';
 import ReadMe from '../README.md';

--- a/packages/govuk-react/package.json
+++ b/packages/govuk-react/package.json
@@ -17,6 +17,7 @@
     "@govuk-react/grid-col": "^0.6.0-alpha.4",
     "@govuk-react/grid-row": "^0.6.0-alpha.4",
     "@govuk-react/header": "^0.6.0-alpha.4",
+    "@govuk-react/heading": "^0.6.0-alpha.4",
     "@govuk-react/hint-text": "^0.6.0-alpha.4",
     "@govuk-react/hoc": "^0.6.0-alpha.4",
     "@govuk-react/icons": "^0.6.0-alpha.4",

--- a/packages/govuk-react/src/index.js
+++ b/packages/govuk-react/src/index.js
@@ -13,6 +13,7 @@ export { default as FileUpload } from '@govuk-react/file-upload';
 export { default as GridCol } from '@govuk-react/grid-col';
 export { default as GridRow } from '@govuk-react/grid-row';
 export { default as Header } from '@govuk-react/header';
+export { default as Heading } from '@govuk-react/heading';
 export { default as HintText } from '@govuk-react/hint-text';
 export { default as Input } from '@govuk-react/input';
 export { default as InputField } from '@govuk-react/input-field';
@@ -46,7 +47,7 @@ export { default as TopNav } from '@govuk-react/top-nav';
 export { default as UnorderedList } from '@govuk-react/unordered-list';
 export { default as WarningText } from '@govuk-react/warning-text';
 
-export { H1, H2, H3, H4, H5, H6 } from '@govuk-react/header';
+export { H1, H2, H3, H4, H5, H6 } from '@govuk-react/heading';
 
 // Higher Order Components
 export { asAnchor } from '@govuk-react/hoc';

--- a/packages/hoc/src/withWhiteSpace/stories.js
+++ b/packages/hoc/src/withWhiteSpace/stories.js
@@ -10,7 +10,7 @@ import Checkbox from '@govuk-react/checkbox';
 import DateField from '@govuk-react/date-field';
 import ErrorText from '@govuk-react/error-text';
 import FileUpload from '@govuk-react/file-upload';
-import Header from '@govuk-react/header';
+import Heading from '@govuk-react/heading';
 import HintText from '@govuk-react/hint-text';
 import Input from '@govuk-react/input';
 import InputField from '@govuk-react/input-field';
@@ -125,7 +125,7 @@ stories.add('multiple existing components', () => (
     <DateField mb={number('DateField marginBottom', 9)}>Example</DateField>
     <ErrorText mb={number('ErrorText marginBottom', 9)}>Example</ErrorText>
     <FileUpload mb={number('File Upload marginBottom', 9)}>Example</FileUpload>
-    <Header mb={number('Header marginBottom', 9)}>Example</Header>
+    <Heading mb={number('Heading marginBottom', 9)}>Example</Heading>
     <HintText mb={number('HintText marginBottom', 9)}>Example</HintText>
     <Input mb={number('Input marginBottom', 9)} />
     <InputField mb={number('Input-text marginBottom', 9)}>Example</InputField>


### PR DESCRIPTION
Heading component allows Header to be deprecated.

Deprecation currently marked in documentation only.

Closes #454 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
