### PR TITLE
Add VisuallyHidden component and lib

### DIFF
--- a/API.md
+++ b/API.md
@@ -2092,6 +2092,37 @@ Prop | Required | Default | Type | Description
  `listStyleType` |  | ```undefined``` | string | CSS value for `list-style-type`, or `bullet` or `number` to match govuk-frontend
 
 
+VisuallyHidden
+==============
+
+### Import
+```js
+  import VisuallyHidden from '@govuk-react/visually-hidden';
+```
+<!-- STORY -->
+
+### Usage
+
+This component is primarily intended to be used for material that will be visually hidden
+but visible to screen-reader devices.
+
+Simple
+```jsx
+<VisuallyHidden>Example</VisuallyHidden>
+```
+
+### References
+- https://github.com/alphagov/govuk-frontend/blob/master/src/helpers/_visually-hidden.scss
+- https://github.com/alphagov/govuk-frontend/blob/master/src/utilities/_visually-hidden.scss
+
+### Properties
+Prop | Required | Default | Type | Description
+:--- | :------- | :------ | :--- | :----------
+ `children` | true | `````` | node | Content to be hidden
+ `focusable` |  | ```false``` | bool | Allow component to be focusable, and thus become visible
+ `important` |  | ```true``` | bool | Set styles with `!important`
+
+
 WarningText
 ===========
 

--- a/components/button/src/__snapshots__/test.js.snap
+++ b/components/button/src/__snapshots__/test.js.snap
@@ -125,7 +125,7 @@ exports[`button basics matches snapshot 1`] = `
   }
 }
 
-<Button
+<ForwardRef
   disabled={false}
   start={false}
 >
@@ -174,7 +174,7 @@ exports[`button basics matches snapshot 1`] = `
       </button>
     </StyledComponent>
   </styled.button>
-</Button>
+</ForwardRef>
 `;
 
 exports[`button blue button, with automatic colours matches snapshot 1`] = `
@@ -303,7 +303,7 @@ exports[`button blue button, with automatic colours matches snapshot 1`] = `
 }
 
 <ButtonBlue>
-  <Button
+  <ForwardRef
     buttonColour="#005ea5"
     disabled={false}
     start={false}
@@ -355,7 +355,7 @@ exports[`button blue button, with automatic colours matches snapshot 1`] = `
         </button>
       </StyledComponent>
     </styled.button>
-  </Button>
+  </ForwardRef>
 </ButtonBlue>
 `;
 
@@ -504,7 +504,7 @@ exports[`button button with icon matches snapshot 1`] = `
 }
 
 <ButtonStartIcon>
-  <Button
+  <ForwardRef
     disabled={false}
     icon={
       <ButtonArrow
@@ -639,7 +639,7 @@ exports[`button button with icon matches snapshot 1`] = `
         </button>
       </StyledComponent>
     </styled.button>
-  </Button>
+  </ForwardRef>
 </ButtonStartIcon>
 `;
 
@@ -769,7 +769,7 @@ exports[`button custom colours matches snapshot 1`] = `
 }
 
 <ButtonWacky>
-  <Button
+  <ForwardRef
     buttonColour="#dee0e2"
     buttonHoverColour="#ffbf47"
     buttonShadowColour="#f47738"
@@ -830,7 +830,7 @@ exports[`button custom colours matches snapshot 1`] = `
         </button>
       </StyledComponent>
     </styled.button>
-  </Button>
+  </ForwardRef>
 </ButtonWacky>
 `;
 
@@ -960,7 +960,7 @@ exports[`button disabled matches snapshot 1`] = `
 }
 
 <ButtonDisabled>
-  <Button
+  <ForwardRef
     disabled={true}
     start={false}
   >
@@ -1009,7 +1009,7 @@ exports[`button disabled matches snapshot 1`] = `
         </button>
       </StyledComponent>
     </styled.button>
-  </Button>
+  </ForwardRef>
 </ButtonDisabled>
 `;
 
