### PR TITLE
Change to docs generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "start": "cd packages/storybook && npm start",
     "bootstrap": "lerna bootstrap",
-    "docs": "./packages/api-docs/bin/doc-component.js './components/**/lib/index.js' './API.md'",
+    "docs": "doc-component './components/**/lib/index.js' './API.md'",
     "docs:components": "lerna run docs --parallel",
     "eslint": "eslint ./{components,packages}/*/src/{*.js,**/*.js}",
     "eslint:fix": "eslint --fix ./{components,packages}/*/src/{*.js,**/*.js}",

--- a/packages/api-docs/src/index.js
+++ b/packages/api-docs/src/index.js
@@ -15,7 +15,7 @@ import generateMarkdown from './markdown/generateMarkdown';
 const components = require('govuk-react');
 
 function getComponentFolderName(file) {
-  const dirs = path.dirname(file).split(path.sep);
+  const dirs = path.dirname(file).split('/');
   let dir = dirs[dirs.length - 1];
   if (dir === 'src' || dir === 'lib') {
     dir = dirs[dirs.length - 2];
@@ -74,7 +74,7 @@ async function generateApiForFiles(files) {
 }
 
 export default async function (relDir, outputMd) {
-  const files = await glob(path.resolve(process.cwd(), relDir));
+  const files = await glob(path.resolve(process.cwd(), relDir.replace(/^'/, '').replace(/'$/, '')));
   const md = await generateApiForFiles(files);
-  await promisify(fs.writeFile)(outputMd, md);
+  await promisify(fs.writeFile)(outputMd.replace(/^'/, '').replace(/'$/, ''), md);
 }


### PR DESCRIPTION
Issues related to the api-docs/src/index.js were hardcoded to handle unix-like systems. The top-level package.json docs script has been changed to use the command doc-components rather than use it's relative path to the file

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
