### PR TITLE
Add skip-link to page

### DIFF
--- a/API.md
+++ b/API.md
@@ -450,10 +450,10 @@ const onHandleErrorClick = (targetName) => {
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `description` |  | ```undefined``` | string | Optional description of the errors
- `errors` |  | ```[]``` | arrayOf[object Object] | Array of errors with text and target element name to scroll into view when clicked
- `heading` | true | `````` | string | Heading text
- `onHandleErrorClick` |  | ```() => {}``` | func | onClick function to scroll the target element into view
+ `description` |  | `````` | string | Optional description of the errors
+ `errors` |  | `````` | arrayOf[object Object] | Array of errors with text and target element name to scroll into view when clicked
+ `heading` |  | ```'There is a problem'``` | string | Heading text
+ `onHandleErrorClick` |  | `````` | func | onClick function to scroll the target element into view
 
 
 ErrorText
@@ -1407,6 +1407,7 @@ Prop | Required | Default | Type | Description
  `container` |  | ```Page.WidthContainer``` | func | Override the default page container component.<br/>`beforeChildren` and `children` (wrapped in `main`) will be placed inside this component.
  `footer` |  | ```undefined``` | node | Override the default page footer component.
  `header` |  | ```<TopNav />``` | node | Override the default page header component.
+ `id` |  | ```'content'``` | string | ID for page content
  `main` |  | ```Page.Main``` | func | Override the default wrapper component for main page content
 
 
@@ -1889,7 +1890,7 @@ Simple
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true | `````` | node | 
+ `children` |  | ```'Skip to main content'``` | node | 
  `href` |  | ```'#content'``` | string | 
 
 

--- a/components/error-summary/README.md
+++ b/components/error-summary/README.md
@@ -56,9 +56,9 @@ const onHandleErrorClick = (targetName) => {
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `description` |  | ```undefined``` | string | Optional description of the errors
- `errors` |  | ```[]``` | arrayOf[object Object] | Array of errors with text and target element name to scroll into view when clicked
- `heading` | true | `````` | string | Heading text
- `onHandleErrorClick` |  | ```() => {}``` | func | onClick function to scroll the target element into view
+ `description` |  | `````` | string | Optional description of the errors
+ `errors` |  | `````` | arrayOf[object Object] | Array of errors with text and target element name to scroll into view when clicked
+ `heading` |  | ```'There is a problem'``` | string | Heading text
+ `onHandleErrorClick` |  | `````` | func | onClick function to scroll the target element into view
 
 

--- a/components/page/README.md
+++ b/components/page/README.md
@@ -33,6 +33,7 @@ Prop | Required | Default | Type | Description
  `container` |  | ```Page.WidthContainer``` | func | Override the default page container component.<br/>`beforeChildren` and `children` (wrapped in `main`) will be placed inside this component.
  `footer` |  | ```undefined``` | node | Override the default page footer component.
  `header` |  | ```<TopNav />``` | node | Override the default page header component.
+ `id` |  | ```'content'``` | string | ID for page content
  `main` |  | ```Page.Main``` | func | Override the default wrapper component for main page content
 
 

--- a/components/page/package.json
+++ b/components/page/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.0",
     "@govuk-react/lib": "^0.7.0",
+    "@govuk-react/skip-link": "^0.7.0",
     "@govuk-react/top-nav": "^0.7.0"
   },
   "peerDependencies": {

--- a/components/page/src/index.js
+++ b/components/page/src/index.js
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import SkipLink from '@govuk-react/skip-link';
 import TopNav from '@govuk-react/top-nav';
 // import Footer from '@govuk-react/footer';
 
@@ -32,12 +33,13 @@ import WidthContainer from './atoms/width-container';
  * - https://github.com/alphagov/govuk-frontend/blob/master/src/objects/_main-wrapper.scss
  * - https://github.com/alphagov/govuk-frontend/blob/master/src/objects/_width-container.scss
  */
-const Page = ({ header, footer, children, beforeChildren, main: MainComponent, container: Container }) => (
+const Page = ({ header, footer, children, id, beforeChildren, main: MainComponent, container: Container }) => (
   <React.Fragment>
+    <SkipLink href={`#${id}`} />
     {header}
     <Container>
       {beforeChildren}
-      <MainComponent>{children}</MainComponent>
+      <MainComponent id={id}>{children}</MainComponent>
     </Container>
     {footer}
   </React.Fragment>
@@ -48,6 +50,10 @@ Page.propTypes = {
    * Page contents
    */
   children: PropTypes.node,
+  /**
+   * ID for page content
+   */
+  id: PropTypes.string,
   /**
    * Override the default page header component.
    */
@@ -77,6 +83,7 @@ Page.WidthContainer = WidthContainer;
 
 Page.defaultProps = {
   children: undefined,
+  id: 'content',
   header: <TopNav />,
   footer: undefined, // <Footer />, // TODO: add Footer component once built
   main: Page.Main,

--- a/components/skip-link/README.md
+++ b/components/skip-link/README.md
@@ -23,7 +23,7 @@ Simple
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true | `````` | node | 
+ `children` |  | ```'Skip to main content'``` | node | 
  `href` |  | ```'#content'``` | string | 
 
 

--- a/components/skip-link/src/__snapshots__/test.js.snap
+++ b/components/skip-link/src/__snapshots__/test.js.snap
@@ -128,6 +128,7 @@ exports[`SkipLink matches snapshot: SkipLink 1`] = `
             ],
           },
           "defaultProps": Object {
+            "children": "Skip to main content",
             "href": "#content",
           },
           "displayName": "styled.a",

--- a/components/skip-link/src/index.js
+++ b/components/skip-link/src/index.js
@@ -36,6 +36,7 @@ SkipLinkDocumented.propTypes = {
 };
 
 SkipLinkDocumented.defaultProps = {
+  children: 'Skip to main content',
   href: '#content',
 };
 


### PR DESCRIPTION
`Page` now includes a `SkipLink`, and will accept an `id` which will be applied to the `main` page contents wrapper.

`SkipLink` now defaults contents

Closes #600 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
