### PR TITLE
revert lerna version

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "jest": "^24.4.0",
     "jest-styled-components": "^6.3.1",
     "jest-transform-stub": "^2.0.0",
-    "lerna": "~3.13.1",
+    "lerna": "2.11",
     "mkdirp-promise": "^5.0.1",
     "prettier": "^1.16.4",
     "prop-types": "^15.6.0",


### PR DESCRIPTION
Lerna was updated when greenkeeper was installed - but should be kept on v2
