### PR TITLE
Negative whitespace support

### DIFF
--- a/packages/hoc/src/withWhiteSpace/stories.js
+++ b/packages/hoc/src/withWhiteSpace/stories.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, number, object, text } from '@storybook/addon-knobs/react';
@@ -43,22 +43,25 @@ const DemoComponent = withWhiteSpace()(
 );
 
 stories.add('demo component, simple single margins and padding', () => (
-  <Fragment>
+  <div>
     <DemoComponent
-      margin={number('margin', 2, { range: true, min: 0, max: 9 })}
+      margin={number('margin', 2, { range: true, min: -9, max: 9 })}
       padding={number('padding', 2, { range: true, min: 0, max: 9 })}
     >
       Component with styles - use knobs to adjust
     </DemoComponent>
     <DemoComponent>Component without styles</DemoComponent>
-  </Fragment>
+  </div>
 ));
 
 stories.add('demo component, single margins and padding (complex)', () => (
-  <Fragment>
+  <div>
     <DemoComponent
+      // Use knobs for children content to kick knobs to life - storybook bug work-around
+      // eslint-disable-next-line react/no-children-prop
+      children={text('content', 'Component with styles - use knobs to adjust')}
       margin={{
-        size: number('margin.size', 2, { range: true, min: 0, max: 9 }),
+        size: number('margin.size', 2, { range: true, min: -9, max: 9 }),
         direction: text('margin.direction', 'all'),
         adjustment: number('margin.adjustment', undefined),
       }}
@@ -67,18 +70,16 @@ stories.add('demo component, single margins and padding (complex)', () => (
         direction: text('padding.direction', 'all'),
         adjustment: number('padding.adjustment', undefined),
       }}
-    >
-      Component with styles - use knobs to adjust
-    </DemoComponent>
+    />
     <DemoComponent>Component without styles</DemoComponent>
-  </Fragment>
+  </div>
 ));
 
 stories.add('demo component, multiple margins and padding (complex)', () => (
-  <Fragment>
+  <div>
     <DemoComponent
       margin={[
-        number('margin (all)', 2, { range: true, min: 0, max: 9 }),
+        number('margin (all)', 2, { range: true, min: -9, max: 9 }),
         object('margin (first object)', {
           size: 2,
           direction: 'bottom',
@@ -97,20 +98,20 @@ stories.add('demo component, multiple margins and padding (complex)', () => (
       Component with styles - use knobs to adjust
     </DemoComponent>
     <DemoComponent>Component without styles</DemoComponent>
-  </Fragment>
+  </div>
 ));
 
 stories.add('existing InputField with spacing size 1', () => (
-  <Fragment>
+  <div>
     <InputField mb={number('marginBottom', 1)} name="group1" hint="Change whitespace value with knobs">
       Example 1
     </InputField>
     <Button>Finish</Button>
-  </Fragment>
+  </div>
 ));
 
 stories.add('existing InputField with various spacing sizes', () => (
-  <Fragment>
+  <div>
     <InputField mb={number('marginBottom1', 1)} name="group1" hint="hi">
       Example 1
     </InputField>
@@ -124,11 +125,11 @@ stories.add('existing InputField with various spacing sizes', () => (
       Example 4
     </InputField>
     <Button>Finish</Button>
-  </Fragment>
+  </div>
 ));
 
 stories.add('multiple existing components', () => (
-  <Fragment>
+  <div>
     <BackLink mb={number('BackLink marginBottom', 9)}>Example</BackLink>
     <Breadcrumb mb={number('Breadcrumb marginBottom', 9)}>Example</Breadcrumb>
     <Button mb={number('Button marginBottom', 9)}>Example</Button>
@@ -164,5 +165,5 @@ stories.add('multiple existing components', () => (
     <Tag mb={number('Tag marginBottom', 9)}>Tag</Tag>
     <TextArea mb={number('TextArea marginBottom', 9)}>TextArea Example</TextArea>
     <UnorderedList mb={number('UnorderedList marginBottom', 9)}>UnorderedList Example</UnorderedList>
-  </Fragment>
+  </div>
 ));

--- a/packages/hoc/src/withWhiteSpace/stories.js
+++ b/packages/hoc/src/withWhiteSpace/stories.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, number, object, text } from '@storybook/addon-knobs/react';
 
 import BackLink from '@govuk-react/back-link';
-import Breadcrumb from '@govuk-react/breadcrumb';
+import Breadcrumbs from '@govuk-react/breadcrumb';
 import Button from '@govuk-react/button';
 import Checkbox from '@govuk-react/checkbox';
 import DateField from '@govuk-react/date-field';
@@ -131,7 +131,7 @@ stories.add('existing InputField with various spacing sizes', () => (
 stories.add('multiple existing components', () => (
   <div>
     <BackLink mb={number('BackLink marginBottom', 9)}>Example</BackLink>
-    <Breadcrumb mb={number('Breadcrumb marginBottom', 9)}>Example</Breadcrumb>
+    <Breadcrumbs mb={number('Breadcrumbs marginBottom', 9)}>Example</Breadcrumbs>
     <Button mb={number('Button marginBottom', 9)}>Example</Button>
     <Checkbox mb={number('Checkbox marginBottom', 9)}>Example</Checkbox>
     <DateField mb={number('DateField marginBottom', 9)}>Example</DateField>

--- a/packages/lib/src/spacing/index.js
+++ b/packages/lib/src/spacing/index.js
@@ -9,13 +9,14 @@ import PropTypes from 'prop-types';
 import { MEDIA_QUERIES, SPACING_MAP, SPACING_MAP_INDEX, SPACING_POINTS, WIDTHS } from '@govuk-react/constants';
 
 export function simple(size) {
-  const scale = SPACING_POINTS[size];
+  const scale = SPACING_POINTS[Math.abs(size)];
+  const polarity = size < 0 ? -1 : 1;
 
   if (scale === undefined) {
     throw Error(`Unknown spacing size ${size} - expected a point from the spacing scale.`);
   }
 
-  return scale;
+  return scale * polarity;
 }
 
 function styleForDirection(size, property, direction) {
@@ -26,7 +27,8 @@ function styleForDirection(size, property, direction) {
 }
 
 export function responsive({ size, property, direction, adjustment = 0 } = {}) {
-  const scale = SPACING_MAP[size];
+  const scale = SPACING_MAP[Math.abs(size)];
+  const polarity = size < 0 ? -1 : 1;
 
   if (scale === undefined) {
     throw Error(`Unknown responsive spacing size ${size} - expected a point from the responsive spacing scale.`);
@@ -40,16 +42,20 @@ export function responsive({ size, property, direction, adjustment = 0 } = {}) {
   // TODO consider supporting non-number (string) adjustments, such as px or rem values
 
   if (Array.isArray(direction)) {
-    return Object.assign({}, ...direction.map(dir => styleForDirection(scale.mobile + adjustment, property, dir)), {
-      [MEDIA_QUERIES.TABLET]: Object.assign(
-        {},
-        ...direction.map(dir => styleForDirection(scale.tablet + adjustment, property, dir))
-      ),
-    });
+    return Object.assign(
+      {},
+      ...direction.map(dir => styleForDirection(scale.mobile * polarity + adjustment, property, dir)),
+      {
+        [MEDIA_QUERIES.TABLET]: Object.assign(
+          {},
+          ...direction.map(dir => styleForDirection(scale.tablet * polarity + adjustment, property, dir))
+        ),
+      }
+    );
   }
 
-  return Object.assign({}, styleForDirection(scale.mobile + adjustment, property, direction), {
-    [MEDIA_QUERIES.TABLET]: styleForDirection(scale.tablet + adjustment, property, direction),
+  return Object.assign({}, styleForDirection(scale.mobile * polarity + adjustment, property, direction), {
+    [MEDIA_QUERIES.TABLET]: styleForDirection(scale.tablet * polarity + adjustment, property, direction),
   });
 }
 

--- a/packages/lib/src/spacing/test.js
+++ b/packages/lib/src/spacing/test.js
@@ -10,6 +10,15 @@ describe('spacing lib', () => {
       });
     });
 
+    it('returns negative spacing values from the spacing scale', () => {
+      Object.keys(SPACING_POINTS).forEach(key => {
+        // skip zero, as -0 !== 0 in JS
+        if (`${key}` !== '0') {
+          expect(spacing.simple(-key)).toEqual(-SPACING_POINTS[key]);
+        }
+      });
+    });
+
     it('throws when not given a size', () => {
       expect(() => spacing.simple()).toThrow();
     });
@@ -27,6 +36,18 @@ describe('spacing lib', () => {
 
         expect(style).toEqual(expect.objectContaining({ test: SPACING_MAP[size].mobile }));
         expect(style[MEDIA_QUERIES.TABLET]).toEqual(expect.objectContaining({ test: SPACING_MAP[size].tablet }));
+      });
+    });
+
+    it('returns negative spacing styles for given sizes on the spacing scale', () => {
+      SPACING_MAP_INDEX.forEach(size => {
+        // skip zero, as -0 !== 0 in JS
+        if (size !== 0) {
+          const style = spacing.responsive({ size: -size, property: 'test' });
+
+          expect(style).toEqual(expect.objectContaining({ test: -SPACING_MAP[size].mobile }));
+          expect(style[MEDIA_QUERIES.TABLET]).toEqual(expect.objectContaining({ test: -SPACING_MAP[size].tablet }));
+        }
       });
     });
 


### PR DESCRIPTION
it's now possible to provide negative whitespace sizes

also fixes `withWhiteSpace` stories rendering in chromatic by wrapping story items in a `div` rather than `Fragment`

Addresses half of #610

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation (via storybook examples)
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
