### PR TITLE
Default error summary heading to match GDS guidelines

### DIFF
--- a/components/error-summary/src/index.js
+++ b/components/error-summary/src/index.js
@@ -141,7 +141,7 @@ ErrorSummary.propTypes = {
   /** onClick function to scroll the target element into view */
   onHandleErrorClick: PropTypes.func,
   /** Heading text */
-  heading: PropTypes.string.isRequired,
+  heading: PropTypes.string,
   /** Optional description of the errors */
   description: PropTypes.string,
   /** Array of errors with text and target element name to scroll into view when clicked */
@@ -151,6 +151,10 @@ ErrorSummary.propTypes = {
       text: PropTypes.string,
     })
   ),
+};
+
+ErrorSummary.defaultProps = {
+  heading: 'There is a problem',
 };
 
 export default ErrorSummary;

--- a/components/error-summary/src/test.js
+++ b/components/error-summary/src/test.js
@@ -78,4 +78,9 @@ describe('error summary', () => {
   it('matches the ErrorSummary snapshot', () => {
     expect(wrapperErrorSummary).toMatchSnapshot('error summary');
   });
+
+  it('defaults the heading to "There is a problem" if not set', () => {
+    const wrapper = mount(<ErrorSummary errors={errors} />);
+    expect(wrapper.find('Heading').text()).toEqual('There is a problem');
+  });
 });


### PR DESCRIPTION
GDS guidelines on https://design-system.service.gov.uk/components/error-summary/ states that the heading must be ‘There is a problem’:
![error summary heading](https://user-images.githubusercontent.com/5099053/54818825-12736780-4c92-11e9-9c41-e0f57356a30e.png)

We should therefore default the heading to this value.

I haven't changed the docs for the component, since we do still allow the override.  Was thinking about something like:
>Optional message to alert the user to a problem goes here, defaulting to 'There is a problem'

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged
