### PR TITLE
Reduce error summary heading size to match GDS

### DIFF
--- a/components/error-summary/src/__snapshots__/test.js.snap
+++ b/components/error-summary/src/__snapshots__/test.js.snap
@@ -7,11 +7,11 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
-  font-size: 24px;
-  line-height: 1.0416666666666667;
+  font-size: 18px;
+  line-height: 1.1111111111111112;
   display: block;
   margin-top: 0;
-  margin-bottom: 20px;
+  margin-bottom: 15px;
 }
 
 .c2 {
@@ -257,21 +257,21 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
 
 @media print {
   .c1 {
+    font-size: 18px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c1 {
     font-size: 24px;
-    line-height: 1.05;
+    line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c1 {
-    font-size: 36px;
-    line-height: 1.1111111111111112;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c1 {
-    margin-bottom: 30px;
+    margin-bottom: 20px;
   }
 }
 
@@ -508,17 +508,17 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
             className="c0"
             tabIndex={-1}
           >
-            <H2>
+            <H3>
               <Heading
-                as="h2"
-                size="LARGE"
+                as="h3"
+                size="MEDIUM"
               >
                 <styled.h1
-                  as="h2"
-                  size="LARGE"
+                  as="h3"
+                  size="MEDIUM"
                 >
                   <StyledComponent
-                    as="h2"
+                    as="h3"
                     forwardedComponent={
                       Object {
                         "$$typeof": Symbol(react.forward_ref),
@@ -548,18 +548,18 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
                       }
                     }
                     forwardedRef={null}
-                    size="LARGE"
+                    size="MEDIUM"
                   >
-                    <h2
+                    <h3
                       className="c1"
-                      size="LARGE"
+                      size="MEDIUM"
                     >
                       Message to alert the user to a problem goes here
-                    </h2>
+                    </h3>
                   </StyledComponent>
                 </styled.h1>
               </Heading>
-            </H2>
+            </H3>
             <Paragraph
               linkRenderer={[Function]}
               mb={3}

--- a/components/error-summary/src/index.js
+++ b/components/error-summary/src/index.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { TEXT_COLOUR, ERROR_COLOUR, FOCUS_COLOUR } from 'govuk-colours';
 
-import { H2 } from '@govuk-react/heading';
+import { H3 } from '@govuk-react/heading';
 import Paragraph from '@govuk-react/paragraph';
 import UnorderedList from '@govuk-react/unordered-list';
 import Link from '@govuk-react/link';
@@ -115,7 +115,7 @@ const StyledErrorSummary = styled('div')(
  */
 const ErrorSummary = ({ onHandleErrorClick, heading, description, errors, ...props }) => (
   <StyledErrorSummary tabIndex={-1} {...props}>
-    <H2>{heading}</H2>
+    <H3>{heading}</H3>
     {description && <Paragraph mb={3}>{description}</Paragraph>}
     {errors.length > 0 && (
       <UnorderedList mb={0} listStyleType="none">


### PR DESCRIPTION
GDS uses 24px for the error summary heading - see https://design-system.service.gov.uk/components/error-summary/.  At present error summary uses `H2` which by 36px instead.  This change reduces to `H3` which matches the GDS design.

* [ ] Documentation - N/A
* [x] Tests - Snapshot changed
* [x] Ready to be merged - Yes

Storybook pre change:
![storybook pre change](https://user-images.githubusercontent.com/5099053/54811927-c91b1c00-4c81-11e9-80dd-b7ade0495b79.png)

Storybook post change:
![storybook post change](https://user-images.githubusercontent.com/5099053/54812138-4d6d9f00-4c82-11e9-9c87-fbd3762097e9.png)

GDS Error Summary page:
![GDS error summary](https://user-images.githubusercontent.com/5099053/54811939-d0dac080-4c81-11e9-9bf2-e7e981a15263.png)