@@ -1139,7 +1139,7 @@ exports[`button start button matches snapshot 1`] = `
 }
 
 <ButtonStart>
-  <Button
+  <ForwardRef
     disabled={false}
     start={true}
   >
@@ -1188,6 +1188,6 @@ exports[`button start button matches snapshot 1`] = `
         </button>
       </StyledComponent>
     </styled.button>
-  </Button>
+  </ForwardRef>
 </ButtonStart>
 `;

--- a/components/button/src/index.js
+++ b/components/button/src/index.js
@@ -167,17 +167,17 @@ const ButtonContents = styled('span')({
  *   - see https://www.w3.org/TR/WCAG20-TECHS/G18.html
  *   - can use Polished's `readableColor` call, but translate their black to govuk's black
  */
-const Button = ({
+const Button = React.forwardRef(({
   start,
   children,
   icon,
   ...props
-}) => (
-  <StyledButton isStart={start} icon={icon} {...props}>
+}, ref) => (
+  <StyledButton ref={ref} isStart={start} icon={icon} {...props}>
     {icon ? <ButtonContents>{children}</ButtonContents> : children}
     {icon}
   </StyledButton>
-);
+));
 
 Button.propTypes = {
   /**

--- a/components/visually-hidden/README.md
+++ b/components/visually-hidden/README.md
@@ -1,0 +1,31 @@
+VisuallyHidden
+==============
+
+### Import
+```js
+  import VisuallyHidden from '@govuk-react/visually-hidden';
+```
+<!-- STORY -->
+
+### Usage
+
+This component is primarily intended to be used for material that will be visually hidden
+but visible to screen-reader devices.
+
+Simple
+```jsx
+<VisuallyHidden>Example</VisuallyHidden>
+```
+
+### References
+- https://github.com/alphagov/govuk-frontend/blob/master/src/helpers/_visually-hidden.scss
+- https://github.com/alphagov/govuk-frontend/blob/master/src/utilities/_visually-hidden.scss
+
+### Properties
+Prop | Required | Default | Type | Description
+:--- | :------- | :------ | :--- | :----------
+ `children` | true | `````` | node | Content to be hidden
+ `focusable` |  | ```false``` | bool | Allow component to be focusable, and thus become visible
+ `important` |  | ```true``` | bool | Set styles with `!important`
+
+

--- a/components/visually-hidden/package.json
+++ b/components/visually-hidden/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@govuk-react/visually-hidden",
+  "version": "0.6.0",
+  "dependencies": {
+    "@govuk-react/lib": "^0.6.0",
+    "govuk-colours": "^1.0.3"
+  },
+  "peerDependencies": {
+    "react": ">=16.2.0",
+    "styled-components": ">=4"
+  },
+  "scripts": {
+    "build": "yarn build:lib && yarn build:es",
+    "build:lib": "rimraf lib && babel src -d lib --source-maps --config-file ../../babel.config.js",
+    "build:es": "rimraf es && cross-env BABEL_ENV=es babel src -d es --source-maps --config-file ../../babel.config.js",
+    "docs": "doc-component ./lib/index.js ./README.md"
+  },
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "author": "Alasdair McLeay",
+  "license": "MIT",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/visually-hidden",
+  "description": "govuk-react VisuallyHidden component.",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/visually-hidden/src/__snapshots__/test.js.snap
+++ b/components/visually-hidden/src/__snapshots__/test.js.snap
@@ -1,0 +1,222 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VisuallyHidden focusable version matches snapshot: focusable 1`] = `
+.c0 {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: 0 !important;
+  overflow: hidden !important;
+  -webkit-clip: rect(0 0 0 0) !important;
+  clip: rect(0 0 0 0) !important;
+  -webkit-clip-path: inset(50%) !important;
+  clip-path: inset(50%) !important;
+  border: 0 !important;
+  white-space: nowrap !important;
+}
+
+.c0:active,
+.c0:focus {
+  position: static !important;
+  width: auto !important;
+  height: auto !important;
+  margin: inherit !important;
+  overflow: visible !important;
+  -webkit-clip: auto !important;
+  clip: auto !important;
+  -webkit-clip-path: none !important;
+  clip-path: none !important;
+  white-space: inherit !important;
+}
+
+<VisuallyHiddenDocumented
+  focusable={true}
+  important={true}
+>
+  <styled.span
+    focusable={true}
+    important={true}
+  >
+    <StyledComponent
+      focusable={true}
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [
+            [Function],
+          ],
+          "componentStyle": ComponentStyle {
+            "componentId": "sc-bdVaJa",
+            "isStatic": false,
+            "lastClassName": "c0",
+            "rules": Array [
+              [Function],
+            ],
+          },
+          "defaultProps": Object {
+            "focusable": false,
+            "important": true,
+          },
+          "displayName": "styled.span",
+          "foldedComponentIds": Array [],
+          "propTypes": undefined,
+          "render": [Function],
+          "styledComponentId": "sc-bdVaJa",
+          "target": "span",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+      important={true}
+    >
+      <span
+        className="c0"
+        focusable={true}
+        tabIndex="0"
+      >
+        Example
+      </span>
+    </StyledComponent>
+  </styled.span>
+</VisuallyHiddenDocumented>
+`;
+
+exports[`VisuallyHidden matches snapshot: default render 1`] = `
+.c0 {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: 0 !important;
+  overflow: hidden !important;
+  -webkit-clip: rect(0 0 0 0) !important;
+  clip: rect(0 0 0 0) !important;
+  -webkit-clip-path: inset(50%) !important;
+  clip-path: inset(50%) !important;
+  border: 0 !important;
+  white-space: nowrap !important;
+  padding: 0 !important;
+}
+
+<VisuallyHiddenDocumented
+  focusable={false}
+  important={true}
+>
+  <styled.span
+    focusable={false}
+    important={true}
+  >
+    <StyledComponent
+      focusable={false}
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [
+            [Function],
+          ],
+          "componentStyle": ComponentStyle {
+            "componentId": "sc-bdVaJa",
+            "isStatic": false,
+            "lastClassName": "c0",
+            "rules": Array [
+              [Function],
+            ],
+          },
+          "defaultProps": Object {
+            "focusable": false,
+            "important": true,
+          },
+          "displayName": "styled.span",
+          "foldedComponentIds": Array [],
+          "propTypes": undefined,
+          "render": [Function],
+          "styledComponentId": "sc-bdVaJa",
+          "target": "span",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+      important={true}
+    >
+      <span
+        className="c0"
+        focusable={false}
+      >
+        Example
+      </span>
+    </StyledComponent>
+  </styled.span>
+</VisuallyHiddenDocumented>
+`;
+
+exports[`VisuallyHidden with important={false} matches snapshot: not important 1`] = `
+.c0 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  overflow: hidden;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  border: 0;
+  white-space: nowrap;
+  padding: 0;
+}
+
+<VisuallyHiddenDocumented
+  focusable={false}
+  important={false}
+>
+  <styled.span
+    focusable={false}
+    important={false}
+  >
+    <StyledComponent
+      focusable={false}
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [
+            [Function],
+          ],
+          "componentStyle": ComponentStyle {
+            "componentId": "sc-bdVaJa",
+            "isStatic": false,
+            "lastClassName": "c0",
+            "rules": Array [
+              [Function],
+            ],
+          },
+          "defaultProps": Object {
+            "focusable": false,
+            "important": true,
+          },
+          "displayName": "styled.span",
+          "foldedComponentIds": Array [],
+          "propTypes": undefined,
+          "render": [Function],
+          "styledComponentId": "sc-bdVaJa",
+          "target": "span",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+      important={false}
+    >
+      <span
+        className="c0"
+        focusable={false}
+      >
+        Example
+      </span>
+    </StyledComponent>
+  </styled.span>
+</VisuallyHiddenDocumented>
+`;

--- a/components/visually-hidden/src/index.js
+++ b/components/visually-hidden/src/index.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { visuallyHidden } from '@govuk-react/lib';
+
+const VisuallyHidden = styled('span').attrs(({ focusable, tabIndex }) => (
+  // if we're focusable but don't have a `tabIndex` set, add one
+  focusable && (tabIndex === undefined) ? { tabIndex: '0' } : undefined
+))(({ focusable, important }) => (
+  visuallyHidden({ focusable, important })
+));
+
+/**
+ *
+ * ### Usage
+ *
+ * This component is primarily intended to be used for material that will be visually hidden
+ * but visible to screen-reader devices.
+ *
+ * Simple
+ * ```jsx
+ * <VisuallyHidden>Example</VisuallyHidden>
+ * ```
+ *
+ * ### References
+ * - https://github.com/alphagov/govuk-frontend/blob/master/src/helpers/_visually-hidden.scss
+ * - https://github.com/alphagov/govuk-frontend/blob/master/src/utilities/_visually-hidden.scss
+ */
+const VisuallyHiddenDocumented = props => <VisuallyHidden {...props} />;
+
+VisuallyHiddenDocumented.propTypes = {
+  /**
+   * Content to be hidden
+   */
+  children: PropTypes.node.isRequired,
+  /**
+   * Allow component to be focusable, and thus become visible
+   */
+  focusable: PropTypes.bool,
+  /**
+   * Set styles with `!important`
+   */
+  important: PropTypes.bool,
+};
+
+VisuallyHiddenDocumented.defaultProps = {
+  focusable: false,
+  important: true,
+};
+
+VisuallyHidden.propTypes = VisuallyHiddenDocumented.propTypes;
+VisuallyHidden.defaultProps = VisuallyHiddenDocumented.defaultProps;
+
+export { VisuallyHiddenDocumented };
+export default VisuallyHidden;

