### PR TITLE
Reduce error summary heading size to match GDS

### DIFF
--- a/components/error-summary/src/__snapshots__/test.js.snap
+++ b/components/error-summary/src/__snapshots__/test.js.snap
@@ -7,11 +7,11 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
-  font-size: 24px;
-  line-height: 1.0416666666666667;
+  font-size: 18px;
+  line-height: 1.1111111111111112;
   display: block;
   margin-top: 0;
-  margin-bottom: 20px;
+  margin-bottom: 15px;
 }
 
 .c2 {
@@ -257,21 +257,21 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
 
 @media print {
   .c1 {
+    font-size: 18px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c1 {
     font-size: 24px;
-    line-height: 1.05;
+    line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c1 {
-    font-size: 36px;
-    line-height: 1.1111111111111112;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c1 {
-    margin-bottom: 30px;
+    margin-bottom: 20px;
   }
 }
 
@@ -508,14 +508,16 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
             className="c0"
             tabIndex={-1}
           >
-            <H2>
+            <H2
+              size="MEDIUM"
+            >
               <Heading
                 as="h2"
-                size="LARGE"
+                size="MEDIUM"
               >
                 <styled.h1
                   as="h2"
-                  size="LARGE"
+                  size="MEDIUM"
                 >
                   <StyledComponent
                     as="h2"
@@ -548,11 +550,11 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
                       }
                     }
                     forwardedRef={null}
-                    size="LARGE"
+                    size="MEDIUM"
                   >
                     <h2
                       className="c1"
-                      size="LARGE"
+                      size="MEDIUM"
                     >
                       Message to alert the user to a problem goes here
                     </h2>

--- a/components/error-summary/src/index.js
+++ b/components/error-summary/src/index.js
@@ -115,7 +115,7 @@ const StyledErrorSummary = styled('div')(
  */
 const ErrorSummary = ({ onHandleErrorClick, heading, description, errors, ...props }) => (
   <StyledErrorSummary tabIndex={-1} {...props}>
-    <H2>{heading}</H2>
+    <H2 size="MEDIUM">{heading}</H2>
     {description && <Paragraph mb={3}>{description}</Paragraph>}
     {errors.length > 0 && (
       <UnorderedList mb={0} listStyleType="none">


### PR DESCRIPTION
GDS uses 24px for the error summary heading - see https://design-system.service.gov.uk/components/error-summary/.  At present error summary uses `H2` which brings in size `LARGE` of 36px instead.  This change reduces the size to `MEDIUM` which matches the GDS design.

* [ ] Documentation - N/A
* [x] Tests - Snapshot changed
* [x] Ready to be merged - Yes

Storybook pre change:
![storybook pre change](https://user-images.githubusercontent.com/5099053/54811927-c91b1c00-4c81-11e9-80dd-b7ade0495b79.png)

Storybook post change:
![storybook post change h2 medium](https://user-images.githubusercontent.com/5099053/54908221-4d1e0f80-4edf-11e9-95f0-9105166c62a7.png)

GDS Error Summary page:
![GDS error summary](https://user-images.githubusercontent.com/5099053/54811939-d0dac080-4c81-11e9-9bf2-e7e981a15263.png)

Note that the font size reduction was originally attempted in https://github.com/govuk-react/govuk-react/pull/634 by switching from `H2` to `H3`, but I have subsequently discovered (thanks @jsrobertson) that a `size` can be applied to a heading element so have done that instead.