### PR TITLE
Default parameter for withDocsCustom

### DIFF
--- a/packages/storybook-components/src/WithDocsCustom.js
+++ b/packages/storybook-components/src/WithDocsCustom.js
@@ -17,7 +17,7 @@ const PreviewComponent = ({ children }) => (
   </div>
 );
 
-const withDocsCustom = (readme, ...rest) => withDocs({ PreviewComponent })(navigator.userAgent.match(/Chromatic/) ? '' : readme, ...rest);
+const withDocsCustom = (readme = '', ...rest) => withDocs({ PreviewComponent })(navigator.userAgent.match(/Chromatic/) ? '' : readme, ...rest);
 
 PreviewComponent.propTypes = {
   children: PropTypes.node.isRequired,


### PR DESCRIPTION
withDocsCustom's stylings can be useful regardless of where the example stories have a readme or not, providing an empty string as a default parameter allows the function to be called with no parameters

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