--- a/components/visually-hidden/src/stories.js
+++ b/components/visually-hidden/src/stories.js
@@ -52,8 +52,9 @@ examples.add(
   'Focussed focusable',
   () => (
     <Focusable>Focussed focusable VisuallyHidden element</Focusable>
-  ), {
-    chromatic: { delay: 100 },
+  ),
+  {
+    chromatic: { delay: 300 },
   },
 );
 
@@ -63,6 +64,6 @@ examples.add(
     <Focusable as={Button}>VisuallyHidden as Button (focusable)</Focusable>
   ),
   {
-    chromatic: { delay: 100 },
+    chromatic: { delay: 300 },
   },
 );

--- a/components/visually-hidden/src/stories.js
+++ b/components/visually-hidden/src/stories.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { boolean, withKnobs } from '@storybook/addon-knobs/react';
+import { WithDocsCustom } from '@govuk-react/storybook-components';
+
+import VisuallyHidden from '.';
+
+import ReadMe from '../README.md';
+
+const stories = storiesOf('Misc/VisuallyHidden', module);
+stories.addDecorator(withKnobs);
+stories.addDecorator(WithDocsCustom(ReadMe));
+
+stories.add('Component default', () => (
+  <VisuallyHidden focusable={boolean('focusable', true)}>
+    Some hidden content
+  </VisuallyHidden>
+));

--- a/components/visually-hidden/src/stories.js
+++ b/components/visually-hidden/src/stories.js
@@ -1,18 +1,68 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, withKnobs } from '@storybook/addon-knobs/react';
 import { WithDocsCustom } from '@govuk-react/storybook-components';
+import Paragraph from '@govuk-react/paragraph';
+import Button from '@govuk-react/button';
 
 import VisuallyHidden from '.';
 
 import ReadMe from '../README.md';
 
 const stories = storiesOf('Misc/VisuallyHidden', module);
