### PR TITLE
Allow tabs to be used with react-router

### DIFF
--- a/components/tabs/src/atoms/tab/index.js
+++ b/components/tabs/src/atoms/tab/index.js
@@ -65,11 +65,9 @@ const StyledHyperLink = styled('a')(
   })
 );
 
-const Tab = ({ children, href, onClick, selected }) => (
+const Tab = props => (
   <StyledListItem>
-    <StyledHyperLink selected={selected} onClick={onClick} href={href}>
-      {children}
-    </StyledHyperLink>
+    <StyledHyperLink {...props} />
   </StyledListItem>
 );
 

--- a/components/tabs/src/atoms/title/index.js
+++ b/components/tabs/src/atoms/title/index.js
@@ -9,4 +9,8 @@ const TabsTitle = styled('h2')(typography.font({ size: 19 }), {
   },
 });
 
+TabsTitle.defaultProps = {
+  children: 'Contents',
+};
+
 export default TabsTitle;

--- a/components/tabs/src/fixtures.js
+++ b/components/tabs/src/fixtures.js
@@ -1,9 +1,11 @@
-import React, { Component } from 'react';
+import React, { Component, useLayoutEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { BREAKPOINTS } from '@govuk-react/constants';
 import { H2, H4 } from '@govuk-react/heading';
 import SectionBreak from '@govuk-react/section-break';
 import Table from '@govuk-react/table';
+import { MemoryRouter, Route, Link } from 'react-router-dom';
+import { useMedia } from 'react-use-media';
 
 import Tabs from '.';
 
@@ -238,7 +240,7 @@ class ProposedClassPropertiesPlugin extends Component {
     const { tabIndex } = this.state;
     return (
       <Tabs>
-        <Tabs.Title>Contents</Tabs.Title>
+        <Tabs.Title />
         <Tabs.List>
           {arrProposedBabel.map(({ contentListItem, id }, index) => (
             <Tabs.Tab
@@ -318,4 +320,157 @@ HooksExample.defaultProps = sharedDefaultProps;
 
 HooksExample.propTypes = sharedPropTypes;
 
-export { HooksExample, ProposedClassPropertiesPlugin, SimpleTabs, SimpleMapTabs, TableTabs };
+// This example demonstrates one way to use react-router with tabs.
+// The use of useMedia means it is not suitable for server-side rendering.
+// When in mobile mode, all panels will be shown but the route will
+// still be updated to match the last clicked tab title.
+// NB in this example react-router is in control over which panel is rendered
+const RouterTabs = ({
+  // eslint-disable-next-line react/prop-types
+  match: {
+    params: { section },
+  },
+}) => {
+  const isTablet = useMedia(`(min-width: ${BREAKPOINTS.TABLET})`);
+  const [prevSection, setPrevSection] = useState(undefined);
+
+  useLayoutEffect(() => {
+    // scroll to the chosen tab if it's changed
+    if (section !== prevSection && !isTablet) {
+      // eslint-disable-next-line no-undef
+      document.querySelector(`#${section || 'first'}`).scrollIntoView();
+    }
+    setPrevSection(section);
+  }, [section, isTablet]);
+
+  return (
+    <Tabs>
+      <Tabs.Title />
+      <Tabs.List>
+        <Tabs.Tab as={Link} selected={!section} to="/">
+          First tab
+        </Tabs.Tab>
+        <Tabs.Tab as={Link} selected={section === 'test'} to="/test">
+          Second tab
+        </Tabs.Tab>
+      </Tabs.List>
+      <Route
+        path={isTablet ? '/' : null}
+        exact={isTablet}
+        render={() => (
+          <Tabs.Panel id="first" selected>
+            First tab contents
+          </Tabs.Panel>
+        )}
+      />
+      <Route
+        path={isTablet ? '/test' : null}
+        render={() => (
+          <Tabs.Panel id="test" selected>
+            Second tab contents
+          </Tabs.Panel>
+        )}
+      />
+    </Tabs>
+  );
+};
+
+const ReactRouterExample = () => (
+  <MemoryRouter>
+    <div>
+      <Route path="/:section?" component={RouterTabs} />
+    </div>
+  </MemoryRouter>
+);
+
+// This example demonstrates one way to use tabs with react-router in a way
+// that is compatible with server-side/universal rendering
+// NB in this example react-router does not directly control what content/panel is rendered
+// and on a mobile view the client will not jump to the content for the clicked title
+const RouterTabsSSR = ({
+  // eslint-disable-next-line react/prop-types
+  match: {
+    params: { section },
+  },
+}) => (
+  <Tabs>
+    <Tabs.Title />
+    <Tabs.List>
+      <Tabs.Tab as={Link} selected={!section} to="/">
+        First tab
+      </Tabs.Tab>
+      <Tabs.Tab as={Link} selected={section === 'test'} to="/test">
+        Second tab
+      </Tabs.Tab>
+    </Tabs.List>
+    <Tabs.Panel selected={!section}>First tab contents</Tabs.Panel>
+    <Tabs.Panel selected={section === 'test'}>Second tab contents</Tabs.Panel>
+  </Tabs>
+);
+
+const ReactRouterSSRExample = () => (
+  <MemoryRouter>
+    <div>
+      <Route path="/:section?" component={RouterTabsSSR} />
+    </div>
+  </MemoryRouter>
+);
+
+// This example demonstrates another way to use tabs with react-router in a way
+// that is compatible with server-side/universal rendering
+// NB in this example react-router controls what content is rendered, and thus
+// will only show a single panel, even when the screen is at a mobile width
+const RouterTabsSSRSinglePanel = ({
+  // eslint-disable-next-line react/prop-types
+  match: {
+    params: { section },
+  },
+}) => (
+  <Tabs>
+    <Tabs.Title />
+    <Tabs.List>
+      <Tabs.Tab as={Link} selected={!section} to="/">
+        First tab
+      </Tabs.Tab>
+      <Tabs.Tab as={Link} selected={section === 'test'} to="/test">
+        Second tab
+      </Tabs.Tab>
+    </Tabs.List>
+    <Route
+      path="/"
+      exact
+      render={() => (
+        <Tabs.Panel id="first" selected>
+          First tab contents
+        </Tabs.Panel>
+      )}
+    />
+    <Route
+      path="/test"
+      render={() => (
+        <Tabs.Panel id="test" selected>
+          Second tab contents
+        </Tabs.Panel>
+      )}
+    />
+  </Tabs>
+);
+
+const ReactRouterSSRSinglePanelExample = () => (
+  <MemoryRouter>
+    <div>
+      <Route path="/:section?" component={RouterTabsSSRSinglePanel} />
+    </div>
+  </MemoryRouter>
+);
+
+export {
+  HooksExample,
+  ProposedClassPropertiesPlugin,
+  SimpleTabs,
+  SimpleMapTabs,
+  TableTabs,
+  ReactRouterExample,
+  ReactRouterSSRExample,
+  ReactRouterSSRSinglePanelExample,
+};

--- a/components/tabs/src/stories.js
+++ b/components/tabs/src/stories.js
@@ -3,7 +3,16 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, number } from '@storybook/addon-knobs';
 import { withDocsCustom } from '@govuk-react/storybook-components';
 
-import { HooksExample, ProposedClassPropertiesPlugin, SimpleTabs, SimpleMapTabs, TableTabs } from './fixtures';
+import {
+  HooksExample,
+  ProposedClassPropertiesPlugin,
+  SimpleTabs,
+  SimpleMapTabs,
+  TableTabs,
+  ReactRouterExample,
+  ReactRouterSSRExample,
+  ReactRouterSSRSinglePanelExample,
+} from './fixtures';
 import ReadMe from '../README.md';
 
 const stories = storiesOf('Tabs', module);
@@ -24,3 +33,11 @@ examples.add("simple with map and babel's proposed class properties plugin", () 
 examples.add('complex mapped table', () => <TableTabs />);
 
 examples.add('hooks example', () => <HooksExample defaultIndex={number('defaultIndex', 1)} />);
+
+examples.add('using react-router (client-side)', () => <ReactRouterExample />);
+
+examples.add('using react-router (server-side rendering compatible)', () => <ReactRouterSSRExample />);
+
+examples.add('using react-router (server-side rendering compatible, single panel only)', () => (
+  <ReactRouterSSRSinglePanelExample />
+));

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "react-router-dom": "^5.0.0",
     "react-test-renderer": "^16.2.0",
     "react-testing-library": "^7.0.0",
+    "react-use-media": "^0.3.0",
     "rimraf": "^2.6.2",
     "sinon": "^7.3.0",
     "storybook-readme": "^5.0.1",


### PR DESCRIPTION
Includes a storybook example

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation  (Storybook example added)
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
