### PR TITLE
Minor tab styling tweaks and fixes

### DIFF
--- a/components/tabs/src/__snapshots__/test.js.snap
+++ b/components/tabs/src/__snapshots__/test.js.snap
@@ -24,7 +24,7 @@ exports[`Tabs matches wrapper snapshot 1`] = `
 }
 
 .c3:before {
-  content: '\\2014 ';
+  content: '\\2014  ';
   margin-left: -25px;
   padding-right: 5px;
 }

--- a/components/tabs/src/__snapshots__/test.js.snap
+++ b/components/tabs/src/__snapshots__/test.js.snap
@@ -10,19 +10,13 @@ exports[`Tabs matches wrapper snapshot 1`] = `
 }
 
 .c6 {
+  margin-bottom: 30px;
   display: block;
-}
-
-.c6 marginBottom {
-  mobile-bottom: 30px;
 }
 
 .c7 {
+  margin-bottom: 30px;
   display: block;
-}
-
-.c7 marginBottom {
-  mobile-bottom: 30px;
 }
 
 .c3 {
@@ -30,7 +24,7 @@ exports[`Tabs matches wrapper snapshot 1`] = `
 }
 
 .c3:before {
-  content: '— ';
+  content: '\\2014 ';
   margin-left: -25px;
   padding-right: 5px;
 }
@@ -138,13 +132,7 @@ exports[`Tabs matches wrapper snapshot 1`] = `
   font-size: 16px;
   line-height: 1.25;
   color: #0b0c0c;
-}
-
-.c0 marginTop {
   margin-top: 5px;
-}
-
-.c0 marginBottom {
   margin-bottom: 20px;
 }
 
@@ -168,8 +156,8 @@ exports[`Tabs matches wrapper snapshot 1`] = `
 }
 
 @media only screen and (min-width:641px) {
-  .c6 marginBottom {
-    mobile-bottom: 50px;
+  .c6 {
+    margin-bottom: 50px;
   }
 }
 
@@ -184,14 +172,14 @@ exports[`Tabs matches wrapper snapshot 1`] = `
     border-top: 0;
   }
 
-  .c6 >:last-child {
+  .c6 > :last-child {
     margin-bottom: 0;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c7 marginBottom {
-    mobile-bottom: 50px;
+  .c7 {
+    margin-bottom: 50px;
   }
 }
 
@@ -206,7 +194,7 @@ exports[`Tabs matches wrapper snapshot 1`] = `
     border-top: 0;
   }
 
-  .c7 >:last-child {
+  .c7 > :last-child {
     margin-bottom: 0;
   }
 }
@@ -354,14 +342,20 @@ exports[`Tabs matches wrapper snapshot 1`] = `
   }
 }
 
+@media print {
+  .c0 {
+    color: #000;
+  }
+}
+
 @media only screen and (min-width:641px) {
-  .c0 marginTop {
+  .c0 {
     margin-top: 5px;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c0 marginBottom {
+  .c0 {
     margin-bottom: 30px;
   }
 }

--- a/components/tabs/src/atoms/list/index.js
+++ b/components/tabs/src/atoms/list/index.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { GREY_2 } from 'govuk-colours';
+import { BORDER_COLOUR } from 'govuk-colours';
 import { spacing } from '@govuk-react/lib';
 import { MEDIA_QUERIES } from '@govuk-react/constants';
 
@@ -20,7 +20,7 @@ const TabList = styled('ul')(
     padding: 0,
     listStyle: 'none',
     [MEDIA_QUERIES.TABLET]: {
-      borderBottom: `1px solid ${GREY_2}`,
+      borderBottom: `1px solid ${BORDER_COLOUR}`,
       marginBottom: 0,
       ...clearfix,
     },

--- a/components/tabs/src/atoms/panel/index.js
+++ b/components/tabs/src/atoms/panel/index.js
@@ -1,21 +1,21 @@
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { GREY_2 } from 'govuk-colours';
+import { BORDER_COLOUR } from 'govuk-colours';
 import { spacing } from '@govuk-react/lib';
 import { MEDIA_QUERIES } from '@govuk-react/constants';
 
 const TabPanel = styled('section')(
+  spacing.responsiveMargin({ size: 8, direction: 'bottom' }),
   {
-    marginBottom: spacing.responsive({ size: 8, property: 'mobile', direction: 'bottom' }),
     [MEDIA_QUERIES.TABLET]: {
       marginBottom: spacing.simple(0),
       paddingTop: spacing.simple(6),
       paddingRight: spacing.simple(4),
       paddingBottom: spacing.simple(6),
       paddingLeft: spacing.simple(4),
-      border: `1px solid ${GREY_2}`,
+      border: `1px solid ${BORDER_COLOUR}`,
       borderTop: 0,
-      '& >: last-child': {
+      '& > :last-child': {
         marginBottom: 0,
       },
     },

--- a/components/tabs/src/atoms/tab/index.js
+++ b/components/tabs/src/atoms/tab/index.js
@@ -15,7 +15,7 @@ const spacingSimple5 = spacing.simple(5);
 const StyledListItem = styled('li')({
   marginLeft: spacingSimple5,
   ':before': {
-    content: "'\\2014 '",
+    content: "'\\2014  '",
     marginLeft: -spacingSimple5,
     paddingRight: spacingSimple1,
   },

--- a/components/tabs/src/atoms/tab/index.js
+++ b/components/tabs/src/atoms/tab/index.js
@@ -15,7 +15,7 @@ const spacingSimple5 = spacing.simple(5);
 const StyledListItem = styled('li')({
   marginLeft: spacingSimple5,
   ':before': {
-    content: "'— '",
+    content: "'\\2014 '",
     marginLeft: -spacingSimple5,
     paddingRight: spacingSimple1,
   },

--- a/components/tabs/src/index.js
+++ b/components/tabs/src/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { TEXT_COLOUR } from 'govuk-colours';
 import { spacing, typography } from '@govuk-react/lib';
 
 import List from './atoms/list';
@@ -11,11 +10,9 @@ import Title from './atoms/title';
 
 const TabsContainer = styled('div')(
   typography.font({ size: 19 }),
-  {
-    color: TEXT_COLOUR,
-    marginTop: spacing.responsive({ size: 1, property: 'margin', direction: 'top' }),
-    marginBottom: spacing.responsive({ size: 6, property: 'margin', direction: 'bottom' }),
-  },
+  typography.textColour,
+  spacing.responsiveMargin({ size: 1, direction: 'top' }),
+  spacing.responsiveMargin({ size: 6, direction: 'bottom' }),
   spacing.withWhiteSpace(),
 );
 


### PR DESCRIPTION
Some styling calls weren't being made correctly, so their styles were not being applied
Use `BORDER_COLOUR`
Tweak of tab item `:before` `content` as per recent govuk-frontend fix

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