+const examples = storiesOf('Misc/VisuallyHidden/Examples', module);
+
 stories.addDecorator(withKnobs);
 stories.addDecorator(WithDocsCustom(ReadMe));
 
 stories.add('Component default', () => (
-  <VisuallyHidden focusable={boolean('focusable', true)}>
-    Some hidden content
-  </VisuallyHidden>
+  <div>
+    <Paragraph>
+      Following this paragraph is some hidden content.
+      If `focusable` is enabled then you should be able to tab to it.
+    </Paragraph>
+    <VisuallyHidden focusable={boolean('focusable', true)}>
+      Some hidden content
+    </VisuallyHidden>
+  </div>
 ));
+
+class Focusable extends Component {
+  constructor(props) {
+    super(props);
+    // create a ref to store the focusable DOM element
+    this.focusableRef = React.createRef();
+  }
+
+  componentDidMount() {
+    this.focusableRef.current.focus();
+  }
+
+  render() {
+    return (
+      <VisuallyHidden
+        ref={this.focusableRef}
+        focusable
+        {...this.props}
+      />
+    );
+  }
+}
+examples.add(
+  'Focussed focusable',
+  () => (
+    <Focusable>Focussed focusable VisuallyHidden element</Focusable>
+  ), {
+    chromatic: { delay: 100 },
+  },
+);
+
+examples.add(
+  'Focussed focusable as a button',
+  () => (
+    <Focusable as={Button}>VisuallyHidden as Button (focusable)</Focusable>
+  ),
+  {
+    chromatic: { delay: 100 },
+  },
+);

--- a/components/visually-hidden/src/test.js
+++ b/components/visually-hidden/src/test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { VisuallyHiddenDocumented as VisuallyHidden } from '.';
+
+describe('VisuallyHidden', () => {
+  it('matches snapshot', () => {
+    expect(mount(<VisuallyHidden>Example</VisuallyHidden>)).toMatchSnapshot('default render');
+  });
+
+  it('focusable version matches snapshot', () => {
+    expect(mount(<VisuallyHidden focusable>Example</VisuallyHidden>)).toMatchSnapshot('focusable');
+  });
+
+  it('with important={false} matches snapshot', () => {
+    expect(mount(<VisuallyHidden important={false}>Example</VisuallyHidden>)).toMatchSnapshot('not important');
+  });
+});

--- a/packages/govuk-react/package.json
+++ b/packages/govuk-react/package.json
@@ -51,6 +51,7 @@
     "@govuk-react/text-area": "^0.6.0",
     "@govuk-react/top-nav": "^0.6.0",
     "@govuk-react/unordered-list": "^0.6.0",
+    "@govuk-react/visually-hidden": "^0.6.0",
     "@govuk-react/warning-text": "^0.6.0",
     "govuk-colours": "^1.0.3"
   },

--- a/packages/govuk-react/src/index.js
+++ b/packages/govuk-react/src/index.js
@@ -45,6 +45,7 @@ export { default as Tag } from '@govuk-react/tag';
 export { default as TextArea } from '@govuk-react/text-area';
 export { default as TopNav } from '@govuk-react/top-nav';
 export { default as UnorderedList } from '@govuk-react/unordered-list';
+export { default as VisuallyHidden } from '@govuk-react/visually-hidden';
 export { default as WarningText } from '@govuk-react/warning-text';
 
 export { H1, H2, H3, H4, H5, H6 } from '@govuk-react/heading';

--- a/packages/lib/src/index.js
+++ b/packages/lib/src/index.js
@@ -2,3 +2,4 @@ export * as link from './link';
 export * as shape from './shape';
 export * as spacing from './spacing';
 export * as typography from './typography';
+export visuallyHidden from './visually-hidden';

--- a/packages/lib/src/visually-hidden/index.js
+++ b/packages/lib/src/visually-hidden/index.js
@@ -1,0 +1,51 @@
+// This lib is effectively a port of govuk-frontend's visually-hidden sass helpers
+// Tracking:
+// https://github.com/alphagov/govuk-frontend/blob/master/src/helpers/_visually-hidden.scss
+
+function visuallyHidden({
+  important: isImportant = true,
+  focusable: isFocusable = false,
+} = {}) {
+  const important = isImportant ? ' !important' : '';
+  return Object.assign(
+    {},
+    {
+      position: `absolute${important}`,
+
+      width: `1px${important}`,
+      height: `1px${important}`,
+      margin: `0${important}`,
+
+      overflow: `hidden${important}`,
+      clip: `rect(0 0 0 0)${important}`,
+      clipPath: `inset(50%)${important}`,
+
+      border: `0${important}`,
+
+      whiteSpace: `nowrap${important}`,
+    },
+    isFocusable ? {
+      '&:active,&:focus': {
+        position: `static${important}`,
+
+        width: `auto${important}`,
+        height: `auto${important}`,
+        margin: `inherit${important}`,
+
+        overflow: `visible${important}`,
+        clip: `auto${important}`,
+        clipPath: `none${important}`,
+
+        whiteSpace: `inherit${important}`,
+      },
+    } : {
+      padding: `0${important}`,
+    },
+  );
+}
+
+visuallyHidden.focusable = function focusable({ important = true } = {}) {
+  return visuallyHidden({ important, focusable: true });
+};
+
+export default visuallyHidden;

--- a/packages/lib/src/visually-hidden/test.js
+++ b/packages/lib/src/visually-hidden/test.js
@@ -1,0 +1,70 @@
+import visuallyHidden, { focusable } from '.';
+
+describe('visuallyHidden lib', () => {
+  describe('visuallyHidden', () => {
+    it('produces a style declaration', () => {
+      const style = visuallyHidden();
+
+      expect(style).toBeTruthy();
+      expect(style).toBeInstanceOf(Object);
+    });
+
+    it('produces styles which, by default, are marked as important', () => {
+      const style = visuallyHidden();
+
+      Object.values(style).forEach((value) => {
+        expect(value).toContain(' !important');
+      });
+    });
+
+    it('can produce styles that do not contain important', () => {
+      const style = visuallyHidden({ important: false });
+
+      Object.values(style).forEach((value) => {
+        expect(value).not.toContain('!important');
+      });
+    });
+  });
+
+  describe('visuallyHidden.focusable', () => {
+    it('produces a style declaration, with focus and active styles', () => {
+      const style = focusable();
+
+      expect(style).toBeTruthy();
+      expect(style).toBeInstanceOf(Object);
+
+      const hasStyles = Object.keys(style).some(key =>
+        [':focus', ':active'].some(checkKey => key.includes(checkKey)));
+
+      expect(hasStyles).toBe(true);
+    });
+
+    it('produces styles which, by default, are marked as important', () => {
+      const style = visuallyHidden();
+
+      Object.entries(style).forEach(([key, value]) => {
+        if ([':focus', ':active'].some(checkKey => key.includes(checkKey))) {
+          Object.values(value).forEach((activeValue) => {
+            expect(activeValue).toContain(' !important');
+          });
+        } else {
+          expect(value).toContain(' !important');
+        }
+      });
+    });
+
+    it('can produce styles that do not contain important', () => {
+      const style = visuallyHidden({ important: false });
+
+      Object.entries(style).forEach(([key, value]) => {
+        if ([':focus', ':active'].some(checkKey => key.includes(checkKey))) {
+          Object.values(value).forEach((activeValue) => {
+            expect(activeValue).not.toContain(' !important');
+          });
+        } else {
+          expect(value).not.toContain(' !important');
+        }
+      });
+    });
+  });
+});

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -44,6 +44,7 @@
     "@govuk-react/text-area": "^0.6.0",
     "@govuk-react/top-nav": "^0.6.0",
     "@govuk-react/unordered-list": "^0.6.0",
+    "@govuk-react/visually-hidden": "^0.6.0",
     "@govuk-react/warning-text": "^0.6.0",
     "@storybook/addon-actions": "^4.1.13",
     "@storybook/addon-knobs": "^4.1.13",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "babel-loader": "^8.0.4",
     "babel-plugin-styled-components": "^1.10.0",
-    "storybook-chromatic": "^1.2.6"
+    "storybook-chromatic": "^1.3.0"
   },
   "scripts": {
     "start": "start-storybook -p 9009",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,6 +1229,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.3.1":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
+  integrity sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@^7.1.0", "@babel/template@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
@@ -2221,11 +2228,12 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-apollo-fetch@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/apollo-fetch/-/apollo-fetch-0.6.0.tgz#aae9b28c117af344b091ec8ba4d1a5aa0474dc5d"
+apollo-fetch@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/apollo-fetch/-/apollo-fetch-0.7.0.tgz#63c255a0ccb1b4c473524d8f9b536d72438bd3e7"
+  integrity sha512-0oHsDW3Zxx+Of1wuqcOXruNj4Kv55WN69tkIjwkCQDEIrgCpgA2scjChFsgflSVMy/1mkTKCY1Mc0TYJhNRzmw==
   dependencies:
-    isomorphic-fetch "^2.2.1"
+    cross-fetch "^1.0.0"
 
 app-root-dir@^1.0.2:
   version "1.0.2"
@@ -4570,6 +4578,14 @@ cross-env@^5.1.3, cross-env@^5.1.4:
   dependencies:
     cross-spawn "^6.0.5"
     is-windows "^1.0.0"
+
+cross-fetch@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-1.1.1.tgz#dede6865ae30f37eae62ac90ebb7bdac002b05a0"
+  integrity sha512-+VJE04+UfxxmBfcnmAu/lKor53RUCx/1ilOti4p+JgrnLQ4AZZIRoe2OEd76VaHyWQmQxqKnV+TaqjHC4r0HWw==
+  dependencies:
+    node-fetch "1.7.3"
+    whatwg-fetch "2.0.3"
 
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -9337,7 +9353,7 @@ node-emoji@1.8.1:
   dependencies:
     lodash.toarray "^4.4.0"
 
-node-fetch@^1.0.1:
+node-fetch@1.7.3, node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
@@ -11860,14 +11876,14 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
-storybook-chromatic@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/storybook-chromatic/-/storybook-chromatic-1.2.6.tgz#bada3ea3b15469378cd85b5048309af954e43ad0"
-  integrity sha512-rJ0Qr95PwXp1//l8SDDCYkv9++YOsqTeJSIOIUTncDkNar2Tggj5IRDnJZkYvccGJQ5PeOlxHjie4Cnol2bz3Q==
+storybook-chromatic@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/storybook-chromatic/-/storybook-chromatic-1.3.0.tgz#f8eb02c479014621e1f957418314a82450563ddf"
+  integrity sha512-7s4j5aEoSnXbcyqd0TXVezHm5yXHW0svuextiUTkYIDhJP9AxGE4n4SYGvboMpJ3DXSSEdC805zN1ch/Aau+CQ==
   dependencies:
+    "@babel/runtime" "^7.3.1"
     "@chromaui/localtunnel" "1.9.1-chromatic.3"
-    apollo-fetch "^0.6.0"
-    babel-runtime "^6.26.0"
+    apollo-fetch "^0.7.0"
     commander "^2.9.0"
     debug "^3.0.1"
     denodeify "^1.2.1"
@@ -13095,6 +13111,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+  integrity sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=
 
 whatwg-fetch@>=0.10.0:
   version "3.0.0"


### PR DESCRIPTION
adds new `VisuallyHidden` component, which styles a span as visually-hidden replicating the most common use of that class within govuk-frontend

adds `visuallyHidden()` and `visuallyHidden.focusable()` to `@govuk-react/lib`, tracking equivalent sass helper in govuk-frontend

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
