### PR TITLE
Footer component updates

### DIFF
--- a/API.md
+++ b/API.md
@@ -622,7 +622,7 @@ import { Link } from 'react-router-dom';
 
 <Footer>
   <Footer.Navigation>
-    <Footer.NavigationLinks heading="Two column list" listColumns="2">
+    <Footer.NavigationLinks heading="Two column list" listColumns={2}>
       <Footer.Link href="/">Navigation item 1</Footer.Link>
       <Footer.Link to="/footer-nav-item-2" as={Link}>Navigation item 2 (Router Link)</Footer.Link>
       <Footer.Link href="/">Navigation item 3</Footer.Link>

--- a/components/footer/README.md
+++ b/components/footer/README.md
@@ -39,7 +39,7 @@ import { Link } from 'react-router-dom';
 
 <Footer>
   <Footer.Navigation>
-    <Footer.NavigationLinks heading="Two column list" listColumns="2">
+    <Footer.NavigationLinks heading="Two column list" listColumns={2}>
       <Footer.Link href="/">Navigation item 1</Footer.Link>
       <Footer.Link to="/footer-nav-item-2" as={Link}>Navigation item 2 (Router Link)</Footer.Link>
       <Footer.Link href="/">Navigation item 3</Footer.Link>

--- a/components/footer/src/__snapshots__/test.js.snap
+++ b/components/footer/src/__snapshots__/test.js.snap
@@ -1503,33 +1503,33 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
   margin: 0 15px;
 }
 
-.c5 {
+.c6 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-.c5:link {
+.c6:link {
   color: #005ea5;
 }
 
-.c5:visited {
+.c6:visited {
   color: #4c2c92;
 }
 
-.c5:hover {
+.c6:hover {
   color: #2b8cc4;
 }
 
-.c5:active {
+.c6:active {
   color: #2b8cc4;
 }
 
-.c5:focus {
+.c6:focus {
   color: #0b0c0c;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 3px solid #ffbf47;
   outline-offset: 0;
   background-color: #ffbf47;
@@ -1583,14 +1583,14 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
   flex-basis: 320px;
 }
 
-.c6 {
+.c7 {
   display: inline-block;
   margin-right: 10px;
   margin-bottom: 15px;
   vertical-align: top;
 }
 
-.c7 {
+.c8 {
   display: inline-block;
 }
 
@@ -1621,15 +1621,15 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
 }
 
 @media print {
-  .c5 {
+  .c6 {
     font-family: sans-serif;
   }
 }
 
 @media print {
-  .c5[href^="/"]::after,
-  .c5[href^="http://"]::after,
-  .c5[href^="https://"]::after {
+  .c6[href^="/"]::after,
+  .c6[href^="http://"]::after,
+  .c6[href^="https://"]::after {
     content: " (" attr(href) ")";
     font-size: 90%;
     word-wrap: break-word;
@@ -1651,7 +1651,7 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
 }
 
 @media only screen and (min-width:769px) {
-  .c6 {
+  .c7 {
     margin-bottom: 0;
   }
 }
@@ -1900,11 +1900,8 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
                                     <FooterLink
                                       href="/"
                                     >
-                                      <Styled(styled.a)
+                                      <Styled(LinkDocumented)
                                         href="/"
-                                        muted={false}
-                                        noVisitedState={false}
-                                        textColour={false}
                                       >
                                         <StyledComponent
                                           forwardedComponent={
@@ -1913,13 +1910,58 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
                                               "attrs": Array [],
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "sc-bxivhb",
-                                                "isStatic": false,
+                                                "isStatic": true,
                                                 "lastClassName": "c5",
                                                 "rules": Array [
-                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                  ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                ],
+                                              },
+                                              "displayName": "Styled(LinkDocumented)",
+                                              "foldedComponentIds": Array [],
+                                              "render": [Function],
+                                              "styledComponentId": "sc-bxivhb",
+                                              "target": [Function],
+                                              "toString": [Function],
+                                              "warnTooManyClasses": [Function],
+                                              "withComponent": [Function],
+                                            }
+                                          }
+                                          forwardedRef={null}
+                                          href="/"
+                                        >
+                                          <LinkDocumented
+                                            className="c5"
+                                            href="/"
+                                            muted={false}
+                                            noVisitedState={false}
+                                            textColour={false}
+                                          >
+                                            <styled.a
+                                              className="c5"
+                                              href="/"
+                                              muted={false}
+                                              noVisitedState={false}
+                                              textColour={false}
+                                            >
+                                              <StyledComponent
+                                                className="c5"
+                                                forwardedComponent={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "attrs": Array [],
+                                                    "componentStyle": ComponentStyle {
+                                                      "componentId": "sc-htpNat",
+                                                      "isStatic": false,
+                                                      "lastClassName": "c6",
+                                                      "rules": Array [
+                                                        "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                  ":link {
+                                                        ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -1930,59 +1972,55 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
 } :focus {
   color: #0b0c0c;
 }",
-                                                  "&:focus {
+                                                        "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                  "@media print {
+                                                        "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                ],
-                                              },
-                                              "defaultProps": Object {
-                                                "muted": false,
-                                                "noVisitedState": false,
-                                                "textColour": false,
-                                              },
-                                              "displayName": "Styled(styled.a)",
-                                              "foldedComponentIds": Array [
-                                                "sc-htpNat",
-                                              ],
-                                              "propTypes": undefined,
-                                              "render": [Function],
-                                              "styledComponentId": "sc-bxivhb",
-                                              "target": "a",
-                                              "toString": [Function],
-                                              "warnTooManyClasses": [Function],
-                                              "withComponent": [Function],
-                                            }
-                                          }
-                                          forwardedRef={null}
-                                          href="/"
-                                          muted={false}
-                                          noVisitedState={false}
-                                          textColour={false}
-                                        >
-                                          <a
-                                            className="c5"
-                                            href="/"
-                                            muted={false}
-                                          >
-                                            Government Digital Service
-                                          </a>
+                                                        [Function],
+                                                        [Function],
+                                                        [Function],
+                                                      ],
+                                                    },
+                                                    "defaultProps": Object {
+                                                      "muted": false,
+                                                      "noVisitedState": false,
+                                                      "textColour": false,
+                                                    },
+                                                    "displayName": "styled.a",
+                                                    "foldedComponentIds": Array [],
+                                                    "propTypes": undefined,
+                                                    "render": [Function],
+                                                    "styledComponentId": "sc-htpNat",
+                                                    "target": "a",
+                                                    "toString": [Function],
+                                                    "warnTooManyClasses": [Function],
+                                                    "withComponent": [Function],
+                                                  }
+                                                }
+                                                forwardedRef={null}
+                                                href="/"
+                                                muted={false}
+                                                noVisitedState={false}
+                                                textColour={false}
+                                              >
+                                                <a
+                                                  className="c5 c6"
+                                                  href="/"
+                                                  muted={false}
+                                                >
+                                                  Government Digital Service
+                                                </a>
+                                              </StyledComponent>
+                                            </styled.a>
+                                          </LinkDocumented>
                                         </StyledComponent>
-                                      </Styled(styled.a)>
+                                      </Styled(LinkDocumented)>
                                     </FooterLink>
                                   </div>
                                 </StyledComponent>
@@ -2006,7 +2044,7 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-htoDjs",
                                             "isStatic": true,
-                                            "lastClassName": "c6",
+                                            "lastClassName": "c7",
                                             "rules": Array [
                                               "display: inline-block; margin-right: 10px; margin-bottom: 15px; vertical-align: top; @media only screen and (min-width: 769px) {
   margin-bottom: 0;
@@ -2031,7 +2069,7 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
                                       <svg
-                                        className="c6"
+                                        className="c7"
                                         focusable="false"
                                         height="17"
                                         role="presentation"
@@ -2055,7 +2093,7 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-dnqmqq",
                                             "isStatic": true,
-                                            "lastClassName": "c7",
+                                            "lastClassName": "c8",
                                             "rules": Array [
                                               "display: inline-block;",
                                             ],
@@ -2073,7 +2111,7 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
                                       forwardedRef={null}
                                     >
                                       <span
-                                        className="c7"
+                                        className="c8"
                                       >
                                         All content is available under the Open Government Licence v3.0, except where otherwise stated
                                       </span>
@@ -2104,33 +2142,33 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
   margin: 0 15px;
 }
 
-.c8 {
+.c9 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-.c8:link {
+.c9:link {
   color: #005ea5;
 }
 
-.c8:visited {
+.c9:visited {
   color: #4c2c92;
 }
 
-.c8:hover {
+.c9:hover {
   color: #2b8cc4;
 }
 
-.c8:active {
+.c9:active {
   color: #2b8cc4;
 }
 
-.c8:focus {
+.c9:focus {
   color: #0b0c0c;
 }
 
-.c8:focus {
+.c9:focus {
   outline: 3px solid #ffbf47;
   outline-offset: 0;
   background-color: #ffbf47;
@@ -2145,7 +2183,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
   color: #171819;
 }
 
-.c9 {
+.c10 {
   margin-bottom: 20px;
 }
 
@@ -2184,14 +2222,14 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
   flex-basis: 320px;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   margin-right: 10px;
   margin-bottom: 15px;
   vertical-align: top;
 }
 
-.c11 {
+.c12 {
   display: inline-block;
 }
 
@@ -2266,15 +2304,15 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
 }
 
 @media print {
-  .c8 {
+  .c9 {
     font-family: sans-serif;
   }
 }
 
 @media print {
-  .c8[href^="/"]::after,
-  .c8[href^="http://"]::after,
-  .c8[href^="https://"]::after {
+  .c9[href^="/"]::after,
+  .c9[href^="http://"]::after,
+  .c9[href^="https://"]::after {
     content: " (" attr(href) ")";
     font-size: 90%;
     word-wrap: break-word;
@@ -2296,7 +2334,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
 }
 
 @media only screen and (min-width:769px) {
-  .c10 {
+  .c11 {
     margin-bottom: 0;
   }
 }
@@ -2769,11 +2807,8 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                                 <FooterLink
                                                   href="/"
                                                 >
-                                                  <Styled(styled.a)
+                                                  <Styled(LinkDocumented)
                                                     href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
                                                   >
                                                     <StyledComponent
                                                       forwardedComponent={
@@ -2782,13 +2817,58 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                                           "attrs": Array [],
                                                           "componentStyle": ComponentStyle {
                                                             "componentId": "sc-bxivhb",
-                                                            "isStatic": false,
+                                                            "isStatic": true,
                                                             "lastClassName": "c8",
                                                             "rules": Array [
-                                                              "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                              ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                            ],
+                                                          },
+                                                          "displayName": "Styled(LinkDocumented)",
+                                                          "foldedComponentIds": Array [],
+                                                          "render": [Function],
+                                                          "styledComponentId": "sc-bxivhb",
+                                                          "target": [Function],
+                                                          "toString": [Function],
+                                                          "warnTooManyClasses": [Function],
+                                                          "withComponent": [Function],
+                                                        }
+                                                      }
+                                                      forwardedRef={null}
+                                                      href="/"
+                                                    >
+                                                      <LinkDocumented
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <styled.a
+                                                          className="c8"
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <StyledComponent
+                                                            className="c8"
+                                                            forwardedComponent={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "attrs": Array [],
+                                                                "componentStyle": ComponentStyle {
+                                                                  "componentId": "sc-htpNat",
+                                                                  "isStatic": false,
+                                                                  "lastClassName": "c9",
+                                                                  "rules": Array [
+                                                                    "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                              ":link {
+                                                                    ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -2799,59 +2879,55 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
 } :focus {
   color: #0b0c0c;
 }",
-                                                              "&:focus {
+                                                                    "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                              "@media print {
+                                                                    "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                              [Function],
-                                                              [Function],
-                                                              [Function],
-                                                              ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                            ],
-                                                          },
-                                                          "defaultProps": Object {
-                                                            "muted": false,
-                                                            "noVisitedState": false,
-                                                            "textColour": false,
-                                                          },
-                                                          "displayName": "Styled(styled.a)",
-                                                          "foldedComponentIds": Array [
-                                                            "sc-htpNat",
-                                                          ],
-                                                          "propTypes": undefined,
-                                                          "render": [Function],
-                                                          "styledComponentId": "sc-bxivhb",
-                                                          "target": "a",
-                                                          "toString": [Function],
-                                                          "warnTooManyClasses": [Function],
-                                                          "withComponent": [Function],
-                                                        }
-                                                      }
-                                                      forwardedRef={null}
-                                                      href="/"
-                                                      muted={false}
-                                                      noVisitedState={false}
-                                                      textColour={false}
-                                                    >
-                                                      <a
-                                                        className="c8"
-                                                        href="/"
-                                                        muted={false}
-                                                      >
-                                                        Item 1
-                                                      </a>
+                                                                    [Function],
+                                                                    [Function],
+                                                                    [Function],
+                                                                  ],
+                                                                },
+                                                                "defaultProps": Object {
+                                                                  "muted": false,
+                                                                  "noVisitedState": false,
+                                                                  "textColour": false,
+                                                                },
+                                                                "displayName": "styled.a",
+                                                                "foldedComponentIds": Array [],
+                                                                "propTypes": undefined,
+                                                                "render": [Function],
+                                                                "styledComponentId": "sc-htpNat",
+                                                                "target": "a",
+                                                                "toString": [Function],
+                                                                "warnTooManyClasses": [Function],
+                                                                "withComponent": [Function],
+                                                              }
+                                                            }
+                                                            forwardedRef={null}
+                                                            href="/"
+                                                            muted={false}
+                                                            noVisitedState={false}
+                                                            textColour={false}
+                                                          >
+                                                            <a
+                                                              className="c8 c9"
+                                                              href="/"
+                                                              muted={false}
+                                                            >
+                                                              Item 1
+                                                            </a>
+                                                          </StyledComponent>
+                                                        </styled.a>
+                                                      </LinkDocumented>
                                                     </StyledComponent>
-                                                  </Styled(styled.a)>
+                                                  </Styled(LinkDocumented)>
                                                 </FooterLink>
                                               </li>
                                             </StyledComponent>
@@ -2902,11 +2978,8 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                                   as={[Function]}
                                                   to="/footer-meta-item-2"
                                                 >
-                                                  <Styled(styled.a)
+                                                  <Styled(LinkDocumented)
                                                     as={[Function]}
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
                                                     to="/footer-meta-item-2"
                                                   >
                                                     <StyledComponent
@@ -2917,36 +2990,9 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                                           "attrs": Array [],
                                                           "componentStyle": ComponentStyle {
                                                             "componentId": "sc-bxivhb",
-                                                            "isStatic": false,
+                                                            "isStatic": true,
                                                             "lastClassName": "c8",
                                                             "rules": Array [
-                                                              "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
-  font-family: sans-serif;
-}",
-                                                              ":link {
-  color: #005ea5;
-} :visited {
-  color: #4c2c92;
-} :hover {
-  color: #2b8cc4;
-} :active {
-  color: #2b8cc4;
-} :focus {
-  color: #0b0c0c;
-}",
-                                                              "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
-}",
-                                                              "@media print {
-  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
-  &::after {
-  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
-}
-}
-}",
-                                                              [Function],
-                                                              [Function],
-                                                              [Function],
                                                               ":link, :visited {
   color: #454a4c;
 } :hover {
@@ -2954,50 +3000,33 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
 }",
                                                             ],
                                                           },
-                                                          "defaultProps": Object {
-                                                            "muted": false,
-                                                            "noVisitedState": false,
-                                                            "textColour": false,
-                                                          },
-                                                          "displayName": "Styled(styled.a)",
-                                                          "foldedComponentIds": Array [
-                                                            "sc-htpNat",
-                                                          ],
-                                                          "propTypes": undefined,
+                                                          "displayName": "Styled(LinkDocumented)",
+                                                          "foldedComponentIds": Array [],
                                                           "render": [Function],
                                                           "styledComponentId": "sc-bxivhb",
-                                                          "target": "a",
+                                                          "target": [Function],
                                                           "toString": [Function],
                                                           "warnTooManyClasses": [Function],
                                                           "withComponent": [Function],
                                                         }
                                                       }
                                                       forwardedRef={null}
-                                                      muted={false}
-                                                      noVisitedState={false}
-                                                      textColour={false}
                                                       to="/footer-meta-item-2"
                                                     >
                                                       <Link
                                                         className="c8"
-                                                        muted={false}
-                                                        noVisitedState={false}
-                                                        textColour={false}
                                                         to="/footer-meta-item-2"
                                                       >
                                                         <a
                                                           className="c8"
                                                           href="/footer-meta-item-2"
-                                                          muted={false}
-                                                          noVisitedState={false}
                                                           onClick={[Function]}
-                                                          textColour={false}
                                                         >
                                                           Item 2 (Router Link)
                                                         </a>
                                                       </Link>
                                                     </StyledComponent>
-                                                  </Styled(styled.a)>
+                                                  </Styled(LinkDocumented)>
                                                 </FooterLink>
                                               </li>
                                             </StyledComponent>
@@ -3047,11 +3076,8 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                                 <FooterLink
                                                   href="/"
                                                 >
-                                                  <Styled(styled.a)
+                                                  <Styled(LinkDocumented)
                                                     href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
                                                   >
                                                     <StyledComponent
                                                       forwardedComponent={
@@ -3060,13 +3086,58 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                                           "attrs": Array [],
                                                           "componentStyle": ComponentStyle {
                                                             "componentId": "sc-bxivhb",
-                                                            "isStatic": false,
+                                                            "isStatic": true,
                                                             "lastClassName": "c8",
                                                             "rules": Array [
-                                                              "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                              ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                            ],
+                                                          },
+                                                          "displayName": "Styled(LinkDocumented)",
+                                                          "foldedComponentIds": Array [],
+                                                          "render": [Function],
+                                                          "styledComponentId": "sc-bxivhb",
+                                                          "target": [Function],
+                                                          "toString": [Function],
+                                                          "warnTooManyClasses": [Function],
+                                                          "withComponent": [Function],
+                                                        }
+                                                      }
+                                                      forwardedRef={null}
+                                                      href="/"
+                                                    >
+                                                      <LinkDocumented
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <styled.a
+                                                          className="c8"
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <StyledComponent
+                                                            className="c8"
+                                                            forwardedComponent={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "attrs": Array [],
+                                                                "componentStyle": ComponentStyle {
+                                                                  "componentId": "sc-htpNat",
+                                                                  "isStatic": false,
+                                                                  "lastClassName": "c9",
+                                                                  "rules": Array [
+                                                                    "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                              ":link {
+                                                                    ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -3077,59 +3148,55 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
 } :focus {
   color: #0b0c0c;
 }",
-                                                              "&:focus {
+                                                                    "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                              "@media print {
+                                                                    "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                              [Function],
-                                                              [Function],
-                                                              [Function],
-                                                              ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                            ],
-                                                          },
-                                                          "defaultProps": Object {
-                                                            "muted": false,
-                                                            "noVisitedState": false,
-                                                            "textColour": false,
-                                                          },
-                                                          "displayName": "Styled(styled.a)",
-                                                          "foldedComponentIds": Array [
-                                                            "sc-htpNat",
-                                                          ],
-                                                          "propTypes": undefined,
-                                                          "render": [Function],
-                                                          "styledComponentId": "sc-bxivhb",
-                                                          "target": "a",
-                                                          "toString": [Function],
-                                                          "warnTooManyClasses": [Function],
-                                                          "withComponent": [Function],
-                                                        }
-                                                      }
-                                                      forwardedRef={null}
-                                                      href="/"
-                                                      muted={false}
-                                                      noVisitedState={false}
-                                                      textColour={false}
-                                                    >
-                                                      <a
-                                                        className="c8"
-                                                        href="/"
-                                                        muted={false}
-                                                      >
-                                                        Item 3
-                                                      </a>
+                                                                    [Function],
+                                                                    [Function],
+                                                                    [Function],
+                                                                  ],
+                                                                },
+                                                                "defaultProps": Object {
+                                                                  "muted": false,
+                                                                  "noVisitedState": false,
+                                                                  "textColour": false,
+                                                                },
+                                                                "displayName": "styled.a",
+                                                                "foldedComponentIds": Array [],
+                                                                "propTypes": undefined,
+                                                                "render": [Function],
+                                                                "styledComponentId": "sc-htpNat",
+                                                                "target": "a",
+                                                                "toString": [Function],
+                                                                "warnTooManyClasses": [Function],
+                                                                "withComponent": [Function],
+                                                              }
+                                                            }
+                                                            forwardedRef={null}
+                                                            href="/"
+                                                            muted={false}
+                                                            noVisitedState={false}
+                                                            textColour={false}
+                                                          >
+                                                            <a
+                                                              className="c8 c9"
+                                                              href="/"
+                                                              muted={false}
+                                                            >
+                                                              Item 3
+                                                            </a>
+                                                          </StyledComponent>
+                                                        </styled.a>
+                                                      </LinkDocumented>
                                                     </StyledComponent>
-                                                  </Styled(styled.a)>
+                                                  </Styled(LinkDocumented)>
                                                 </FooterLink>
                                               </li>
                                             </StyledComponent>
@@ -3147,7 +3214,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-EHOje",
                                             "isStatic": true,
-                                            "lastClassName": "c9",
+                                            "lastClassName": "c10",
                                             "rules": Array [
                                               "margin-bottom: 20px;",
                                             ],
@@ -3165,17 +3232,14 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                       forwardedRef={null}
                                     >
                                       <div
-                                        className="c9"
+                                        className="c10"
                                       >
                                         Built by the 
                                         <FooterLink
                                           href="/"
                                         >
-                                          <Styled(styled.a)
+                                          <Styled(LinkDocumented)
                                             href="/"
-                                            muted={false}
-                                            noVisitedState={false}
-                                            textColour={false}
                                           >
                                             <StyledComponent
                                               forwardedComponent={
@@ -3184,13 +3248,58 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                                   "attrs": Array [],
                                                   "componentStyle": ComponentStyle {
                                                     "componentId": "sc-bxivhb",
-                                                    "isStatic": false,
+                                                    "isStatic": true,
                                                     "lastClassName": "c8",
                                                     "rules": Array [
-                                                      "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                      ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                    ],
+                                                  },
+                                                  "displayName": "Styled(LinkDocumented)",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-bxivhb",
+                                                  "target": [Function],
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
+                                              href="/"
+                                            >
+                                              <LinkDocumented
+                                                className="c8"
+                                                href="/"
+                                                muted={false}
+                                                noVisitedState={false}
+                                                textColour={false}
+                                              >
+                                                <styled.a
+                                                  className="c8"
+                                                  href="/"
+                                                  muted={false}
+                                                  noVisitedState={false}
+                                                  textColour={false}
+                                                >
+                                                  <StyledComponent
+                                                    className="c8"
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-htpNat",
+                                                          "isStatic": false,
+                                                          "lastClassName": "c9",
+                                                          "rules": Array [
+                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                      ":link {
+                                                            ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -3201,59 +3310,55 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
 } :focus {
   color: #0b0c0c;
 }",
-                                                      "&:focus {
+                                                            "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                      "@media print {
+                                                            "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                      [Function],
-                                                      [Function],
-                                                      [Function],
-                                                      ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                    ],
-                                                  },
-                                                  "defaultProps": Object {
-                                                    "muted": false,
-                                                    "noVisitedState": false,
-                                                    "textColour": false,
-                                                  },
-                                                  "displayName": "Styled(styled.a)",
-                                                  "foldedComponentIds": Array [
-                                                    "sc-htpNat",
-                                                  ],
-                                                  "propTypes": undefined,
-                                                  "render": [Function],
-                                                  "styledComponentId": "sc-bxivhb",
-                                                  "target": "a",
-                                                  "toString": [Function],
-                                                  "warnTooManyClasses": [Function],
-                                                  "withComponent": [Function],
-                                                }
-                                              }
-                                              forwardedRef={null}
-                                              href="/"
-                                              muted={false}
-                                              noVisitedState={false}
-                                              textColour={false}
-                                            >
-                                              <a
-                                                className="c8"
-                                                href="/"
-                                                muted={false}
-                                              >
-                                                Government Digital Service
-                                              </a>
+                                                            [Function],
+                                                            [Function],
+                                                            [Function],
+                                                          ],
+                                                        },
+                                                        "defaultProps": Object {
+                                                          "muted": false,
+                                                          "noVisitedState": false,
+                                                          "textColour": false,
+                                                        },
+                                                        "displayName": "styled.a",
+                                                        "foldedComponentIds": Array [],
+                                                        "propTypes": undefined,
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-htpNat",
+                                                        "target": "a",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                    muted={false}
+                                                    noVisitedState={false}
+                                                    textColour={false}
+                                                  >
+                                                    <a
+                                                      className="c8 c9"
+                                                      href="/"
+                                                      muted={false}
+                                                    >
+                                                      Government Digital Service
+                                                    </a>
+                                                  </StyledComponent>
+                                                </styled.a>
+                                              </LinkDocumented>
                                             </StyledComponent>
-                                          </Styled(styled.a)>
+                                          </Styled(LinkDocumented)>
                                         </FooterLink>
                                       </div>
                                     </StyledComponent>
@@ -3277,7 +3382,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "sc-htoDjs",
                                                 "isStatic": true,
-                                                "lastClassName": "c10",
+                                                "lastClassName": "c11",
                                                 "rules": Array [
                                                   "display: inline-block; margin-right: 10px; margin-bottom: 15px; vertical-align: top; @media only screen and (min-width: 769px) {
   margin-bottom: 0;
@@ -3302,7 +3407,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                           xmlns="http://www.w3.org/2000/svg"
                                         >
                                           <svg
-                                            className="c10"
+                                            className="c11"
                                             focusable="false"
                                             height="17"
                                             role="presentation"
@@ -3326,7 +3431,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "sc-dnqmqq",
                                                 "isStatic": true,
-                                                "lastClassName": "c11",
+                                                "lastClassName": "c12",
                                                 "rules": Array [
                                                   "display: inline-block;",
                                                 ],
@@ -3344,7 +3449,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                           forwardedRef={null}
                                         >
                                           <span
-                                            className="c11"
+                                            className="c12"
                                           >
                                             All content is available under the Open Government Licence v3.0, except where otherwise stated
                                           </span>
@@ -3385,33 +3490,33 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
   margin: 0 15px;
 }
 
-.c8 {
+.c9 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-.c8:link {
+.c9:link {
   color: #005ea5;
 }
 
-.c8:visited {
+.c9:visited {
   color: #4c2c92;
 }
 
-.c8:hover {
+.c9:hover {
   color: #2b8cc4;
 }
 
-.c8:active {
+.c9:active {
   color: #2b8cc4;
 }
 
-.c8:focus {
+.c9:focus {
   color: #0b0c0c;
 }
 
-.c8:focus {
+.c9:focus {
   outline: 3px solid #ffbf47;
   outline-offset: 0;
   background-color: #ffbf47;
@@ -3461,14 +3566,14 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
   flex-basis: 320px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   margin-right: 10px;
   margin-bottom: 15px;
   vertical-align: top;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
 }
 
@@ -3543,15 +3648,15 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
 }
 
 @media print {
-  .c8 {
+  .c9 {
     font-family: sans-serif;
   }
 }
 
 @media print {
-  .c8[href^="/"]::after,
-  .c8[href^="http://"]::after,
-  .c8[href^="https://"]::after {
+  .c9[href^="/"]::after,
+  .c9[href^="http://"]::after,
+  .c9[href^="https://"]::after {
     content: " (" attr(href) ")";
     font-size: 90%;
     word-wrap: break-word;
@@ -3573,7 +3678,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
 }
 
 @media only screen and (min-width:769px) {
-  .c9 {
+  .c10 {
     margin-bottom: 0;
   }
 }
@@ -4036,11 +4141,8 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
                                                 <FooterLink
                                                   href="/"
                                                 >
-                                                  <Styled(styled.a)
+                                                  <Styled(LinkDocumented)
                                                     href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
                                                   >
                                                     <StyledComponent
                                                       forwardedComponent={
@@ -4049,13 +4151,58 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
                                                           "attrs": Array [],
                                                           "componentStyle": ComponentStyle {
                                                             "componentId": "sc-bxivhb",
-                                                            "isStatic": false,
+                                                            "isStatic": true,
                                                             "lastClassName": "c8",
                                                             "rules": Array [
-                                                              "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                              ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                            ],
+                                                          },
+                                                          "displayName": "Styled(LinkDocumented)",
+                                                          "foldedComponentIds": Array [],
+                                                          "render": [Function],
+                                                          "styledComponentId": "sc-bxivhb",
+                                                          "target": [Function],
+                                                          "toString": [Function],
+                                                          "warnTooManyClasses": [Function],
+                                                          "withComponent": [Function],
+                                                        }
+                                                      }
+                                                      forwardedRef={null}
+                                                      href="/"
+                                                    >
+                                                      <LinkDocumented
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <styled.a
+                                                          className="c8"
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <StyledComponent
+                                                            className="c8"
+                                                            forwardedComponent={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "attrs": Array [],
+                                                                "componentStyle": ComponentStyle {
+                                                                  "componentId": "sc-htpNat",
+                                                                  "isStatic": false,
+                                                                  "lastClassName": "c9",
+                                                                  "rules": Array [
+                                                                    "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                              ":link {
+                                                                    ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -4066,59 +4213,55 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
 } :focus {
   color: #0b0c0c;
 }",
-                                                              "&:focus {
+                                                                    "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                              "@media print {
+                                                                    "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                              [Function],
-                                                              [Function],
-                                                              [Function],
-                                                              ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                            ],
-                                                          },
-                                                          "defaultProps": Object {
-                                                            "muted": false,
-                                                            "noVisitedState": false,
-                                                            "textColour": false,
-                                                          },
-                                                          "displayName": "Styled(styled.a)",
-                                                          "foldedComponentIds": Array [
-                                                            "sc-htpNat",
-                                                          ],
-                                                          "propTypes": undefined,
-                                                          "render": [Function],
-                                                          "styledComponentId": "sc-bxivhb",
-                                                          "target": "a",
-                                                          "toString": [Function],
-                                                          "warnTooManyClasses": [Function],
-                                                          "withComponent": [Function],
-                                                        }
-                                                      }
-                                                      forwardedRef={null}
-                                                      href="/"
-                                                      muted={false}
-                                                      noVisitedState={false}
-                                                      textColour={false}
-                                                    >
-                                                      <a
-                                                        className="c8"
-                                                        href="/"
-                                                        muted={false}
-                                                      >
-                                                        Item 1
-                                                      </a>
+                                                                    [Function],
+                                                                    [Function],
+                                                                    [Function],
+                                                                  ],
+                                                                },
+                                                                "defaultProps": Object {
+                                                                  "muted": false,
+                                                                  "noVisitedState": false,
+                                                                  "textColour": false,
+                                                                },
+                                                                "displayName": "styled.a",
+                                                                "foldedComponentIds": Array [],
+                                                                "propTypes": undefined,
+                                                                "render": [Function],
+                                                                "styledComponentId": "sc-htpNat",
+                                                                "target": "a",
+                                                                "toString": [Function],
+                                                                "warnTooManyClasses": [Function],
+                                                                "withComponent": [Function],
+                                                              }
+                                                            }
+                                                            forwardedRef={null}
+                                                            href="/"
+                                                            muted={false}
+                                                            noVisitedState={false}
+                                                            textColour={false}
+                                                          >
+                                                            <a
+                                                              className="c8 c9"
+                                                              href="/"
+                                                              muted={false}
+                                                            >
+                                                              Item 1
+                                                            </a>
+                                                          </StyledComponent>
+                                                        </styled.a>
+                                                      </LinkDocumented>
                                                     </StyledComponent>
-                                                  </Styled(styled.a)>
+                                                  </Styled(LinkDocumented)>
                                                 </FooterLink>
                                               </li>
                                             </StyledComponent>
@@ -4169,11 +4312,8 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
                                                   as={[Function]}
                                                   to="/footer-meta-item-2"
                                                 >
-                                                  <Styled(styled.a)
+                                                  <Styled(LinkDocumented)
                                                     as={[Function]}
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
                                                     to="/footer-meta-item-2"
                                                   >
                                                     <StyledComponent
@@ -4184,36 +4324,9 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
                                                           "attrs": Array [],
                                                           "componentStyle": ComponentStyle {
                                                             "componentId": "sc-bxivhb",
-                                                            "isStatic": false,
+                                                            "isStatic": true,
                                                             "lastClassName": "c8",
                                                             "rules": Array [
-                                                              "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
-  font-family: sans-serif;
-}",
-                                                              ":link {
-  color: #005ea5;
-} :visited {
-  color: #4c2c92;
-} :hover {
-  color: #2b8cc4;
-} :active {
-  color: #2b8cc4;
-} :focus {
-  color: #0b0c0c;
-}",
-                                                              "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
-}",
-                                                              "@media print {
-  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
-  &::after {
-  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
-}
-}
-}",
-                                                              [Function],
-                                                              [Function],
-                                                              [Function],
                                                               ":link, :visited {
   color: #454a4c;
 } :hover {
@@ -4221,50 +4334,33 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
 }",
                                                             ],
                                                           },
-                                                          "defaultProps": Object {
-                                                            "muted": false,
-                                                            "noVisitedState": false,
-                                                            "textColour": false,
-                                                          },
-                                                          "displayName": "Styled(styled.a)",
-                                                          "foldedComponentIds": Array [
-                                                            "sc-htpNat",
-                                                          ],
-                                                          "propTypes": undefined,
+                                                          "displayName": "Styled(LinkDocumented)",
+                                                          "foldedComponentIds": Array [],
                                                           "render": [Function],
                                                           "styledComponentId": "sc-bxivhb",
-                                                          "target": "a",
+                                                          "target": [Function],
                                                           "toString": [Function],
                                                           "warnTooManyClasses": [Function],
                                                           "withComponent": [Function],
                                                         }
                                                       }
                                                       forwardedRef={null}
-                                                      muted={false}
-                                                      noVisitedState={false}
-                                                      textColour={false}
                                                       to="/footer-meta-item-2"
                                                     >
                                                       <Link
                                                         className="c8"
-                                                        muted={false}
-                                                        noVisitedState={false}
-                                                        textColour={false}
                                                         to="/footer-meta-item-2"
                                                       >
                                                         <a
                                                           className="c8"
                                                           href="/footer-meta-item-2"
-                                                          muted={false}
-                                                          noVisitedState={false}
                                                           onClick={[Function]}
-                                                          textColour={false}
                                                         >
                                                           Item 2 (Router Link)
                                                         </a>
                                                       </Link>
                                                     </StyledComponent>
-                                                  </Styled(styled.a)>
+                                                  </Styled(LinkDocumented)>
                                                 </FooterLink>
                                               </li>
                                             </StyledComponent>
@@ -4314,11 +4410,8 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
                                                 <FooterLink
                                                   href="/"
                                                 >
-                                                  <Styled(styled.a)
+                                                  <Styled(LinkDocumented)
                                                     href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
                                                   >
                                                     <StyledComponent
                                                       forwardedComponent={
@@ -4327,13 +4420,58 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
                                                           "attrs": Array [],
                                                           "componentStyle": ComponentStyle {
                                                             "componentId": "sc-bxivhb",
-                                                            "isStatic": false,
+                                                            "isStatic": true,
                                                             "lastClassName": "c8",
                                                             "rules": Array [
-                                                              "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                              ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                            ],
+                                                          },
+                                                          "displayName": "Styled(LinkDocumented)",
+                                                          "foldedComponentIds": Array [],
+                                                          "render": [Function],
+                                                          "styledComponentId": "sc-bxivhb",
+                                                          "target": [Function],
+                                                          "toString": [Function],
+                                                          "warnTooManyClasses": [Function],
+                                                          "withComponent": [Function],
+                                                        }
+                                                      }
+                                                      forwardedRef={null}
+                                                      href="/"
+                                                    >
+                                                      <LinkDocumented
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <styled.a
+                                                          className="c8"
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <StyledComponent
+                                                            className="c8"
+                                                            forwardedComponent={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "attrs": Array [],
+                                                                "componentStyle": ComponentStyle {
+                                                                  "componentId": "sc-htpNat",
+                                                                  "isStatic": false,
+                                                                  "lastClassName": "c9",
+                                                                  "rules": Array [
+                                                                    "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                              ":link {
+                                                                    ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -4344,59 +4482,55 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
 } :focus {
   color: #0b0c0c;
 }",
-                                                              "&:focus {
+                                                                    "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                              "@media print {
+                                                                    "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                              [Function],
-                                                              [Function],
-                                                              [Function],
-                                                              ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                            ],
-                                                          },
-                                                          "defaultProps": Object {
-                                                            "muted": false,
-                                                            "noVisitedState": false,
-                                                            "textColour": false,
-                                                          },
-                                                          "displayName": "Styled(styled.a)",
-                                                          "foldedComponentIds": Array [
-                                                            "sc-htpNat",
-                                                          ],
-                                                          "propTypes": undefined,
-                                                          "render": [Function],
-                                                          "styledComponentId": "sc-bxivhb",
-                                                          "target": "a",
-                                                          "toString": [Function],
-                                                          "warnTooManyClasses": [Function],
-                                                          "withComponent": [Function],
-                                                        }
-                                                      }
-                                                      forwardedRef={null}
-                                                      href="/"
-                                                      muted={false}
-                                                      noVisitedState={false}
-                                                      textColour={false}
-                                                    >
-                                                      <a
-                                                        className="c8"
-                                                        href="/"
-                                                        muted={false}
-                                                      >
-                                                        Item 3
-                                                      </a>
+                                                                    [Function],
+                                                                    [Function],
+                                                                    [Function],
+                                                                  ],
+                                                                },
+                                                                "defaultProps": Object {
+                                                                  "muted": false,
+                                                                  "noVisitedState": false,
+                                                                  "textColour": false,
+                                                                },
+                                                                "displayName": "styled.a",
+                                                                "foldedComponentIds": Array [],
+                                                                "propTypes": undefined,
+                                                                "render": [Function],
+                                                                "styledComponentId": "sc-htpNat",
+                                                                "target": "a",
+                                                                "toString": [Function],
+                                                                "warnTooManyClasses": [Function],
+                                                                "withComponent": [Function],
+                                                              }
+                                                            }
+                                                            forwardedRef={null}
+                                                            href="/"
+                                                            muted={false}
+                                                            noVisitedState={false}
+                                                            textColour={false}
+                                                          >
+                                                            <a
+                                                              className="c8 c9"
+                                                              href="/"
+                                                              muted={false}
+                                                            >
+                                                              Item 3
+                                                            </a>
+                                                          </StyledComponent>
+                                                        </styled.a>
+                                                      </LinkDocumented>
                                                     </StyledComponent>
-                                                  </Styled(styled.a)>
+                                                  </Styled(LinkDocumented)>
                                                 </FooterLink>
                                               </li>
                                             </StyledComponent>
@@ -4424,7 +4558,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "sc-htoDjs",
                                                 "isStatic": true,
-                                                "lastClassName": "c9",
+                                                "lastClassName": "c10",
                                                 "rules": Array [
                                                   "display: inline-block; margin-right: 10px; margin-bottom: 15px; vertical-align: top; @media only screen and (min-width: 769px) {
   margin-bottom: 0;
@@ -4449,7 +4583,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
                                           xmlns="http://www.w3.org/2000/svg"
                                         >
                                           <svg
-                                            className="c9"
+                                            className="c10"
                                             focusable="false"
                                             height="17"
                                             role="presentation"
@@ -4473,7 +4607,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "sc-dnqmqq",
                                                 "isStatic": true,
-                                                "lastClassName": "c10",
+                                                "lastClassName": "c11",
                                                 "rules": Array [
                                                   "display: inline-block;",
                                                 ],
@@ -4491,7 +4625,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
                                           forwardedRef={null}
                                         >
                                           <span
-                                            className="c10"
+                                            className="c11"
                                           >
                                             All content is available under the Open Government Licence v3.0, except where otherwise stated
                                           </span>
@@ -4544,33 +4678,33 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   flex-wrap: wrap;
 }
 
-.c8 {
+.c9 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-.c8:link {
+.c9:link {
   color: #005ea5;
 }
 
-.c8:visited {
+.c9:visited {
   color: #4c2c92;
 }
 
-.c8:hover {
+.c9:hover {
   color: #2b8cc4;
 }
 
-.c8:active {
+.c9:active {
   color: #2b8cc4;
 }
 
-.c8:focus {
+.c9:focus {
   color: #0b0c0c;
 }
 
-.c8:focus {
+.c9:focus {
   outline: 3px solid #ffbf47;
   outline-offset: 0;
   background-color: #ffbf47;
@@ -4585,18 +4719,18 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   color: #171819;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   border: 0;
   border-bottom: 1px solid #bfc1c3;
   margin-bottom: 30px;
 }
 
-.c17 {
+.c18 {
   margin-bottom: 20px;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4619,7 +4753,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   -moz-osx-font-smoothing: grayscale;
 }
 
-.c12 {
+.c13 {
   margin-right: 15px;
   margin-bottom: 25px;
   margin-left: 15px;
@@ -4631,18 +4765,18 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   flex-basis: 320px;
 }
 
-.c18 {
+.c19 {
   display: inline-block;
   margin-right: 10px;
   margin-bottom: 15px;
   vertical-align: top;
 }
 
-.c19 {
+.c20 {
   display: inline-block;
 }
 
-.c14 {
+.c15 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -4668,7 +4802,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   margin-bottom: 15px;
 }
 
-.c13 {
+.c14 {
   position: absolute !important;
   width: 1px !important;
   height: 1px !important;
@@ -4683,13 +4817,13 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   padding: 0 !important;
 }
 
-.c15 {
+.c16 {
   margin-top: 0;
   margin-bottom: 15px;
   padding: 0;
 }
 
-.c9 {
+.c10 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -4705,13 +4839,13 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   column-gap: 30px;
 }
 
-.c16 {
+.c17 {
   display: inline-block;
   margin-right: 15px;
   margin-bottom: 5px;
 }
 
-.c16:last-child {
+.c17:last-child {
   margin-bottom: 0;
 }
 
@@ -4775,15 +4909,15 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 }
 
 @media print {
-  .c8 {
+  .c9 {
     font-family: sans-serif;
   }
 }
 
 @media print {
-  .c8[href^="/"]::after,
-  .c8[href^="http://"]::after,
-  .c8[href^="https://"]::after {
+  .c9[href^="/"]::after,
+  .c9[href^="http://"]::after,
+  .c9[href^="https://"]::after {
     content: " (" attr(href) ")";
     font-size: 90%;
     word-wrap: break-word;
@@ -4791,19 +4925,19 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-bottom: 50px;
   }
 }
 
 @media print {
-  .c11 {
+  .c12 {
     font-family: sans-serif;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c12 {
+  .c13 {
     -webkit-flex-basis: auto;
     -ms-flex-preferred-size: auto;
     flex-basis: auto;
@@ -4811,33 +4945,33 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 }
 
 @media only screen and (min-width:769px) {
-  .c18 {
+  .c19 {
     margin-bottom: 0;
   }
 }
 
 @media print {
-  .c14 {
+  .c15 {
     color: #000;
   }
 }
 
 @media print {
-  .c14 {
+  .c15 {
     font-size: 24px;
     line-height: 1.05;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c14 {
+  .c15 {
     font-size: 36px;
     line-height: 1.1111111111111112;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c14 {
+  .c15 {
     margin-bottom: 30px;
   }
 }
@@ -5123,7 +5257,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                         >
                           <NavigationLinks
                             heading="Two column list"
-                            listColumns="2"
+                            listColumns={2}
                           >
                             <styled.div>
                               <StyledComponent
@@ -5207,7 +5341,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "sc-gZMcBi",
                                                   "isStatic": false,
-                                                  "lastClassName": "c14",
+                                                  "lastClassName": "c15",
                                                   "rules": Array [
                                                     "color: #0b0c0c; @media print {
   color: #000;
@@ -5243,11 +5377,11 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                     </StyledComponent>
                                   </Styled(Heading)>
                                   <styled.ul
-                                    columns="2"
+                                    columns={2}
                                     inline={false}
                                   >
                                     <StyledComponent
-                                      columns="2"
+                                      columns={2}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
@@ -5255,7 +5389,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-VigVT",
                                             "isStatic": false,
-                                            "lastClassName": "c15",
+                                            "lastClassName": "c16",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -5297,7 +5431,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "sc-jTzLTM",
                                                   "isStatic": false,
-                                                  "lastClassName": "c16",
+                                                  "lastClassName": "c17",
                                                   "rules": Array [
                                                     [Function],
                                                     "&:last-child {
@@ -5330,11 +5464,8 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -5343,13 +5474,58 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -5360,59 +5536,55 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 1
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 1
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -5429,7 +5601,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "sc-jTzLTM",
                                                   "isStatic": false,
-                                                  "lastClassName": "c16",
+                                                  "lastClassName": "c17",
                                                   "rules": Array [
                                                     [Function],
                                                     "&:last-child {
@@ -5463,11 +5635,8 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                 as={[Function]}
                                                 to="/footer-nav-item-2"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   as={[Function]}
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                   to="/footer-nav-item-2"
                                                 >
                                                   <StyledComponent
@@ -5478,36 +5647,9 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
-  font-family: sans-serif;
-}",
-                                                            ":link {
-  color: #005ea5;
-} :visited {
-  color: #4c2c92;
-} :hover {
-  color: #2b8cc4;
-} :active {
-  color: #2b8cc4;
-} :focus {
-  color: #0b0c0c;
-}",
-                                                            "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
-}",
-                                                            "@media print {
-  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
-  &::after {
-  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
-}
-}
-}",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
                                                             ":link, :visited {
   color: #454a4c;
 } :hover {
@@ -5515,50 +5657,33 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 }",
                                                           ],
                                                         },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
                                                         "render": [Function],
                                                         "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
+                                                        "target": [Function],
                                                         "toString": [Function],
                                                         "warnTooManyClasses": [Function],
                                                         "withComponent": [Function],
                                                       }
                                                     }
                                                     forwardedRef={null}
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
                                                     to="/footer-nav-item-2"
                                                   >
                                                     <Link
                                                       className="c8"
-                                                      muted={false}
-                                                      noVisitedState={false}
-                                                      textColour={false}
                                                       to="/footer-nav-item-2"
                                                     >
                                                       <a
                                                         className="c8"
                                                         href="/footer-nav-item-2"
-                                                        muted={false}
-                                                        noVisitedState={false}
                                                         onClick={[Function]}
-                                                        textColour={false}
                                                       >
                                                         Navigation item 2 (Router Link)
                                                       </a>
                                                     </Link>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -5575,7 +5700,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "sc-jTzLTM",
                                                   "isStatic": false,
-                                                  "lastClassName": "c16",
+                                                  "lastClassName": "c17",
                                                   "rules": Array [
                                                     [Function],
                                                     "&:last-child {
@@ -5608,11 +5733,8 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -5621,13 +5743,58 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -5638,59 +5805,55 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 3
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 3
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -5707,7 +5870,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "sc-jTzLTM",
                                                   "isStatic": false,
-                                                  "lastClassName": "c16",
+                                                  "lastClassName": "c17",
                                                   "rules": Array [
                                                     [Function],
                                                     "&:last-child {
@@ -5740,11 +5903,8 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -5753,13 +5913,58 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -5770,59 +5975,55 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 4
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 4
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -5839,7 +6040,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "sc-jTzLTM",
                                                   "isStatic": false,
-                                                  "lastClassName": "c16",
+                                                  "lastClassName": "c17",
                                                   "rules": Array [
                                                     [Function],
                                                     "&:last-child {
@@ -5872,11 +6073,8 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -5885,13 +6083,58 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -5902,59 +6145,55 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 5
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 5
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -5971,7 +6210,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "sc-jTzLTM",
                                                   "isStatic": false,
-                                                  "lastClassName": "c16",
+                                                  "lastClassName": "c17",
                                                   "rules": Array [
                                                     [Function],
                                                     "&:last-child {
@@ -6004,11 +6243,8 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -6017,13 +6253,58 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -6034,59 +6315,55 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 6
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 6
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -6184,7 +6461,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "sc-gZMcBi",
                                                   "isStatic": false,
-                                                  "lastClassName": "c14",
+                                                  "lastClassName": "c15",
                                                   "rules": Array [
                                                     "color: #0b0c0c; @media print {
   color: #000;
@@ -6232,7 +6509,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-VigVT",
                                             "isStatic": false,
-                                            "lastClassName": "c15",
+                                            "lastClassName": "c16",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -6260,7 +6537,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                       inline={false}
                                     >
                                       <ul
-                                        className="c9"
+                                        className="c10"
                                       >
                                         <styled.li
                                           inline={false}
@@ -6274,7 +6551,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "sc-jTzLTM",
                                                   "isStatic": false,
-                                                  "lastClassName": "c16",
+                                                  "lastClassName": "c17",
                                                   "rules": Array [
                                                     [Function],
                                                     "&:last-child {
@@ -6307,11 +6584,8 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -6320,13 +6594,58 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -6337,59 +6656,55 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 1
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 1
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -6406,7 +6721,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "sc-jTzLTM",
                                                   "isStatic": false,
-                                                  "lastClassName": "c16",
+                                                  "lastClassName": "c17",
                                                   "rules": Array [
                                                     [Function],
                                                     "&:last-child {
@@ -6439,11 +6754,8 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -6452,13 +6764,58 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -6469,59 +6826,55 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 2
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 2
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -6538,7 +6891,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                 "componentStyle": ComponentStyle {
                                                   "componentId": "sc-jTzLTM",
                                                   "isStatic": false,
-                                                  "lastClassName": "c16",
+                                                  "lastClassName": "c17",
                                                   "rules": Array [
                                                     [Function],
                                                     "&:last-child {
@@ -6571,11 +6924,8 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -6584,13 +6934,58 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -6601,59 +6996,55 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 3
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 3
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -6677,7 +7068,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                             "componentStyle": ComponentStyle {
                               "componentId": "sc-ifAKCX",
                               "isStatic": false,
-                              "lastClassName": "c10",
+                              "lastClassName": "c11",
                               "rules": Array [
                                 "margin: 0; border: 0; border-bottom: 1px solid #bfc1c3;",
                                 [Function],
@@ -6696,7 +7087,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                         forwardedRef={null}
                       >
                         <hr
-                          className="c10"
+                          className="c11"
                         />
                       </StyledComponent>
                     </styled.hr>
@@ -6710,7 +7101,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                               "componentStyle": ComponentStyle {
                                 "componentId": "sc-bZQynM",
                                 "isStatic": true,
-                                "lastClassName": "c11",
+                                "lastClassName": "c12",
                                 "rules": Array [
                                   "display: flex; margin-right: -15px; margin-left: -15px; flex-wrap: wrap; align-items: flex-end; justify-content: center;",
                                   "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
@@ -6731,7 +7122,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                           forwardedRef={null}
                         >
                           <div
-                            className="c11"
+                            className="c12"
                           >
                             <styled.div
                               grow={true}
@@ -6744,7 +7135,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                     "componentStyle": ComponentStyle {
                                       "componentId": "sc-gzVnrw",
                                       "isStatic": false,
-                                      "lastClassName": "c12",
+                                      "lastClassName": "c13",
                                       "rules": Array [
                                         "margin-right: 15px; margin-bottom: 25px; margin-left: 15px;",
                                         [Function],
@@ -6770,7 +7161,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                 grow={true}
                               >
                                 <div
-                                  className="c12"
+                                  className="c13"
                                 >
                                   <MetaLinks
                                     heading="Support links"
@@ -6790,7 +7181,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                             "componentStyle": ComponentStyle {
                                               "componentId": "sc-gqjmRU",
                                               "isStatic": false,
-                                              "lastClassName": "c13",
+                                              "lastClassName": "c14",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -6814,7 +7205,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                         important={true}
                                       >
                                         <span
-                                          className="c13"
+                                          className="c14"
                                           focusable={false}
                                         >
                                           <H2>
@@ -6835,7 +7226,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                       "componentStyle": ComponentStyle {
                                                         "componentId": "sc-gZMcBi",
                                                         "isStatic": false,
-                                                        "lastClassName": "c14",
+                                                        "lastClassName": "c15",
                                                         "rules": Array [
                                                           "color: #0b0c0c; @media print {
   color: #000;
@@ -6860,7 +7251,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                   size="LARGE"
                                                 >
                                                   <h2
-                                                    className="c14"
+                                                    className="c15"
                                                     size="LARGE"
                                                   >
                                                     Support links
@@ -6883,7 +7274,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                             "componentStyle": ComponentStyle {
                                               "componentId": "sc-VigVT",
                                               "isStatic": false,
-                                              "lastClassName": "c15",
+                                              "lastClassName": "c16",
                                               "rules": Array [
                                                 [Function],
                                                 [Function],
@@ -6911,7 +7302,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                         inline={true}
                                       >
                                         <ul
-                                          className="c15"
+                                          className="c16"
                                         >
                                           <styled.li
                                             inline={true}
@@ -6925,7 +7316,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                   "componentStyle": ComponentStyle {
                                                     "componentId": "sc-jTzLTM",
                                                     "isStatic": false,
-                                                    "lastClassName": "c16",
+                                                    "lastClassName": "c17",
                                                     "rules": Array [
                                                       [Function],
                                                       "&:last-child {
@@ -6953,16 +7344,13 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               inline={true}
                                             >
                                               <li
-                                                className="c16"
+                                                className="c17"
                                               >
                                                 <FooterLink
                                                   href="/"
                                                 >
-                                                  <Styled(styled.a)
+                                                  <Styled(LinkDocumented)
                                                     href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
                                                   >
                                                     <StyledComponent
                                                       forwardedComponent={
@@ -6971,13 +7359,58 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                           "attrs": Array [],
                                                           "componentStyle": ComponentStyle {
                                                             "componentId": "sc-bxivhb",
-                                                            "isStatic": false,
+                                                            "isStatic": true,
                                                             "lastClassName": "c8",
                                                             "rules": Array [
-                                                              "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                              ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                            ],
+                                                          },
+                                                          "displayName": "Styled(LinkDocumented)",
+                                                          "foldedComponentIds": Array [],
+                                                          "render": [Function],
+                                                          "styledComponentId": "sc-bxivhb",
+                                                          "target": [Function],
+                                                          "toString": [Function],
+                                                          "warnTooManyClasses": [Function],
+                                                          "withComponent": [Function],
+                                                        }
+                                                      }
+                                                      forwardedRef={null}
+                                                      href="/"
+                                                    >
+                                                      <LinkDocumented
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <styled.a
+                                                          className="c8"
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <StyledComponent
+                                                            className="c8"
+                                                            forwardedComponent={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "attrs": Array [],
+                                                                "componentStyle": ComponentStyle {
+                                                                  "componentId": "sc-htpNat",
+                                                                  "isStatic": false,
+                                                                  "lastClassName": "c9",
+                                                                  "rules": Array [
+                                                                    "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                              ":link {
+                                                                    ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -6988,59 +7421,55 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 } :focus {
   color: #0b0c0c;
 }",
-                                                              "&:focus {
+                                                                    "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                              "@media print {
+                                                                    "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                              [Function],
-                                                              [Function],
-                                                              [Function],
-                                                              ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                            ],
-                                                          },
-                                                          "defaultProps": Object {
-                                                            "muted": false,
-                                                            "noVisitedState": false,
-                                                            "textColour": false,
-                                                          },
-                                                          "displayName": "Styled(styled.a)",
-                                                          "foldedComponentIds": Array [
-                                                            "sc-htpNat",
-                                                          ],
-                                                          "propTypes": undefined,
-                                                          "render": [Function],
-                                                          "styledComponentId": "sc-bxivhb",
-                                                          "target": "a",
-                                                          "toString": [Function],
-                                                          "warnTooManyClasses": [Function],
-                                                          "withComponent": [Function],
-                                                        }
-                                                      }
-                                                      forwardedRef={null}
-                                                      href="/"
-                                                      muted={false}
-                                                      noVisitedState={false}
-                                                      textColour={false}
-                                                    >
-                                                      <a
-                                                        className="c8"
-                                                        href="/"
-                                                        muted={false}
-                                                      >
-                                                        Item 1
-                                                      </a>
+                                                                    [Function],
+                                                                    [Function],
+                                                                    [Function],
+                                                                  ],
+                                                                },
+                                                                "defaultProps": Object {
+                                                                  "muted": false,
+                                                                  "noVisitedState": false,
+                                                                  "textColour": false,
+                                                                },
+                                                                "displayName": "styled.a",
+                                                                "foldedComponentIds": Array [],
+                                                                "propTypes": undefined,
+                                                                "render": [Function],
+                                                                "styledComponentId": "sc-htpNat",
+                                                                "target": "a",
+                                                                "toString": [Function],
+                                                                "warnTooManyClasses": [Function],
+                                                                "withComponent": [Function],
+                                                              }
+                                                            }
+                                                            forwardedRef={null}
+                                                            href="/"
+                                                            muted={false}
+                                                            noVisitedState={false}
+                                                            textColour={false}
+                                                          >
+                                                            <a
+                                                              className="c8 c9"
+                                                              href="/"
+                                                              muted={false}
+                                                            >
+                                                              Item 1
+                                                            </a>
+                                                          </StyledComponent>
+                                                        </styled.a>
+                                                      </LinkDocumented>
                                                     </StyledComponent>
-                                                  </Styled(styled.a)>
+                                                  </Styled(LinkDocumented)>
                                                 </FooterLink>
                                               </li>
                                             </StyledComponent>
@@ -7057,7 +7486,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                   "componentStyle": ComponentStyle {
                                                     "componentId": "sc-jTzLTM",
                                                     "isStatic": false,
-                                                    "lastClassName": "c16",
+                                                    "lastClassName": "c17",
                                                     "rules": Array [
                                                       [Function],
                                                       "&:last-child {
@@ -7085,17 +7514,14 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               inline={true}
                                             >
                                               <li
-                                                className="c16"
+                                                className="c17"
                                               >
                                                 <FooterLink
                                                   as={[Function]}
                                                   to="/footer-meta-item-2"
                                                 >
-                                                  <Styled(styled.a)
+                                                  <Styled(LinkDocumented)
                                                     as={[Function]}
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
                                                     to="/footer-meta-item-2"
                                                   >
                                                     <StyledComponent
@@ -7106,36 +7532,9 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                           "attrs": Array [],
                                                           "componentStyle": ComponentStyle {
                                                             "componentId": "sc-bxivhb",
-                                                            "isStatic": false,
+                                                            "isStatic": true,
                                                             "lastClassName": "c8",
                                                             "rules": Array [
-                                                              "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
-  font-family: sans-serif;
-}",
-                                                              ":link {
-  color: #005ea5;
-} :visited {
-  color: #4c2c92;
-} :hover {
-  color: #2b8cc4;
-} :active {
-  color: #2b8cc4;
-} :focus {
-  color: #0b0c0c;
-}",
-                                                              "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
-}",
-                                                              "@media print {
-  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
-  &::after {
-  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
-}
-}
-}",
-                                                              [Function],
-                                                              [Function],
-                                                              [Function],
                                                               ":link, :visited {
   color: #454a4c;
 } :hover {
@@ -7143,50 +7542,33 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 }",
                                                             ],
                                                           },
-                                                          "defaultProps": Object {
-                                                            "muted": false,
-                                                            "noVisitedState": false,
-                                                            "textColour": false,
-                                                          },
-                                                          "displayName": "Styled(styled.a)",
-                                                          "foldedComponentIds": Array [
-                                                            "sc-htpNat",
-                                                          ],
-                                                          "propTypes": undefined,
+                                                          "displayName": "Styled(LinkDocumented)",
+                                                          "foldedComponentIds": Array [],
                                                           "render": [Function],
                                                           "styledComponentId": "sc-bxivhb",
-                                                          "target": "a",
+                                                          "target": [Function],
                                                           "toString": [Function],
                                                           "warnTooManyClasses": [Function],
                                                           "withComponent": [Function],
                                                         }
                                                       }
                                                       forwardedRef={null}
-                                                      muted={false}
-                                                      noVisitedState={false}
-                                                      textColour={false}
                                                       to="/footer-meta-item-2"
                                                     >
                                                       <Link
                                                         className="c8"
-                                                        muted={false}
-                                                        noVisitedState={false}
-                                                        textColour={false}
                                                         to="/footer-meta-item-2"
                                                       >
                                                         <a
                                                           className="c8"
                                                           href="/footer-meta-item-2"
-                                                          muted={false}
-                                                          noVisitedState={false}
                                                           onClick={[Function]}
-                                                          textColour={false}
                                                         >
                                                           Item 2 (Router Link)
                                                         </a>
                                                       </Link>
                                                     </StyledComponent>
-                                                  </Styled(styled.a)>
+                                                  </Styled(LinkDocumented)>
                                                 </FooterLink>
                                               </li>
                                             </StyledComponent>
@@ -7203,7 +7585,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                   "componentStyle": ComponentStyle {
                                                     "componentId": "sc-jTzLTM",
                                                     "isStatic": false,
-                                                    "lastClassName": "c16",
+                                                    "lastClassName": "c17",
                                                     "rules": Array [
                                                       [Function],
                                                       "&:last-child {
@@ -7231,16 +7613,13 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               inline={true}
                                             >
                                               <li
-                                                className="c16"
+                                                className="c17"
                                               >
                                                 <FooterLink
                                                   href="/"
                                                 >
-                                                  <Styled(styled.a)
+                                                  <Styled(LinkDocumented)
                                                     href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
                                                   >
                                                     <StyledComponent
                                                       forwardedComponent={
@@ -7249,13 +7628,58 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                           "attrs": Array [],
                                                           "componentStyle": ComponentStyle {
                                                             "componentId": "sc-bxivhb",
-                                                            "isStatic": false,
+                                                            "isStatic": true,
                                                             "lastClassName": "c8",
                                                             "rules": Array [
-                                                              "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                              ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                            ],
+                                                          },
+                                                          "displayName": "Styled(LinkDocumented)",
+                                                          "foldedComponentIds": Array [],
+                                                          "render": [Function],
+                                                          "styledComponentId": "sc-bxivhb",
+                                                          "target": [Function],
+                                                          "toString": [Function],
+                                                          "warnTooManyClasses": [Function],
+                                                          "withComponent": [Function],
+                                                        }
+                                                      }
+                                                      forwardedRef={null}
+                                                      href="/"
+                                                    >
+                                                      <LinkDocumented
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <styled.a
+                                                          className="c8"
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <StyledComponent
+                                                            className="c8"
+                                                            forwardedComponent={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "attrs": Array [],
+                                                                "componentStyle": ComponentStyle {
+                                                                  "componentId": "sc-htpNat",
+                                                                  "isStatic": false,
+                                                                  "lastClassName": "c9",
+                                                                  "rules": Array [
+                                                                    "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                              ":link {
+                                                                    ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -7266,59 +7690,55 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 } :focus {
   color: #0b0c0c;
 }",
-                                                              "&:focus {
+                                                                    "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                              "@media print {
+                                                                    "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                              [Function],
-                                                              [Function],
-                                                              [Function],
-                                                              ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                            ],
-                                                          },
-                                                          "defaultProps": Object {
-                                                            "muted": false,
-                                                            "noVisitedState": false,
-                                                            "textColour": false,
-                                                          },
-                                                          "displayName": "Styled(styled.a)",
-                                                          "foldedComponentIds": Array [
-                                                            "sc-htpNat",
-                                                          ],
-                                                          "propTypes": undefined,
-                                                          "render": [Function],
-                                                          "styledComponentId": "sc-bxivhb",
-                                                          "target": "a",
-                                                          "toString": [Function],
-                                                          "warnTooManyClasses": [Function],
-                                                          "withComponent": [Function],
-                                                        }
-                                                      }
-                                                      forwardedRef={null}
-                                                      href="/"
-                                                      muted={false}
-                                                      noVisitedState={false}
-                                                      textColour={false}
-                                                    >
-                                                      <a
-                                                        className="c8"
-                                                        href="/"
-                                                        muted={false}
-                                                      >
-                                                        Item 3
-                                                      </a>
+                                                                    [Function],
+                                                                    [Function],
+                                                                    [Function],
+                                                                  ],
+                                                                },
+                                                                "defaultProps": Object {
+                                                                  "muted": false,
+                                                                  "noVisitedState": false,
+                                                                  "textColour": false,
+                                                                },
+                                                                "displayName": "styled.a",
+                                                                "foldedComponentIds": Array [],
+                                                                "propTypes": undefined,
+                                                                "render": [Function],
+                                                                "styledComponentId": "sc-htpNat",
+                                                                "target": "a",
+                                                                "toString": [Function],
+                                                                "warnTooManyClasses": [Function],
+                                                                "withComponent": [Function],
+                                                              }
+                                                            }
+                                                            forwardedRef={null}
+                                                            href="/"
+                                                            muted={false}
+                                                            noVisitedState={false}
+                                                            textColour={false}
+                                                          >
+                                                            <a
+                                                              className="c8 c9"
+                                                              href="/"
+                                                              muted={false}
+                                                            >
+                                                              Item 3
+                                                            </a>
+                                                          </StyledComponent>
+                                                        </styled.a>
+                                                      </LinkDocumented>
                                                     </StyledComponent>
-                                                  </Styled(styled.a)>
+                                                  </Styled(LinkDocumented)>
                                                 </FooterLink>
                                               </li>
                                             </StyledComponent>
@@ -7336,7 +7756,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-EHOje",
                                             "isStatic": true,
-                                            "lastClassName": "c17",
+                                            "lastClassName": "c18",
                                             "rules": Array [
                                               "margin-bottom: 20px;",
                                             ],
@@ -7354,17 +7774,14 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                       forwardedRef={null}
                                     >
                                       <div
-                                        className="c17"
+                                        className="c18"
                                       >
                                         Built by the 
                                         <FooterLink
                                           href="/"
                                         >
-                                          <Styled(styled.a)
+                                          <Styled(LinkDocumented)
                                             href="/"
-                                            muted={false}
-                                            noVisitedState={false}
-                                            textColour={false}
                                           >
                                             <StyledComponent
                                               forwardedComponent={
@@ -7373,13 +7790,58 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                                   "attrs": Array [],
                                                   "componentStyle": ComponentStyle {
                                                     "componentId": "sc-bxivhb",
-                                                    "isStatic": false,
+                                                    "isStatic": true,
                                                     "lastClassName": "c8",
                                                     "rules": Array [
-                                                      "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                      ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                    ],
+                                                  },
+                                                  "displayName": "Styled(LinkDocumented)",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-bxivhb",
+                                                  "target": [Function],
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
+                                              href="/"
+                                            >
+                                              <LinkDocumented
+                                                className="c8"
+                                                href="/"
+                                                muted={false}
+                                                noVisitedState={false}
+                                                textColour={false}
+                                              >
+                                                <styled.a
+                                                  className="c8"
+                                                  href="/"
+                                                  muted={false}
+                                                  noVisitedState={false}
+                                                  textColour={false}
+                                                >
+                                                  <StyledComponent
+                                                    className="c8"
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-htpNat",
+                                                          "isStatic": false,
+                                                          "lastClassName": "c9",
+                                                          "rules": Array [
+                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                      ":link {
+                                                            ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -7390,59 +7852,55 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 } :focus {
   color: #0b0c0c;
 }",
-                                                      "&:focus {
+                                                            "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                      "@media print {
+                                                            "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                      [Function],
-                                                      [Function],
-                                                      [Function],
-                                                      ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                    ],
-                                                  },
-                                                  "defaultProps": Object {
-                                                    "muted": false,
-                                                    "noVisitedState": false,
-                                                    "textColour": false,
-                                                  },
-                                                  "displayName": "Styled(styled.a)",
-                                                  "foldedComponentIds": Array [
-                                                    "sc-htpNat",
-                                                  ],
-                                                  "propTypes": undefined,
-                                                  "render": [Function],
-                                                  "styledComponentId": "sc-bxivhb",
-                                                  "target": "a",
-                                                  "toString": [Function],
-                                                  "warnTooManyClasses": [Function],
-                                                  "withComponent": [Function],
-                                                }
-                                              }
-                                              forwardedRef={null}
-                                              href="/"
-                                              muted={false}
-                                              noVisitedState={false}
-                                              textColour={false}
-                                            >
-                                              <a
-                                                className="c8"
-                                                href="/"
-                                                muted={false}
-                                              >
-                                                Government Digital Service
-                                              </a>
+                                                            [Function],
+                                                            [Function],
+                                                            [Function],
+                                                          ],
+                                                        },
+                                                        "defaultProps": Object {
+                                                          "muted": false,
+                                                          "noVisitedState": false,
+                                                          "textColour": false,
+                                                        },
+                                                        "displayName": "styled.a",
+                                                        "foldedComponentIds": Array [],
+                                                        "propTypes": undefined,
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-htpNat",
+                                                        "target": "a",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                    muted={false}
+                                                    noVisitedState={false}
+                                                    textColour={false}
+                                                  >
+                                                    <a
+                                                      className="c8 c9"
+                                                      href="/"
+                                                      muted={false}
+                                                    >
+                                                      Government Digital Service
+                                                    </a>
+                                                  </StyledComponent>
+                                                </styled.a>
+                                              </LinkDocumented>
                                             </StyledComponent>
-                                          </Styled(styled.a)>
+                                          </Styled(LinkDocumented)>
                                         </FooterLink>
                                       </div>
                                     </StyledComponent>
@@ -7466,7 +7924,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "sc-htoDjs",
                                                 "isStatic": true,
-                                                "lastClassName": "c18",
+                                                "lastClassName": "c19",
                                                 "rules": Array [
                                                   "display: inline-block; margin-right: 10px; margin-bottom: 15px; vertical-align: top; @media only screen and (min-width: 769px) {
   margin-bottom: 0;
@@ -7491,7 +7949,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                           xmlns="http://www.w3.org/2000/svg"
                                         >
                                           <svg
-                                            className="c18"
+                                            className="c19"
                                             focusable="false"
                                             height="17"
                                             role="presentation"
@@ -7515,7 +7973,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "sc-dnqmqq",
                                                 "isStatic": true,
-                                                "lastClassName": "c19",
+                                                "lastClassName": "c20",
                                                 "rules": Array [
                                                   "display: inline-block;",
                                                 ],
@@ -7533,7 +7991,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                           forwardedRef={null}
                                         >
                                           <span
-                                            className="c19"
+                                            className="c20"
                                           >
                                             All content is available under the Open Government Licence v3.0, except where otherwise stated
                                           </span>
@@ -7586,33 +8044,33 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   flex-wrap: wrap;
 }
 
-.c8 {
+.c9 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-.c8:link {
+.c9:link {
   color: #005ea5;
 }
 
-.c8:visited {
+.c9:visited {
   color: #4c2c92;
 }
 
-.c8:hover {
+.c9:hover {
   color: #2b8cc4;
 }
 
-.c8:active {
+.c9:active {
   color: #2b8cc4;
 }
 
-.c8:focus {
+.c9:focus {
   color: #0b0c0c;
 }
 
-.c8:focus {
+.c9:focus {
   outline: 3px solid #ffbf47;
   outline-offset: 0;
   background-color: #ffbf47;
@@ -7627,14 +8085,14 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   color: #171819;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   border: 0;
   border-bottom: 1px solid #bfc1c3;
   margin-bottom: 30px;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7657,7 +8115,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   -moz-osx-font-smoothing: grayscale;
 }
 
-.c12 {
+.c13 {
   margin-right: 15px;
   margin-bottom: 25px;
   margin-left: 15px;
@@ -7669,14 +8127,14 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   flex-basis: 320px;
 }
 
-.c13 {
+.c14 {
   display: inline-block;
   margin-right: 10px;
   margin-bottom: 15px;
   vertical-align: top;
 }
 
-.c14 {
+.c15 {
   display: inline-block;
 }
 
@@ -7693,7 +8151,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   margin-bottom: 15px;
 }
 
-.c9 {
+.c10 {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -7769,15 +8227,15 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 }
 
 @media print {
-  .c8 {
+  .c9 {
     font-family: sans-serif;
   }
 }
 
 @media print {
-  .c8[href^="/"]::after,
-  .c8[href^="http://"]::after,
-  .c8[href^="https://"]::after {
+  .c9[href^="/"]::after,
+  .c9[href^="http://"]::after,
+  .c9[href^="https://"]::after {
     content: " (" attr(href) ")";
     font-size: 90%;
     word-wrap: break-word;
@@ -7785,19 +8243,19 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-bottom: 50px;
   }
 }
 
 @media print {
-  .c11 {
+  .c12 {
     font-family: sans-serif;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c12 {
+  .c13 {
     -webkit-flex-basis: auto;
     -ms-flex-preferred-size: auto;
     flex-basis: auto;
@@ -7805,7 +8263,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 }
 
 @media only screen and (min-width:769px) {
-  .c13 {
+  .c14 {
     margin-bottom: 0;
   }
 }
@@ -8059,7 +8517,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                         >
                           <NavigationLinks
                             heading="Two column list"
-                            listColumns="2"
+                            listColumns={2}
                           >
                             <styled.div>
                               <StyledComponent
@@ -8179,11 +8637,11 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                     </StyledComponent>
                                   </Styled(Heading)>
                                   <styled.ul
-                                    columns="2"
+                                    columns={2}
                                     inline={false}
                                   >
                                     <StyledComponent
-                                      columns="2"
+                                      columns={2}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
@@ -8191,7 +8649,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-VigVT",
                                             "isStatic": false,
-                                            "lastClassName": "c9",
+                                            "lastClassName": "c10",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -8266,11 +8724,8 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -8279,13 +8734,58 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -8296,59 +8796,55 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 1
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 1
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -8399,11 +8895,8 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                                 as={[Function]}
                                                 to="/footer-nav-item-2"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   as={[Function]}
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                   to="/footer-nav-item-2"
                                                 >
                                                   <StyledComponent
@@ -8414,36 +8907,9 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
-  font-family: sans-serif;
-}",
-                                                            ":link {
-  color: #005ea5;
-} :visited {
-  color: #4c2c92;
-} :hover {
-  color: #2b8cc4;
-} :active {
-  color: #2b8cc4;
-} :focus {
-  color: #0b0c0c;
-}",
-                                                            "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
-}",
-                                                            "@media print {
-  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
-  &::after {
-  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
-}
-}
-}",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
                                                             ":link, :visited {
   color: #454a4c;
 } :hover {
@@ -8451,50 +8917,33 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 }",
                                                           ],
                                                         },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
                                                         "render": [Function],
                                                         "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
+                                                        "target": [Function],
                                                         "toString": [Function],
                                                         "warnTooManyClasses": [Function],
                                                         "withComponent": [Function],
                                                       }
                                                     }
                                                     forwardedRef={null}
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
                                                     to="/footer-nav-item-2"
                                                   >
                                                     <Link
                                                       className="c8"
-                                                      muted={false}
-                                                      noVisitedState={false}
-                                                      textColour={false}
                                                       to="/footer-nav-item-2"
                                                     >
                                                       <a
                                                         className="c8"
                                                         href="/footer-nav-item-2"
-                                                        muted={false}
-                                                        noVisitedState={false}
                                                         onClick={[Function]}
-                                                        textColour={false}
                                                       >
                                                         Navigation item 2 (Router Link)
                                                       </a>
                                                     </Link>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -8544,11 +8993,8 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -8557,13 +9003,58 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -8574,59 +9065,55 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 3
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 3
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -8676,11 +9163,8 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -8689,13 +9173,58 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -8706,59 +9235,55 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 4
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 4
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -8808,11 +9333,8 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -8821,13 +9343,58 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -8838,59 +9405,55 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 5
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 5
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -8940,11 +9503,8 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -8953,13 +9513,58 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -8970,59 +9575,55 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 6
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 6
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -9168,7 +9769,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-VigVT",
                                             "isStatic": false,
-                                            "lastClassName": "c9",
+                                            "lastClassName": "c10",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -9196,7 +9797,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                       inline={false}
                                     >
                                       <ul
-                                        className="c9"
+                                        className="c10"
                                       >
                                         <styled.li
                                           inline={false}
@@ -9243,11 +9844,8 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -9256,13 +9854,58 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -9273,59 +9916,55 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 1
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 1
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -9375,11 +10014,8 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -9388,13 +10024,58 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -9405,59 +10086,55 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 2
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 2
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -9507,11 +10184,8 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                               <FooterLink
                                                 href="/"
                                               >
-                                                <Styled(styled.a)
+                                                <Styled(LinkDocumented)
                                                   href="/"
-                                                  muted={false}
-                                                  noVisitedState={false}
-                                                  textColour={false}
                                                 >
                                                   <StyledComponent
                                                     forwardedComponent={
@@ -9520,13 +10194,58 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "sc-bxivhb",
-                                                          "isStatic": false,
+                                                          "isStatic": true,
                                                           "lastClassName": "c8",
                                                           "rules": Array [
-                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                            ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                          ],
+                                                        },
+                                                        "displayName": "Styled(LinkDocumented)",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-bxivhb",
+                                                        "target": [Function],
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="/"
+                                                  >
+                                                    <LinkDocumented
+                                                      className="c8"
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <styled.a
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <StyledComponent
+                                                          className="c8"
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-htpNat",
+                                                                "isStatic": false,
+                                                                "lastClassName": "c9",
+                                                                "rules": Array [
+                                                                  "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                            ":link {
+                                                                  ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -9537,59 +10256,55 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 } :focus {
   color: #0b0c0c;
 }",
-                                                            "&:focus {
+                                                                  "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                            "@media print {
+                                                                  "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                            [Function],
-                                                            [Function],
-                                                            [Function],
-                                                            ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                          ],
-                                                        },
-                                                        "defaultProps": Object {
-                                                          "muted": false,
-                                                          "noVisitedState": false,
-                                                          "textColour": false,
-                                                        },
-                                                        "displayName": "Styled(styled.a)",
-                                                        "foldedComponentIds": Array [
-                                                          "sc-htpNat",
-                                                        ],
-                                                        "propTypes": undefined,
-                                                        "render": [Function],
-                                                        "styledComponentId": "sc-bxivhb",
-                                                        "target": "a",
-                                                        "toString": [Function],
-                                                        "warnTooManyClasses": [Function],
-                                                        "withComponent": [Function],
-                                                      }
-                                                    }
-                                                    forwardedRef={null}
-                                                    href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
-                                                  >
-                                                    <a
-                                                      className="c8"
-                                                      href="/"
-                                                      muted={false}
-                                                    >
-                                                      Navigation item 3
-                                                    </a>
+                                                                  [Function],
+                                                                  [Function],
+                                                                  [Function],
+                                                                ],
+                                                              },
+                                                              "defaultProps": Object {
+                                                                "muted": false,
+                                                                "noVisitedState": false,
+                                                                "textColour": false,
+                                                              },
+                                                              "displayName": "styled.a",
+                                                              "foldedComponentIds": Array [],
+                                                              "propTypes": undefined,
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-htpNat",
+                                                              "target": "a",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <a
+                                                            className="c8 c9"
+                                                            href="/"
+                                                            muted={false}
+                                                          >
+                                                            Navigation item 3
+                                                          </a>
+                                                        </StyledComponent>
+                                                      </styled.a>
+                                                    </LinkDocumented>
                                                   </StyledComponent>
-                                                </Styled(styled.a)>
+                                                </Styled(LinkDocumented)>
                                               </FooterLink>
                                             </li>
                                           </StyledComponent>
@@ -9613,7 +10328,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                             "componentStyle": ComponentStyle {
                               "componentId": "sc-ifAKCX",
                               "isStatic": false,
-                              "lastClassName": "c10",
+                              "lastClassName": "c11",
                               "rules": Array [
                                 "margin: 0; border: 0; border-bottom: 1px solid #bfc1c3;",
                                 [Function],
@@ -9632,7 +10347,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                         forwardedRef={null}
                       >
                         <hr
-                          className="c10"
+                          className="c11"
                         />
                       </StyledComponent>
                     </styled.hr>
@@ -9646,7 +10361,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                               "componentStyle": ComponentStyle {
                                 "componentId": "sc-bZQynM",
                                 "isStatic": true,
-                                "lastClassName": "c11",
+                                "lastClassName": "c12",
                                 "rules": Array [
                                   "display: flex; margin-right: -15px; margin-left: -15px; flex-wrap: wrap; align-items: flex-end; justify-content: center;",
                                   "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
@@ -9667,7 +10382,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                           forwardedRef={null}
                         >
                           <div
-                            className="c11"
+                            className="c12"
                           >
                             <styled.div
                               grow={true}
@@ -9680,7 +10395,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                     "componentStyle": ComponentStyle {
                                       "componentId": "sc-gzVnrw",
                                       "isStatic": false,
-                                      "lastClassName": "c12",
+                                      "lastClassName": "c13",
                                       "rules": Array [
                                         "margin-right: 15px; margin-bottom: 25px; margin-left: 15px;",
                                         [Function],
@@ -9706,7 +10421,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                 grow={true}
                               >
                                 <div
-                                  className="c12"
+                                  className="c13"
                                 >
                                   <Licence>
                                     <div>
@@ -9727,7 +10442,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "sc-htoDjs",
                                                 "isStatic": true,
-                                                "lastClassName": "c13",
+                                                "lastClassName": "c14",
                                                 "rules": Array [
                                                   "display: inline-block; margin-right: 10px; margin-bottom: 15px; vertical-align: top; @media only screen and (min-width: 769px) {
   margin-bottom: 0;
@@ -9752,7 +10467,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                           xmlns="http://www.w3.org/2000/svg"
                                         >
                                           <svg
-                                            className="c13"
+                                            className="c14"
                                             focusable="false"
                                             height="17"
                                             role="presentation"
@@ -9776,7 +10491,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "sc-dnqmqq",
                                                 "isStatic": true,
-                                                "lastClassName": "c14",
+                                                "lastClassName": "c15",
                                                 "rules": Array [
                                                   "display: inline-block;",
                                                 ],
@@ -9794,7 +10509,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                           forwardedRef={null}
                                         >
                                           <span
-                                            className="c14"
+                                            className="c15"
                                           >
                                             All content is available under the Open Government Licence v3.0, except where otherwise stated
                                           </span>
@@ -9835,33 +10550,33 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
   margin: 0 15px;
 }
 
-.c8 {
+.c9 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-.c8:link {
+.c9:link {
   color: #005ea5;
 }
 
-.c8:visited {
+.c9:visited {
   color: #4c2c92;
 }
 
-.c8:hover {
+.c9:hover {
   color: #2b8cc4;
 }
 
-.c8:active {
+.c9:active {
   color: #2b8cc4;
 }
 
-.c8:focus {
+.c9:focus {
   color: #0b0c0c;
 }
 
-.c8:focus {
+.c9:focus {
   outline: 3px solid #ffbf47;
   outline-offset: 0;
   background-color: #ffbf47;
@@ -9911,14 +10626,14 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
   flex-basis: 320px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   margin-right: 10px;
   margin-bottom: 15px;
   vertical-align: top;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
 }
 
@@ -9993,15 +10708,15 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
 }
 
 @media print {
-  .c8 {
+  .c9 {
     font-family: sans-serif;
   }
 }
 
 @media print {
-  .c8[href^="/"]::after,
-  .c8[href^="http://"]::after,
-  .c8[href^="https://"]::after {
+  .c9[href^="/"]::after,
+  .c9[href^="http://"]::after,
+  .c9[href^="https://"]::after {
     content: " (" attr(href) ")";
     font-size: 90%;
     word-wrap: break-word;
@@ -10023,7 +10738,7 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
 }
 
 @media only screen and (min-width:769px) {
-  .c9 {
+  .c10 {
     margin-bottom: 0;
   }
 }
@@ -10474,11 +11189,8 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
                                                 <FooterLink
                                                   href="/"
                                                 >
-                                                  <Styled(styled.a)
+                                                  <Styled(LinkDocumented)
                                                     href="/"
-                                                    muted={false}
-                                                    noVisitedState={false}
-                                                    textColour={false}
                                                   >
                                                     <StyledComponent
                                                       forwardedComponent={
@@ -10487,13 +11199,58 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
                                                           "attrs": Array [],
                                                           "componentStyle": ComponentStyle {
                                                             "componentId": "sc-bxivhb",
-                                                            "isStatic": false,
+                                                            "isStatic": true,
                                                             "lastClassName": "c8",
                                                             "rules": Array [
-                                                              "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                              ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                            ],
+                                                          },
+                                                          "displayName": "Styled(LinkDocumented)",
+                                                          "foldedComponentIds": Array [],
+                                                          "render": [Function],
+                                                          "styledComponentId": "sc-bxivhb",
+                                                          "target": [Function],
+                                                          "toString": [Function],
+                                                          "warnTooManyClasses": [Function],
+                                                          "withComponent": [Function],
+                                                        }
+                                                      }
+                                                      forwardedRef={null}
+                                                      href="/"
+                                                    >
+                                                      <LinkDocumented
+                                                        className="c8"
+                                                        href="/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        textColour={false}
+                                                      >
+                                                        <styled.a
+                                                          className="c8"
+                                                          href="/"
+                                                          muted={false}
+                                                          noVisitedState={false}
+                                                          textColour={false}
+                                                        >
+                                                          <StyledComponent
+                                                            className="c8"
+                                                            forwardedComponent={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "attrs": Array [],
+                                                                "componentStyle": ComponentStyle {
+                                                                  "componentId": "sc-htpNat",
+                                                                  "isStatic": false,
+                                                                  "lastClassName": "c9",
+                                                                  "rules": Array [
+                                                                    "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                              ":link {
+                                                                    ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -10504,59 +11261,55 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
 } :focus {
   color: #0b0c0c;
 }",
-                                                              "&:focus {
+                                                                    "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                              "@media print {
+                                                                    "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                              [Function],
-                                                              [Function],
-                                                              [Function],
-                                                              ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                            ],
-                                                          },
-                                                          "defaultProps": Object {
-                                                            "muted": false,
-                                                            "noVisitedState": false,
-                                                            "textColour": false,
-                                                          },
-                                                          "displayName": "Styled(styled.a)",
-                                                          "foldedComponentIds": Array [
-                                                            "sc-htpNat",
-                                                          ],
-                                                          "propTypes": undefined,
-                                                          "render": [Function],
-                                                          "styledComponentId": "sc-bxivhb",
-                                                          "target": "a",
-                                                          "toString": [Function],
-                                                          "warnTooManyClasses": [Function],
-                                                          "withComponent": [Function],
-                                                        }
-                                                      }
-                                                      forwardedRef={null}
-                                                      href="/"
-                                                      muted={false}
-                                                      noVisitedState={false}
-                                                      textColour={false}
-                                                    >
-                                                      <a
-                                                        className="c8"
-                                                        href="/"
-                                                        muted={false}
-                                                      >
-                                                        Item 1
-                                                      </a>
+                                                                    [Function],
+                                                                    [Function],
+                                                                    [Function],
+                                                                  ],
+                                                                },
+                                                                "defaultProps": Object {
+                                                                  "muted": false,
+                                                                  "noVisitedState": false,
+                                                                  "textColour": false,
+                                                                },
+                                                                "displayName": "styled.a",
+                                                                "foldedComponentIds": Array [],
+                                                                "propTypes": undefined,
+                                                                "render": [Function],
+                                                                "styledComponentId": "sc-htpNat",
+                                                                "target": "a",
+                                                                "toString": [Function],
+                                                                "warnTooManyClasses": [Function],
+                                                                "withComponent": [Function],
+                                                              }
+                                                            }
+                                                            forwardedRef={null}
+                                                            href="/"
+                                                            muted={false}
+                                                            noVisitedState={false}
+                                                            textColour={false}
+                                                          >
+                                                            <a
+                                                              className="c8 c9"
+                                                              href="/"
+                                                              muted={false}
+                                                            >
+                                                              Item 1
+                                                            </a>
+                                                          </StyledComponent>
+                                                        </styled.a>
+                                                      </LinkDocumented>
                                                     </StyledComponent>
-                                                  </Styled(styled.a)>
+                                                  </Styled(LinkDocumented)>
                                                 </FooterLink>
                                               </li>
                                             </StyledComponent>
@@ -10584,7 +11337,7 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "sc-htoDjs",
                                                 "isStatic": true,
-                                                "lastClassName": "c9",
+                                                "lastClassName": "c10",
                                                 "rules": Array [
                                                   "display: inline-block; margin-right: 10px; margin-bottom: 15px; vertical-align: top; @media only screen and (min-width: 769px) {
   margin-bottom: 0;
@@ -10609,7 +11362,7 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
                                           xmlns="http://www.w3.org/2000/svg"
                                         >
                                           <svg
-                                            className="c9"
+                                            className="c10"
                                             focusable="false"
                                             height="17"
                                             role="presentation"
@@ -10633,7 +11386,7 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "sc-dnqmqq",
                                                 "isStatic": true,
-                                                "lastClassName": "c10",
+                                                "lastClassName": "c11",
                                                 "rules": Array [
                                                   "display: inline-block;",
                                                 ],
@@ -10651,7 +11404,7 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
                                           forwardedRef={null}
                                         >
                                           <span
-                                            className="c10"
+                                            className="c11"
                                           >
                                             All content is available under the Open Government Licence v3.0, except where otherwise stated
                                           </span>
@@ -10704,33 +11457,33 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
   flex-wrap: wrap;
 }
 
-.c8 {
+.c9 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-.c8:link {
+.c9:link {
   color: #005ea5;
 }
 
-.c8:visited {
+.c9:visited {
   color: #4c2c92;
 }
 
-.c8:hover {
+.c9:hover {
   color: #2b8cc4;
 }
 
-.c8:active {
+.c9:active {
   color: #2b8cc4;
 }
 
-.c8:focus {
+.c9:focus {
   color: #0b0c0c;
 }
 
-.c8:focus {
+.c9:focus {
   outline: 3px solid #ffbf47;
   outline-offset: 0;
   background-color: #ffbf47;
@@ -10745,14 +11498,14 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
   color: #171819;
 }
 
-.c9 {
+.c10 {
   margin: 0;
   border: 0;
   border-bottom: 1px solid #bfc1c3;
   margin-bottom: 30px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10775,7 +11528,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
   -moz-osx-font-smoothing: grayscale;
 }
 
-.c11 {
+.c12 {
   margin-right: 15px;
   margin-bottom: 25px;
   margin-left: 15px;
@@ -10787,14 +11540,14 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
   flex-basis: 320px;
 }
 
-.c12 {
+.c13 {
   display: inline-block;
   margin-right: 10px;
   margin-bottom: 15px;
   vertical-align: top;
 }
 
-.c13 {
+.c14 {
   display: inline-block;
 }
 
@@ -10879,15 +11632,15 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
 }
 
 @media print {
-  .c8 {
+  .c9 {
     font-family: sans-serif;
   }
 }
 
 @media print {
-  .c8[href^="/"]::after,
-  .c8[href^="http://"]::after,
-  .c8[href^="https://"]::after {
+  .c9[href^="/"]::after,
+  .c9[href^="http://"]::after,
+  .c9[href^="https://"]::after {
     content: " (" attr(href) ")";
     font-size: 90%;
     word-wrap: break-word;
@@ -10895,19 +11648,19 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
 }
 
 @media only screen and (min-width:641px) {
-  .c9 {
+  .c10 {
     margin-bottom: 50px;
   }
 }
 
 @media print {
-  .c10 {
+  .c11 {
     font-family: sans-serif;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c12 {
     -webkit-flex-basis: auto;
     -ms-flex-preferred-size: auto;
     flex-basis: auto;
@@ -10915,7 +11668,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
 }
 
 @media only screen and (min-width:769px) {
-  .c12 {
+  .c13 {
     margin-bottom: 0;
   }
 }
@@ -11345,11 +12098,8 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                                           <FooterLink
                                             href="/"
                                           >
-                                            <Styled(styled.a)
+                                            <Styled(LinkDocumented)
                                               href="/"
-                                              muted={false}
-                                              noVisitedState={false}
-                                              textColour={false}
                                             >
                                               <StyledComponent
                                                 forwardedComponent={
@@ -11358,13 +12108,58 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                                                     "attrs": Array [],
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "sc-bxivhb",
-                                                      "isStatic": false,
+                                                      "isStatic": true,
                                                       "lastClassName": "c8",
                                                       "rules": Array [
-                                                        "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+                                                        ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                      ],
+                                                    },
+                                                    "displayName": "Styled(LinkDocumented)",
+                                                    "foldedComponentIds": Array [],
+                                                    "render": [Function],
+                                                    "styledComponentId": "sc-bxivhb",
+                                                    "target": [Function],
+                                                    "toString": [Function],
+                                                    "warnTooManyClasses": [Function],
+                                                    "withComponent": [Function],
+                                                  }
+                                                }
+                                                forwardedRef={null}
+                                                href="/"
+                                              >
+                                                <LinkDocumented
+                                                  className="c8"
+                                                  href="/"
+                                                  muted={false}
+                                                  noVisitedState={false}
+                                                  textColour={false}
+                                                >
+                                                  <styled.a
+                                                    className="c8"
+                                                    href="/"
+                                                    muted={false}
+                                                    noVisitedState={false}
+                                                    textColour={false}
+                                                  >
+                                                    <StyledComponent
+                                                      className="c8"
+                                                      forwardedComponent={
+                                                        Object {
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "attrs": Array [],
+                                                          "componentStyle": ComponentStyle {
+                                                            "componentId": "sc-htpNat",
+                                                            "isStatic": false,
+                                                            "lastClassName": "c9",
+                                                            "rules": Array [
+                                                              "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
 }",
-                                                        ":link {
+                                                              ":link {
   color: #005ea5;
 } :visited {
   color: #4c2c92;
@@ -11375,59 +12170,55 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
 } :focus {
   color: #0b0c0c;
 }",
-                                                        "&:focus {
+                                                              "&:focus {
   outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
 }",
-                                                        "@media print {
+                                                              "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
   &::after {
   content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
 }
 }
 }",
-                                                        [Function],
-                                                        [Function],
-                                                        [Function],
-                                                        ":link, :visited {
-  color: #454a4c;
-} :hover {
-  color: #171819;
-}",
-                                                      ],
-                                                    },
-                                                    "defaultProps": Object {
-                                                      "muted": false,
-                                                      "noVisitedState": false,
-                                                      "textColour": false,
-                                                    },
-                                                    "displayName": "Styled(styled.a)",
-                                                    "foldedComponentIds": Array [
-                                                      "sc-htpNat",
-                                                    ],
-                                                    "propTypes": undefined,
-                                                    "render": [Function],
-                                                    "styledComponentId": "sc-bxivhb",
-                                                    "target": "a",
-                                                    "toString": [Function],
-                                                    "warnTooManyClasses": [Function],
-                                                    "withComponent": [Function],
-                                                  }
-                                                }
-                                                forwardedRef={null}
-                                                href="/"
-                                                muted={false}
-                                                noVisitedState={false}
-                                                textColour={false}
-                                              >
-                                                <a
-                                                  className="c8"
-                                                  href="/"
-                                                  muted={false}
-                                                >
-                                                  Navigation item 1
-                                                </a>
+                                                              [Function],
+                                                              [Function],
+                                                              [Function],
+                                                            ],
+                                                          },
+                                                          "defaultProps": Object {
+                                                            "muted": false,
+                                                            "noVisitedState": false,
+                                                            "textColour": false,
+                                                          },
+                                                          "displayName": "styled.a",
+                                                          "foldedComponentIds": Array [],
+                                                          "propTypes": undefined,
+                                                          "render": [Function],
+                                                          "styledComponentId": "sc-htpNat",
+                                                          "target": "a",
+                                                          "toString": [Function],
+                                                          "warnTooManyClasses": [Function],
+                                                          "withComponent": [Function],
+                                                        }
+                                                      }
+                                                      forwardedRef={null}
+                                                      href="/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      textColour={false}
+                                                    >
+                                                      <a
+                                                        className="c8 c9"
+                                                        href="/"
+                                                        muted={false}
+                                                      >
+                                                        Navigation item 1
+                                                      </a>
+                                                    </StyledComponent>
+                                                  </styled.a>
+                                                </LinkDocumented>
                                               </StyledComponent>
-                                            </Styled(styled.a)>
+                                            </Styled(LinkDocumented)>
                                           </FooterLink>
                                         </li>
                                       </StyledComponent>
@@ -11451,7 +12242,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                         "componentStyle": ComponentStyle {
                           "componentId": "sc-ifAKCX",
                           "isStatic": false,
-                          "lastClassName": "c9",
+                          "lastClassName": "c10",
                           "rules": Array [
                             "margin: 0; border: 0; border-bottom: 1px solid #bfc1c3;",
                             [Function],
@@ -11470,7 +12261,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                     forwardedRef={null}
                   >
                     <hr
-                      className="c9"
+                      className="c10"
                     />
                   </StyledComponent>
                 </styled.hr>
@@ -11484,7 +12275,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                           "componentStyle": ComponentStyle {
                             "componentId": "sc-bZQynM",
                             "isStatic": true,
-                            "lastClassName": "c10",
+                            "lastClassName": "c11",
                             "rules": Array [
                               "display: flex; margin-right: -15px; margin-left: -15px; flex-wrap: wrap; align-items: flex-end; justify-content: center;",
                               "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
@@ -11505,7 +12296,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                       forwardedRef={null}
                     >
                       <div
-                        className="c10"
+                        className="c11"
                       >
                         <styled.div
                           grow={true}
@@ -11518,7 +12309,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                                 "componentStyle": ComponentStyle {
                                   "componentId": "sc-gzVnrw",
                                   "isStatic": false,
-                                  "lastClassName": "c11",
+                                  "lastClassName": "c12",
                                   "rules": Array [
                                     "margin-right: 15px; margin-bottom: 25px; margin-left: 15px;",
                                     [Function],
@@ -11544,7 +12335,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                             grow={true}
                           >
                             <div
-                              className="c11"
+                              className="c12"
                             >
                               <Licence>
                                 <div>
@@ -11565,7 +12356,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-htoDjs",
                                             "isStatic": true,
-                                            "lastClassName": "c12",
+                                            "lastClassName": "c13",
                                             "rules": Array [
                                               "display: inline-block; margin-right: 10px; margin-bottom: 15px; vertical-align: top; @media only screen and (min-width: 769px) {
   margin-bottom: 0;
@@ -11590,7 +12381,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
                                       <svg
-                                        className="c12"
+                                        className="c13"
                                         focusable="false"
                                         height="17"
                                         role="presentation"
@@ -11614,7 +12405,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-dnqmqq",
                                             "isStatic": true,
-                                            "lastClassName": "c13",
+                                            "lastClassName": "c14",
                                             "rules": Array [
                                               "display: inline-block;",
                                             ],
@@ -11632,7 +12423,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                                       forwardedRef={null}
                                     >
                                       <span
-                                        className="c13"
+                                        className="c14"
                                       >
                                         All content is available under the Open Government Licence v3.0, except where otherwise stated
                                       </span>

--- a/components/footer/src/__snapshots__/test.js.snap
+++ b/components/footer/src/__snapshots__/test.js.snap
@@ -141,11 +141,11 @@ exports[`Footer matches default snapshot: Footer 1`] = `
   }
 }
 
-@media only screen and (min-width:641px) {
+@media only screen and (min-width:769px) {
   .c3 {
-    -webkit-flex-basis: auto;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto;
+    -webkit-flex-basis: 0;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
   }
 }
 
@@ -800,11 +800,11 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
   }
 }
 
-@media only screen and (min-width:641px) {
+@media only screen and (min-width:769px) {
   .c3 {
-    -webkit-flex-basis: auto;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto;
+    -webkit-flex-basis: 0;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
   }
 }
 
@@ -1582,11 +1582,11 @@ exports[`Footer matches with custom width snapshot: FooterWithCustomWidth 1`] = 
   }
 }
 
-@media only screen and (min-width:641px) {
+@media only screen and (min-width:769px) {
   .c3 {
-    -webkit-flex-basis: auto;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto;
+    -webkit-flex-basis: 0;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
   }
 }
 
@@ -2215,11 +2215,11 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
   }
 }
 
-@media only screen and (min-width:641px) {
+@media only screen and (min-width:769px) {
   .c3 {
-    -webkit-flex-basis: auto;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto;
+    -webkit-flex-basis: 0;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
   }
 }
 
@@ -3032,11 +3032,11 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
   }
 }
 
-@media only screen and (min-width:641px) {
+@media only screen and (min-width:769px) {
   .c3 {
-    -webkit-flex-basis: auto;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto;
+    -webkit-flex-basis: 0;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
   }
 }
 
@@ -4510,11 +4510,11 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
   }
 }
 
-@media only screen and (min-width:641px) {
+@media only screen and (min-width:769px) {
   .c3 {
-    -webkit-flex-basis: auto;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto;
+    -webkit-flex-basis: 0;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
   }
 }
 
@@ -5911,11 +5911,11 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   }
 }
 
-@media only screen and (min-width:641px) {
+@media only screen and (min-width:769px) {
   .c13 {
-    -webkit-flex-basis: auto;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto;
+    -webkit-flex-basis: 0;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
   }
 }
 
@@ -9379,11 +9379,11 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   }
 }
 
-@media only screen and (min-width:641px) {
+@media only screen and (min-width:769px) {
   .c13 {
-    -webkit-flex-basis: auto;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto;
+    -webkit-flex-basis: 0;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
   }
 }
 
@@ -12004,11 +12004,11 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
   }
 }
 
-@media only screen and (min-width:641px) {
+@media only screen and (min-width:769px) {
   .c3 {
-    -webkit-flex-basis: auto;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto;
+    -webkit-flex-basis: 0;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
   }
 }
 
@@ -13068,11 +13068,11 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
   }
 }
 
-@media only screen and (min-width:641px) {
+@media only screen and (min-width:769px) {
   .c12 {
-    -webkit-flex-basis: auto;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto;
+    -webkit-flex-basis: 0;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
   }
 }
 

--- a/components/footer/src/__snapshots__/test.js.snap
+++ b/components/footer/src/__snapshots__/test.js.snap
@@ -5292,7 +5292,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                 <div
                                   className="c3"
                                 >
-                                  <Styled(Heading)
+                                  <Styled(H2)
                                     size="MEDIUM"
                                   >
                                     <StyledComponent
@@ -5311,7 +5311,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "Styled(Heading)",
+                                          "displayName": "Styled(H2)",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
                                           "styledComponentId": "sc-jzJRlG",
@@ -5324,58 +5324,66 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                       forwardedRef={null}
                                       size="MEDIUM"
                                     >
-                                      <Heading
+                                      <H2
                                         className="c4"
                                         size="MEDIUM"
                                       >
-                                        <styled.h1
+                                        <Heading
+                                          as="h2"
                                           className="c4"
                                           size="MEDIUM"
                                         >
-                                          <StyledComponent
+                                          <styled.h1
+                                            as="h2"
                                             className="c4"
-                                            forwardedComponent={
-                                              Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "attrs": Array [],
-                                                "componentStyle": ComponentStyle {
-                                                  "componentId": "sc-gZMcBi",
-                                                  "isStatic": false,
-                                                  "lastClassName": "c15",
-                                                  "rules": Array [
-                                                    "color: #0b0c0c; @media print {
-  color: #000;
-}",
-                                                    [Function],
-                                                    "display: block; margin-top: 0;",
-                                                    [Function],
-                                                    [Function],
-                                                  ],
-                                                },
-                                                "displayName": "styled.h1",
-                                                "foldedComponentIds": Array [],
-                                                "render": [Function],
-                                                "styledComponentId": "sc-gZMcBi",
-                                                "target": "h1",
-                                                "toString": [Function],
-                                                "warnTooManyClasses": [Function],
-                                                "withComponent": [Function],
-                                              }
-                                            }
-                                            forwardedRef={null}
                                             size="MEDIUM"
                                           >
-                                            <h1
-                                              className="c4 c5"
+                                            <StyledComponent
+                                              as="h2"
+                                              className="c4"
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-gZMcBi",
+                                                    "isStatic": false,
+                                                    "lastClassName": "c15",
+                                                    "rules": Array [
+                                                      "color: #0b0c0c; @media print {
+  color: #000;
+}",
+                                                      [Function],
+                                                      "display: block; margin-top: 0;",
+                                                      [Function],
+                                                      [Function],
+                                                    ],
+                                                  },
+                                                  "displayName": "styled.h1",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-gZMcBi",
+                                                  "target": "h1",
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
                                               size="MEDIUM"
                                             >
-                                              Two column list
-                                            </h1>
-                                          </StyledComponent>
-                                        </styled.h1>
-                                      </Heading>
+                                              <h2
+                                                className="c4 c5"
+                                                size="MEDIUM"
+                                              >
+                                                Two column list
+                                              </h2>
+                                            </StyledComponent>
+                                          </styled.h1>
+                                        </Heading>
+                                      </H2>
                                     </StyledComponent>
-                                  </Styled(Heading)>
+                                  </Styled(H2)>
                                   <styled.ul
                                     columns={2}
                                     inline={false}
@@ -6412,7 +6420,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                 <div
                                   className="c3"
                                 >
-                                  <Styled(Heading)
+                                  <Styled(H2)
                                     size="MEDIUM"
                                   >
                                     <StyledComponent
@@ -6431,7 +6439,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "Styled(Heading)",
+                                          "displayName": "Styled(H2)",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
                                           "styledComponentId": "sc-jzJRlG",
@@ -6444,58 +6452,66 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                       forwardedRef={null}
                                       size="MEDIUM"
                                     >
-                                      <Heading
+                                      <H2
                                         className="c4"
                                         size="MEDIUM"
                                       >
-                                        <styled.h1
+                                        <Heading
+                                          as="h2"
                                           className="c4"
                                           size="MEDIUM"
                                         >
-                                          <StyledComponent
+                                          <styled.h1
+                                            as="h2"
                                             className="c4"
-                                            forwardedComponent={
-                                              Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "attrs": Array [],
-                                                "componentStyle": ComponentStyle {
-                                                  "componentId": "sc-gZMcBi",
-                                                  "isStatic": false,
-                                                  "lastClassName": "c15",
-                                                  "rules": Array [
-                                                    "color: #0b0c0c; @media print {
-  color: #000;
-}",
-                                                    [Function],
-                                                    "display: block; margin-top: 0;",
-                                                    [Function],
-                                                    [Function],
-                                                  ],
-                                                },
-                                                "displayName": "styled.h1",
-                                                "foldedComponentIds": Array [],
-                                                "render": [Function],
-                                                "styledComponentId": "sc-gZMcBi",
-                                                "target": "h1",
-                                                "toString": [Function],
-                                                "warnTooManyClasses": [Function],
-                                                "withComponent": [Function],
-                                              }
-                                            }
-                                            forwardedRef={null}
                                             size="MEDIUM"
                                           >
-                                            <h1
-                                              className="c4 c5"
+                                            <StyledComponent
+                                              as="h2"
+                                              className="c4"
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-gZMcBi",
+                                                    "isStatic": false,
+                                                    "lastClassName": "c15",
+                                                    "rules": Array [
+                                                      "color: #0b0c0c; @media print {
+  color: #000;
+}",
+                                                      [Function],
+                                                      "display: block; margin-top: 0;",
+                                                      [Function],
+                                                      [Function],
+                                                    ],
+                                                  },
+                                                  "displayName": "styled.h1",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-gZMcBi",
+                                                  "target": "h1",
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
                                               size="MEDIUM"
                                             >
-                                              Single column list
-                                            </h1>
-                                          </StyledComponent>
-                                        </styled.h1>
-                                      </Heading>
+                                              <h2
+                                                className="c4 c5"
+                                                size="MEDIUM"
+                                              >
+                                                Single column list
+                                              </h2>
+                                            </StyledComponent>
+                                          </styled.h1>
+                                        </Heading>
+                                      </H2>
                                     </StyledComponent>
-                                  </Styled(Heading)>
+                                  </Styled(H2)>
                                   <styled.ul
                                     columns={0}
                                     inline={false}
@@ -8552,7 +8568,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                 <div
                                   className="c3"
                                 >
-                                  <Styled(Heading)
+                                  <Styled(H2)
                                     size="MEDIUM"
                                   >
                                     <StyledComponent
@@ -8571,7 +8587,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "Styled(Heading)",
+                                          "displayName": "Styled(H2)",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
                                           "styledComponentId": "sc-jzJRlG",
@@ -8584,58 +8600,66 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                       forwardedRef={null}
                                       size="MEDIUM"
                                     >
-                                      <Heading
+                                      <H2
                                         className="c4"
                                         size="MEDIUM"
                                       >
-                                        <styled.h1
+                                        <Heading
+                                          as="h2"
                                           className="c4"
                                           size="MEDIUM"
                                         >
-                                          <StyledComponent
+                                          <styled.h1
+                                            as="h2"
                                             className="c4"
-                                            forwardedComponent={
-                                              Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "attrs": Array [],
-                                                "componentStyle": ComponentStyle {
-                                                  "componentId": "sc-gZMcBi",
-                                                  "isStatic": false,
-                                                  "lastClassName": "c5",
-                                                  "rules": Array [
-                                                    "color: #0b0c0c; @media print {
-  color: #000;
-}",
-                                                    [Function],
-                                                    "display: block; margin-top: 0;",
-                                                    [Function],
-                                                    [Function],
-                                                  ],
-                                                },
-                                                "displayName": "styled.h1",
-                                                "foldedComponentIds": Array [],
-                                                "render": [Function],
-                                                "styledComponentId": "sc-gZMcBi",
-                                                "target": "h1",
-                                                "toString": [Function],
-                                                "warnTooManyClasses": [Function],
-                                                "withComponent": [Function],
-                                              }
-                                            }
-                                            forwardedRef={null}
                                             size="MEDIUM"
                                           >
-                                            <h1
-                                              className="c4 c5"
+                                            <StyledComponent
+                                              as="h2"
+                                              className="c4"
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-gZMcBi",
+                                                    "isStatic": false,
+                                                    "lastClassName": "c5",
+                                                    "rules": Array [
+                                                      "color: #0b0c0c; @media print {
+  color: #000;
+}",
+                                                      [Function],
+                                                      "display: block; margin-top: 0;",
+                                                      [Function],
+                                                      [Function],
+                                                    ],
+                                                  },
+                                                  "displayName": "styled.h1",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-gZMcBi",
+                                                  "target": "h1",
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
                                               size="MEDIUM"
                                             >
-                                              Two column list
-                                            </h1>
-                                          </StyledComponent>
-                                        </styled.h1>
-                                      </Heading>
+                                              <h2
+                                                className="c4 c5"
+                                                size="MEDIUM"
+                                              >
+                                                Two column list
+                                              </h2>
+                                            </StyledComponent>
+                                          </styled.h1>
+                                        </Heading>
+                                      </H2>
                                     </StyledComponent>
-                                  </Styled(Heading)>
+                                  </Styled(H2)>
                                   <styled.ul
                                     columns={2}
                                     inline={false}
@@ -9672,7 +9696,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                 <div
                                   className="c3"
                                 >
-                                  <Styled(Heading)
+                                  <Styled(H2)
                                     size="MEDIUM"
                                   >
                                     <StyledComponent
@@ -9691,7 +9715,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "Styled(Heading)",
+                                          "displayName": "Styled(H2)",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
                                           "styledComponentId": "sc-jzJRlG",
@@ -9704,58 +9728,66 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                       forwardedRef={null}
                                       size="MEDIUM"
                                     >
-                                      <Heading
+                                      <H2
                                         className="c4"
                                         size="MEDIUM"
                                       >
-                                        <styled.h1
+                                        <Heading
+                                          as="h2"
                                           className="c4"
                                           size="MEDIUM"
                                         >
-                                          <StyledComponent
+                                          <styled.h1
+                                            as="h2"
                                             className="c4"
-                                            forwardedComponent={
-                                              Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "attrs": Array [],
-                                                "componentStyle": ComponentStyle {
-                                                  "componentId": "sc-gZMcBi",
-                                                  "isStatic": false,
-                                                  "lastClassName": "c5",
-                                                  "rules": Array [
-                                                    "color: #0b0c0c; @media print {
-  color: #000;
-}",
-                                                    [Function],
-                                                    "display: block; margin-top: 0;",
-                                                    [Function],
-                                                    [Function],
-                                                  ],
-                                                },
-                                                "displayName": "styled.h1",
-                                                "foldedComponentIds": Array [],
-                                                "render": [Function],
-                                                "styledComponentId": "sc-gZMcBi",
-                                                "target": "h1",
-                                                "toString": [Function],
-                                                "warnTooManyClasses": [Function],
-                                                "withComponent": [Function],
-                                              }
-                                            }
-                                            forwardedRef={null}
                                             size="MEDIUM"
                                           >
-                                            <h1
-                                              className="c4 c5"
+                                            <StyledComponent
+                                              as="h2"
+                                              className="c4"
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-gZMcBi",
+                                                    "isStatic": false,
+                                                    "lastClassName": "c5",
+                                                    "rules": Array [
+                                                      "color: #0b0c0c; @media print {
+  color: #000;
+}",
+                                                      [Function],
+                                                      "display: block; margin-top: 0;",
+                                                      [Function],
+                                                      [Function],
+                                                    ],
+                                                  },
+                                                  "displayName": "styled.h1",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-gZMcBi",
+                                                  "target": "h1",
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
                                               size="MEDIUM"
                                             >
-                                              Single column list
-                                            </h1>
-                                          </StyledComponent>
-                                        </styled.h1>
-                                      </Heading>
+                                              <h2
+                                                className="c4 c5"
+                                                size="MEDIUM"
+                                              >
+                                                Single column list
+                                              </h2>
+                                            </StyledComponent>
+                                          </styled.h1>
+                                        </Heading>
+                                      </H2>
                                     </StyledComponent>
-                                  </Styled(Heading)>
+                                  </Styled(H2)>
                                   <styled.ul
                                     columns={0}
                                     inline={false}
@@ -11927,7 +11959,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                             <div
                               className="c3"
                             >
-                              <Styled(Heading)
+                              <Styled(H2)
                                 size="MEDIUM"
                               >
                                 <StyledComponent
@@ -11946,7 +11978,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                                           [Function],
                                         ],
                                       },
-                                      "displayName": "Styled(Heading)",
+                                      "displayName": "Styled(H2)",
                                       "foldedComponentIds": Array [],
                                       "render": [Function],
                                       "styledComponentId": "sc-jzJRlG",
@@ -11959,58 +11991,66 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                                   forwardedRef={null}
                                   size="MEDIUM"
                                 >
-                                  <Heading
+                                  <H2
                                     className="c4"
                                     size="MEDIUM"
                                   >
-                                    <styled.h1
+                                    <Heading
+                                      as="h2"
                                       className="c4"
                                       size="MEDIUM"
                                     >
-                                      <StyledComponent
+                                      <styled.h1
+                                        as="h2"
                                         className="c4"
-                                        forwardedComponent={
-                                          Object {
-                                            "$$typeof": Symbol(react.forward_ref),
-                                            "attrs": Array [],
-                                            "componentStyle": ComponentStyle {
-                                              "componentId": "sc-gZMcBi",
-                                              "isStatic": false,
-                                              "lastClassName": "c5",
-                                              "rules": Array [
-                                                "color: #0b0c0c; @media print {
-  color: #000;
-}",
-                                                [Function],
-                                                "display: block; margin-top: 0;",
-                                                [Function],
-                                                [Function],
-                                              ],
-                                            },
-                                            "displayName": "styled.h1",
-                                            "foldedComponentIds": Array [],
-                                            "render": [Function],
-                                            "styledComponentId": "sc-gZMcBi",
-                                            "target": "h1",
-                                            "toString": [Function],
-                                            "warnTooManyClasses": [Function],
-                                            "withComponent": [Function],
-                                          }
-                                        }
-                                        forwardedRef={null}
                                         size="MEDIUM"
                                       >
-                                        <h1
-                                          className="c4 c5"
+                                        <StyledComponent
+                                          as="h2"
+                                          className="c4"
+                                          forwardedComponent={
+                                            Object {
+                                              "$$typeof": Symbol(react.forward_ref),
+                                              "attrs": Array [],
+                                              "componentStyle": ComponentStyle {
+                                                "componentId": "sc-gZMcBi",
+                                                "isStatic": false,
+                                                "lastClassName": "c5",
+                                                "rules": Array [
+                                                  "color: #0b0c0c; @media print {
+  color: #000;
+}",
+                                                  [Function],
+                                                  "display: block; margin-top: 0;",
+                                                  [Function],
+                                                  [Function],
+                                                ],
+                                              },
+                                              "displayName": "styled.h1",
+                                              "foldedComponentIds": Array [],
+                                              "render": [Function],
+                                              "styledComponentId": "sc-gZMcBi",
+                                              "target": "h1",
+                                              "toString": [Function],
+                                              "warnTooManyClasses": [Function],
+                                              "withComponent": [Function],
+                                            }
+                                          }
+                                          forwardedRef={null}
                                           size="MEDIUM"
                                         >
-                                          Single column list
-                                        </h1>
-                                      </StyledComponent>
-                                    </styled.h1>
-                                  </Heading>
+                                          <h2
+                                            className="c4 c5"
+                                            size="MEDIUM"
+                                          >
+                                            Single column list
+                                          </h2>
+                                        </StyledComponent>
+                                      </styled.h1>
+                                    </Heading>
+                                  </H2>
                                 </StyledComponent>
-                              </Styled(Heading)>
+                              </Styled(H2)>
                               <styled.ul
                                 columns={0}
                                 inline={false}

--- a/components/footer/src/__snapshots__/test.js.snap
+++ b/components/footer/src/__snapshots__/test.js.snap
@@ -6,6 +6,47 @@ exports[`Footer matches default snapshot: Footer 1`] = `
   margin: 0 15px;
 }
 
+.c7 {
+  font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c7:link {
+  color: #005ea5;
+}
+
+.c7:visited {
+  color: #4c2c92;
+}
+
+.c7:hover {
+  color: #2b8cc4;
+}
+
+.c7:active {
+  color: #2b8cc4;
+}
+
+.c7:focus {
+  color: #0b0c0c;
+}
+
+.c7:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+  background-color: #ffbf47;
+}
+
+.c6:link,
+.c6:visited {
+  color: #454a4c;
+}
+
+.c6:hover {
+  color: #171819;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -75,6 +116,22 @@ exports[`Footer matches default snapshot: Footer 1`] = `
 @media only screen and (min-width:1020px) {
   .c1 {
     margin: 0 auto;
+  }
+}
+
+@media print {
+  .c7 {
+    font-family: sans-serif;
+  }
+}
+
+@media print {
+  .c7[href^="/"]::after,
+  .c7[href^="http://"]::after,
+  .c7[href^="https://"]::after {
+    content: " (" attr(href) ")";
+    font-size: 90%;
+    word-wrap: break-word;
   }
 }
 
@@ -387,7 +444,141 @@ exports[`Footer matches default snapshot: Footer 1`] = `
                                       <span
                                         className="c5"
                                       >
-                                        All content is available under the Open Government Licence v3.0, except where otherwise stated
+                                        All content is available under the
+                                         
+                                        <FooterLink
+                                          href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                          rel="license"
+                                        >
+                                          <Styled(LinkDocumented)
+                                            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                            rel="license"
+                                          >
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-bxivhb",
+                                                    "isStatic": true,
+                                                    "lastClassName": "c6",
+                                                    "rules": Array [
+                                                      ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                    ],
+                                                  },
+                                                  "displayName": "Styled(LinkDocumented)",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-bxivhb",
+                                                  "target": [Function],
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
+                                              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                              rel="license"
+                                            >
+                                              <LinkDocumented
+                                                className="c6"
+                                                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                muted={false}
+                                                noVisitedState={false}
+                                                rel="license"
+                                                textColour={false}
+                                              >
+                                                <styled.a
+                                                  className="c6"
+                                                  href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                  muted={false}
+                                                  noVisitedState={false}
+                                                  rel="license"
+                                                  textColour={false}
+                                                >
+                                                  <StyledComponent
+                                                    className="c6"
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-htpNat",
+                                                          "isStatic": false,
+                                                          "lastClassName": "c7",
+                                                          "rules": Array [
+                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+  font-family: sans-serif;
+}",
+                                                            ":link {
+  color: #005ea5;
+} :visited {
+  color: #4c2c92;
+} :hover {
+  color: #2b8cc4;
+} :active {
+  color: #2b8cc4;
+} :focus {
+  color: #0b0c0c;
+}",
+                                                            "&:focus {
+  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+}",
+                                                            "@media print {
+  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
+  &::after {
+  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
+}
+}
+}",
+                                                            [Function],
+                                                            [Function],
+                                                            [Function],
+                                                          ],
+                                                        },
+                                                        "defaultProps": Object {
+                                                          "muted": false,
+                                                          "noVisitedState": false,
+                                                          "textColour": false,
+                                                        },
+                                                        "displayName": "styled.a",
+                                                        "foldedComponentIds": Array [],
+                                                        "propTypes": undefined,
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-htpNat",
+                                                        "target": "a",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                    muted={false}
+                                                    noVisitedState={false}
+                                                    rel="license"
+                                                    textColour={false}
+                                                  >
+                                                    <a
+                                                      className="c6 c7"
+                                                      href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                      muted={false}
+                                                      rel="license"
+                                                    >
+                                                      Open Government Licence v3.0
+                                                    </a>
+                                                  </StyledComponent>
+                                                </styled.a>
+                                              </LinkDocumented>
+                                            </StyledComponent>
+                                          </Styled(LinkDocumented)>
+                                        </FooterLink>
+                                        , except where otherwise stated
                                       </span>
                                     </StyledComponent>
                                   </styled.span>
@@ -414,6 +605,47 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
 .c1 {
   max-width: 960px;
   margin: 0 15px;
+}
+
+.c7 {
+  font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c7:link {
+  color: #005ea5;
+}
+
+.c7:visited {
+  color: #4c2c92;
+}
+
+.c7:hover {
+  color: #2b8cc4;
+}
+
+.c7:active {
+  color: #2b8cc4;
+}
+
+.c7:focus {
+  color: #0b0c0c;
+}
+
+.c7:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+  background-color: #ffbf47;
+}
+
+.c6:link,
+.c6:visited {
+  color: #454a4c;
+}
+
+.c6:hover {
+  color: #171819;
 }
 
 .c2 {
@@ -451,7 +683,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
   flex-basis: 320px;
 }
 
-.c6 {
+.c8 {
   margin-right: 15px;
   margin-bottom: 25px;
   margin-left: 15px;
@@ -468,7 +700,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
   display: inline-block;
 }
 
-.c7 {
+.c9 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -485,38 +717,38 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
   background-size: 125px 102px;
 }
 
-.c7:link {
+.c9:link {
   color: #005ea5;
 }
 
-.c7:visited {
+.c9:visited {
   color: #4c2c92;
 }
 
-.c7:hover {
+.c9:hover {
   color: #2b8cc4;
 }
 
-.c7:active {
+.c9:active {
   color: #2b8cc4;
 }
 
-.c7:focus {
+.c9:focus {
   color: #0b0c0c;
 }
 
-.c7:focus {
+.c9:focus {
   outline: 3px solid #ffbf47;
   outline-offset: 0;
   background-color: #ffbf47;
 }
 
-.c7:link,
-.c7:visited {
+.c9:link,
+.c9:visited {
   color: #454a4c;
 }
 
-.c7:hover {
+.c9:hover {
   color: #171819;
 }
 
@@ -547,6 +779,22 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
 }
 
 @media print {
+  .c7 {
+    font-family: sans-serif;
+  }
+}
+
+@media print {
+  .c7[href^="/"]::after,
+  .c7[href^="http://"]::after,
+  .c7[href^="https://"]::after {
+    content: " (" attr(href) ")";
+    font-size: 90%;
+    word-wrap: break-word;
+  }
+}
+
+@media print {
   .c2 {
     font-family: sans-serif;
   }
@@ -567,15 +815,15 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
 }
 
 @media print {
-  .c7 {
+  .c9 {
     font-family: sans-serif;
   }
 }
 
 @media print {
-  .c7[href^="/"]::after,
-  .c7[href^="http://"]::after,
-  .c7[href^="https://"]::after {
+  .c9[href^="/"]::after,
+  .c9[href^="http://"]::after,
+  .c9[href^="https://"]::after {
     content: " (" attr(href) ")";
     font-size: 90%;
     word-wrap: break-word;
@@ -778,7 +1026,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
                                 "componentStyle": ComponentStyle {
                                   "componentId": "sc-gzVnrw",
                                   "isStatic": false,
-                                  "lastClassName": "c6",
+                                  "lastClassName": "c8",
                                   "rules": Array [
                                     "margin-right: 15px; margin-bottom: 25px; margin-left: 15px;",
                                     [Function],
@@ -894,7 +1142,141 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
                                       <span
                                         className="c5"
                                       >
-                                        All content is available under the Open Government Licence v3.0, except where otherwise stated
+                                        All content is available under the
+                                         
+                                        <FooterLink
+                                          href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                          rel="license"
+                                        >
+                                          <Styled(LinkDocumented)
+                                            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                            rel="license"
+                                          >
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-bxivhb",
+                                                    "isStatic": true,
+                                                    "lastClassName": "c6",
+                                                    "rules": Array [
+                                                      ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                    ],
+                                                  },
+                                                  "displayName": "Styled(LinkDocumented)",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-bxivhb",
+                                                  "target": [Function],
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
+                                              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                              rel="license"
+                                            >
+                                              <LinkDocumented
+                                                className="c6"
+                                                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                muted={false}
+                                                noVisitedState={false}
+                                                rel="license"
+                                                textColour={false}
+                                              >
+                                                <styled.a
+                                                  className="c6"
+                                                  href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                  muted={false}
+                                                  noVisitedState={false}
+                                                  rel="license"
+                                                  textColour={false}
+                                                >
+                                                  <StyledComponent
+                                                    className="c6"
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-htpNat",
+                                                          "isStatic": false,
+                                                          "lastClassName": "c7",
+                                                          "rules": Array [
+                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+  font-family: sans-serif;
+}",
+                                                            ":link {
+  color: #005ea5;
+} :visited {
+  color: #4c2c92;
+} :hover {
+  color: #2b8cc4;
+} :active {
+  color: #2b8cc4;
+} :focus {
+  color: #0b0c0c;
+}",
+                                                            "&:focus {
+  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+}",
+                                                            "@media print {
+  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
+  &::after {
+  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
+}
+}
+}",
+                                                            [Function],
+                                                            [Function],
+                                                            [Function],
+                                                          ],
+                                                        },
+                                                        "defaultProps": Object {
+                                                          "muted": false,
+                                                          "noVisitedState": false,
+                                                          "textColour": false,
+                                                        },
+                                                        "displayName": "styled.a",
+                                                        "foldedComponentIds": Array [],
+                                                        "propTypes": undefined,
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-htpNat",
+                                                        "target": "a",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                    muted={false}
+                                                    noVisitedState={false}
+                                                    rel="license"
+                                                    textColour={false}
+                                                  >
+                                                    <a
+                                                      className="c6 c7"
+                                                      href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                      muted={false}
+                                                      rel="license"
+                                                    >
+                                                      Open Government Licence v3.0
+                                                    </a>
+                                                  </StyledComponent>
+                                                </styled.a>
+                                              </LinkDocumented>
+                                            </StyledComponent>
+                                          </Styled(LinkDocumented)>
+                                        </FooterLink>
+                                        , except where otherwise stated
                                       </span>
                                     </StyledComponent>
                                   </styled.span>
@@ -914,7 +1296,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
                                 "componentStyle": ComponentStyle {
                                   "componentId": "sc-gzVnrw",
                                   "isStatic": false,
-                                  "lastClassName": "c6",
+                                  "lastClassName": "c8",
                                   "rules": Array [
                                     "margin-right: 15px; margin-bottom: 25px; margin-left: 15px;",
                                     [Function],
@@ -940,7 +1322,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
                             grow={false}
                           >
                             <div
-                              className="c6"
+                              className="c8"
                             >
                               <Copyright
                                 image={
@@ -974,7 +1356,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
                                         "componentStyle": ComponentStyle {
                                           "componentId": "sc-iwsKbI",
                                           "isStatic": false,
-                                          "lastClassName": "c7",
+                                          "lastClassName": "c9",
                                           "rules": Array [
                                             "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-family: sans-serif;
@@ -1043,7 +1425,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
                                     textColour={false}
                                   >
                                     <a
-                                      className="c7"
+                                      className="c9"
                                       href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
                                       muted={false}
                                     >
@@ -1071,6 +1453,47 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
 `;
 
 exports[`Footer matches with custom width snapshot: FooterWithCustomWidth 1`] = `
+.c7 {
+  font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c7:link {
+  color: #005ea5;
+}
+
+.c7:visited {
+  color: #4c2c92;
+}
+
+.c7:hover {
+  color: #2b8cc4;
+}
+
+.c7:active {
+  color: #2b8cc4;
+}
+
+.c7:focus {
+  color: #0b0c0c;
+}
+
+.c7:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+  background-color: #ffbf47;
+}
+
+.c6:link,
+.c6:visited {
+  color: #454a4c;
+}
+
+.c6:hover {
+  color: #171819;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1135,6 +1558,22 @@ exports[`Footer matches with custom width snapshot: FooterWithCustomWidth 1`] = 
   max-width: 960px;
   margin: 0 15px;
   max-width: inherit;
+}
+
+@media print {
+  .c7 {
+    font-family: sans-serif;
+  }
+}
+
+@media print {
+  .c7[href^="/"]::after,
+  .c7[href^="http://"]::after,
+  .c7[href^="https://"]::after {
+    content: " (" attr(href) ")";
+    font-size: 90%;
+    word-wrap: break-word;
+  }
 }
 
 @media print {
@@ -1474,7 +1913,141 @@ exports[`Footer matches with custom width snapshot: FooterWithCustomWidth 1`] = 
                                       <span
                                         className="c5"
                                       >
-                                        All content is available under the Open Government Licence v3.0, except where otherwise stated
+                                        All content is available under the
+                                         
+                                        <FooterLink
+                                          href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                          rel="license"
+                                        >
+                                          <Styled(LinkDocumented)
+                                            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                            rel="license"
+                                          >
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-bxivhb",
+                                                    "isStatic": true,
+                                                    "lastClassName": "c6",
+                                                    "rules": Array [
+                                                      ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                    ],
+                                                  },
+                                                  "displayName": "Styled(LinkDocumented)",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-bxivhb",
+                                                  "target": [Function],
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
+                                              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                              rel="license"
+                                            >
+                                              <LinkDocumented
+                                                className="c6"
+                                                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                muted={false}
+                                                noVisitedState={false}
+                                                rel="license"
+                                                textColour={false}
+                                              >
+                                                <styled.a
+                                                  className="c6"
+                                                  href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                  muted={false}
+                                                  noVisitedState={false}
+                                                  rel="license"
+                                                  textColour={false}
+                                                >
+                                                  <StyledComponent
+                                                    className="c6"
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-htpNat",
+                                                          "isStatic": false,
+                                                          "lastClassName": "c7",
+                                                          "rules": Array [
+                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+  font-family: sans-serif;
+}",
+                                                            ":link {
+  color: #005ea5;
+} :visited {
+  color: #4c2c92;
+} :hover {
+  color: #2b8cc4;
+} :active {
+  color: #2b8cc4;
+} :focus {
+  color: #0b0c0c;
+}",
+                                                            "&:focus {
+  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+}",
+                                                            "@media print {
+  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
+  &::after {
+  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
+}
+}
+}",
+                                                            [Function],
+                                                            [Function],
+                                                            [Function],
+                                                          ],
+                                                        },
+                                                        "defaultProps": Object {
+                                                          "muted": false,
+                                                          "noVisitedState": false,
+                                                          "textColour": false,
+                                                        },
+                                                        "displayName": "styled.a",
+                                                        "foldedComponentIds": Array [],
+                                                        "propTypes": undefined,
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-htpNat",
+                                                        "target": "a",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                    muted={false}
+                                                    noVisitedState={false}
+                                                    rel="license"
+                                                    textColour={false}
+                                                  >
+                                                    <a
+                                                      className="c6 c7"
+                                                      href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                      muted={false}
+                                                      rel="license"
+                                                    >
+                                                      Open Government Licence v3.0
+                                                    </a>
+                                                  </StyledComponent>
+                                                </styled.a>
+                                              </LinkDocumented>
+                                            </StyledComponent>
+                                          </Styled(LinkDocumented)>
+                                        </FooterLink>
+                                        , except where otherwise stated
                                       </span>
                                     </StyledComponent>
                                   </styled.span>
@@ -2113,7 +2686,141 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
                                       <span
                                         className="c8"
                                       >
-                                        All content is available under the Open Government Licence v3.0, except where otherwise stated
+                                        All content is available under the
+                                         
+                                        <FooterLink
+                                          href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                          rel="license"
+                                        >
+                                          <Styled(LinkDocumented)
+                                            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                            rel="license"
+                                          >
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-bxivhb",
+                                                    "isStatic": true,
+                                                    "lastClassName": "c5",
+                                                    "rules": Array [
+                                                      ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                    ],
+                                                  },
+                                                  "displayName": "Styled(LinkDocumented)",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-bxivhb",
+                                                  "target": [Function],
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
+                                              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                              rel="license"
+                                            >
+                                              <LinkDocumented
+                                                className="c5"
+                                                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                muted={false}
+                                                noVisitedState={false}
+                                                rel="license"
+                                                textColour={false}
+                                              >
+                                                <styled.a
+                                                  className="c5"
+                                                  href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                  muted={false}
+                                                  noVisitedState={false}
+                                                  rel="license"
+                                                  textColour={false}
+                                                >
+                                                  <StyledComponent
+                                                    className="c5"
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-htpNat",
+                                                          "isStatic": false,
+                                                          "lastClassName": "c6",
+                                                          "rules": Array [
+                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+  font-family: sans-serif;
+}",
+                                                            ":link {
+  color: #005ea5;
+} :visited {
+  color: #4c2c92;
+} :hover {
+  color: #2b8cc4;
+} :active {
+  color: #2b8cc4;
+} :focus {
+  color: #0b0c0c;
+}",
+                                                            "&:focus {
+  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+}",
+                                                            "@media print {
+  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
+  &::after {
+  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
+}
+}
+}",
+                                                            [Function],
+                                                            [Function],
+                                                            [Function],
+                                                          ],
+                                                        },
+                                                        "defaultProps": Object {
+                                                          "muted": false,
+                                                          "noVisitedState": false,
+                                                          "textColour": false,
+                                                        },
+                                                        "displayName": "styled.a",
+                                                        "foldedComponentIds": Array [],
+                                                        "propTypes": undefined,
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-htpNat",
+                                                        "target": "a",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                    muted={false}
+                                                    noVisitedState={false}
+                                                    rel="license"
+                                                    textColour={false}
+                                                  >
+                                                    <a
+                                                      className="c5 c6"
+                                                      href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                      muted={false}
+                                                      rel="license"
+                                                    >
+                                                      Open Government Licence v3.0
+                                                    </a>
+                                                  </StyledComponent>
+                                                </styled.a>
+                                              </LinkDocumented>
+                                            </StyledComponent>
+                                          </Styled(LinkDocumented)>
+                                        </FooterLink>
+                                        , except where otherwise stated
                                       </span>
                                     </StyledComponent>
                                   </styled.span>
@@ -3451,7 +4158,141 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                                           <span
                                             className="c12"
                                           >
-                                            All content is available under the Open Government Licence v3.0, except where otherwise stated
+                                            All content is available under the
+                                             
+                                            <FooterLink
+                                              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                              rel="license"
+                                            >
+                                              <Styled(LinkDocumented)
+                                                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                rel="license"
+                                              >
+                                                <StyledComponent
+                                                  forwardedComponent={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "attrs": Array [],
+                                                      "componentStyle": ComponentStyle {
+                                                        "componentId": "sc-bxivhb",
+                                                        "isStatic": true,
+                                                        "lastClassName": "c8",
+                                                        "rules": Array [
+                                                          ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                        ],
+                                                      },
+                                                      "displayName": "Styled(LinkDocumented)",
+                                                      "foldedComponentIds": Array [],
+                                                      "render": [Function],
+                                                      "styledComponentId": "sc-bxivhb",
+                                                      "target": [Function],
+                                                      "toString": [Function],
+                                                      "warnTooManyClasses": [Function],
+                                                      "withComponent": [Function],
+                                                    }
+                                                  }
+                                                  forwardedRef={null}
+                                                  href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                  rel="license"
+                                                >
+                                                  <LinkDocumented
+                                                    className="c8"
+                                                    href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                    muted={false}
+                                                    noVisitedState={false}
+                                                    rel="license"
+                                                    textColour={false}
+                                                  >
+                                                    <styled.a
+                                                      className="c8"
+                                                      href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      rel="license"
+                                                      textColour={false}
+                                                    >
+                                                      <StyledComponent
+                                                        className="c8"
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "sc-htpNat",
+                                                              "isStatic": false,
+                                                              "lastClassName": "c9",
+                                                              "rules": Array [
+                                                                "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+  font-family: sans-serif;
+}",
+                                                                ":link {
+  color: #005ea5;
+} :visited {
+  color: #4c2c92;
+} :hover {
+  color: #2b8cc4;
+} :active {
+  color: #2b8cc4;
+} :focus {
+  color: #0b0c0c;
+}",
+                                                                "&:focus {
+  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+}",
+                                                                "@media print {
+  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
+  &::after {
+  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
+}
+}
+}",
+                                                                [Function],
+                                                                [Function],
+                                                                [Function],
+                                                              ],
+                                                            },
+                                                            "defaultProps": Object {
+                                                              "muted": false,
+                                                              "noVisitedState": false,
+                                                              "textColour": false,
+                                                            },
+                                                            "displayName": "styled.a",
+                                                            "foldedComponentIds": Array [],
+                                                            "propTypes": undefined,
+                                                            "render": [Function],
+                                                            "styledComponentId": "sc-htpNat",
+                                                            "target": "a",
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
+                                                          }
+                                                        }
+                                                        forwardedRef={null}
+                                                        href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        rel="license"
+                                                        textColour={false}
+                                                      >
+                                                        <a
+                                                          className="c8 c9"
+                                                          href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                          muted={false}
+                                                          rel="license"
+                                                        >
+                                                          Open Government Licence v3.0
+                                                        </a>
+                                                      </StyledComponent>
+                                                    </styled.a>
+                                                  </LinkDocumented>
+                                                </StyledComponent>
+                                              </Styled(LinkDocumented)>
+                                            </FooterLink>
+                                            , except where otherwise stated
                                           </span>
                                         </StyledComponent>
                                       </styled.span>
@@ -4627,7 +5468,141 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
                                           <span
                                             className="c11"
                                           >
-                                            All content is available under the Open Government Licence v3.0, except where otherwise stated
+                                            All content is available under the
+                                             
+                                            <FooterLink
+                                              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                              rel="license"
+                                            >
+                                              <Styled(LinkDocumented)
+                                                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                rel="license"
+                                              >
+                                                <StyledComponent
+                                                  forwardedComponent={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "attrs": Array [],
+                                                      "componentStyle": ComponentStyle {
+                                                        "componentId": "sc-bxivhb",
+                                                        "isStatic": true,
+                                                        "lastClassName": "c8",
+                                                        "rules": Array [
+                                                          ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                        ],
+                                                      },
+                                                      "displayName": "Styled(LinkDocumented)",
+                                                      "foldedComponentIds": Array [],
+                                                      "render": [Function],
+                                                      "styledComponentId": "sc-bxivhb",
+                                                      "target": [Function],
+                                                      "toString": [Function],
+                                                      "warnTooManyClasses": [Function],
+                                                      "withComponent": [Function],
+                                                    }
+                                                  }
+                                                  forwardedRef={null}
+                                                  href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                  rel="license"
+                                                >
+                                                  <LinkDocumented
+                                                    className="c8"
+                                                    href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                    muted={false}
+                                                    noVisitedState={false}
+                                                    rel="license"
+                                                    textColour={false}
+                                                  >
+                                                    <styled.a
+                                                      className="c8"
+                                                      href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      rel="license"
+                                                      textColour={false}
+                                                    >
+                                                      <StyledComponent
+                                                        className="c8"
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "sc-htpNat",
+                                                              "isStatic": false,
+                                                              "lastClassName": "c9",
+                                                              "rules": Array [
+                                                                "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+  font-family: sans-serif;
+}",
+                                                                ":link {
+  color: #005ea5;
+} :visited {
+  color: #4c2c92;
+} :hover {
+  color: #2b8cc4;
+} :active {
+  color: #2b8cc4;
+} :focus {
+  color: #0b0c0c;
+}",
+                                                                "&:focus {
+  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+}",
+                                                                "@media print {
+  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
+  &::after {
+  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
+}
+}
+}",
+                                                                [Function],
+                                                                [Function],
+                                                                [Function],
+                                                              ],
+                                                            },
+                                                            "defaultProps": Object {
+                                                              "muted": false,
+                                                              "noVisitedState": false,
+                                                              "textColour": false,
+                                                            },
+                                                            "displayName": "styled.a",
+                                                            "foldedComponentIds": Array [],
+                                                            "propTypes": undefined,
+                                                            "render": [Function],
+                                                            "styledComponentId": "sc-htpNat",
+                                                            "target": "a",
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
+                                                          }
+                                                        }
+                                                        forwardedRef={null}
+                                                        href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        rel="license"
+                                                        textColour={false}
+                                                      >
+                                                        <a
+                                                          className="c8 c9"
+                                                          href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                          muted={false}
+                                                          rel="license"
+                                                        >
+                                                          Open Government Licence v3.0
+                                                        </a>
+                                                      </StyledComponent>
+                                                    </styled.a>
+                                                  </LinkDocumented>
+                                                </StyledComponent>
+                                              </Styled(LinkDocumented)>
+                                            </FooterLink>
+                                            , except where otherwise stated
                                           </span>
                                         </StyledComponent>
                                       </styled.span>
@@ -8009,7 +8984,141 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                                           <span
                                             className="c20"
                                           >
-                                            All content is available under the Open Government Licence v3.0, except where otherwise stated
+                                            All content is available under the
+                                             
+                                            <FooterLink
+                                              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                              rel="license"
+                                            >
+                                              <Styled(LinkDocumented)
+                                                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                rel="license"
+                                              >
+                                                <StyledComponent
+                                                  forwardedComponent={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "attrs": Array [],
+                                                      "componentStyle": ComponentStyle {
+                                                        "componentId": "sc-bxivhb",
+                                                        "isStatic": true,
+                                                        "lastClassName": "c8",
+                                                        "rules": Array [
+                                                          ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                        ],
+                                                      },
+                                                      "displayName": "Styled(LinkDocumented)",
+                                                      "foldedComponentIds": Array [],
+                                                      "render": [Function],
+                                                      "styledComponentId": "sc-bxivhb",
+                                                      "target": [Function],
+                                                      "toString": [Function],
+                                                      "warnTooManyClasses": [Function],
+                                                      "withComponent": [Function],
+                                                    }
+                                                  }
+                                                  forwardedRef={null}
+                                                  href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                  rel="license"
+                                                >
+                                                  <LinkDocumented
+                                                    className="c8"
+                                                    href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                    muted={false}
+                                                    noVisitedState={false}
+                                                    rel="license"
+                                                    textColour={false}
+                                                  >
+                                                    <styled.a
+                                                      className="c8"
+                                                      href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      rel="license"
+                                                      textColour={false}
+                                                    >
+                                                      <StyledComponent
+                                                        className="c8"
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "sc-htpNat",
+                                                              "isStatic": false,
+                                                              "lastClassName": "c9",
+                                                              "rules": Array [
+                                                                "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+  font-family: sans-serif;
+}",
+                                                                ":link {
+  color: #005ea5;
+} :visited {
+  color: #4c2c92;
+} :hover {
+  color: #2b8cc4;
+} :active {
+  color: #2b8cc4;
+} :focus {
+  color: #0b0c0c;
+}",
+                                                                "&:focus {
+  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+}",
+                                                                "@media print {
+  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
+  &::after {
+  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
+}
+}
+}",
+                                                                [Function],
+                                                                [Function],
+                                                                [Function],
+                                                              ],
+                                                            },
+                                                            "defaultProps": Object {
+                                                              "muted": false,
+                                                              "noVisitedState": false,
+                                                              "textColour": false,
+                                                            },
+                                                            "displayName": "styled.a",
+                                                            "foldedComponentIds": Array [],
+                                                            "propTypes": undefined,
+                                                            "render": [Function],
+                                                            "styledComponentId": "sc-htpNat",
+                                                            "target": "a",
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
+                                                          }
+                                                        }
+                                                        forwardedRef={null}
+                                                        href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        rel="license"
+                                                        textColour={false}
+                                                      >
+                                                        <a
+                                                          className="c8 c9"
+                                                          href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                          muted={false}
+                                                          rel="license"
+                                                        >
+                                                          Open Government Licence v3.0
+                                                        </a>
+                                                      </StyledComponent>
+                                                    </styled.a>
+                                                  </LinkDocumented>
+                                                </StyledComponent>
+                                              </Styled(LinkDocumented)>
+                                            </FooterLink>
+                                            , except where otherwise stated
                                           </span>
                                         </StyledComponent>
                                       </styled.span>
@@ -10543,7 +11652,141 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                                           <span
                                             className="c15"
                                           >
-                                            All content is available under the Open Government Licence v3.0, except where otherwise stated
+                                            All content is available under the
+                                             
+                                            <FooterLink
+                                              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                              rel="license"
+                                            >
+                                              <Styled(LinkDocumented)
+                                                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                rel="license"
+                                              >
+                                                <StyledComponent
+                                                  forwardedComponent={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "attrs": Array [],
+                                                      "componentStyle": ComponentStyle {
+                                                        "componentId": "sc-bxivhb",
+                                                        "isStatic": true,
+                                                        "lastClassName": "c8",
+                                                        "rules": Array [
+                                                          ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                        ],
+                                                      },
+                                                      "displayName": "Styled(LinkDocumented)",
+                                                      "foldedComponentIds": Array [],
+                                                      "render": [Function],
+                                                      "styledComponentId": "sc-bxivhb",
+                                                      "target": [Function],
+                                                      "toString": [Function],
+                                                      "warnTooManyClasses": [Function],
+                                                      "withComponent": [Function],
+                                                    }
+                                                  }
+                                                  forwardedRef={null}
+                                                  href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                  rel="license"
+                                                >
+                                                  <LinkDocumented
+                                                    className="c8"
+                                                    href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                    muted={false}
+                                                    noVisitedState={false}
+                                                    rel="license"
+                                                    textColour={false}
+                                                  >
+                                                    <styled.a
+                                                      className="c8"
+                                                      href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      rel="license"
+                                                      textColour={false}
+                                                    >
+                                                      <StyledComponent
+                                                        className="c8"
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "sc-htpNat",
+                                                              "isStatic": false,
+                                                              "lastClassName": "c9",
+                                                              "rules": Array [
+                                                                "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+  font-family: sans-serif;
+}",
+                                                                ":link {
+  color: #005ea5;
+} :visited {
+  color: #4c2c92;
+} :hover {
+  color: #2b8cc4;
+} :active {
+  color: #2b8cc4;
+} :focus {
+  color: #0b0c0c;
+}",
+                                                                "&:focus {
+  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+}",
+                                                                "@media print {
+  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
+  &::after {
+  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
+}
+}
+}",
+                                                                [Function],
+                                                                [Function],
+                                                                [Function],
+                                                              ],
+                                                            },
+                                                            "defaultProps": Object {
+                                                              "muted": false,
+                                                              "noVisitedState": false,
+                                                              "textColour": false,
+                                                            },
+                                                            "displayName": "styled.a",
+                                                            "foldedComponentIds": Array [],
+                                                            "propTypes": undefined,
+                                                            "render": [Function],
+                                                            "styledComponentId": "sc-htpNat",
+                                                            "target": "a",
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
+                                                          }
+                                                        }
+                                                        forwardedRef={null}
+                                                        href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        rel="license"
+                                                        textColour={false}
+                                                      >
+                                                        <a
+                                                          className="c8 c9"
+                                                          href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                          muted={false}
+                                                          rel="license"
+                                                        >
+                                                          Open Government Licence v3.0
+                                                        </a>
+                                                      </StyledComponent>
+                                                    </styled.a>
+                                                  </LinkDocumented>
+                                                </StyledComponent>
+                                              </Styled(LinkDocumented)>
+                                            </FooterLink>
+                                            , except where otherwise stated
                                           </span>
                                         </StyledComponent>
                                       </styled.span>
@@ -11438,7 +12681,141 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
                                           <span
                                             className="c11"
                                           >
-                                            All content is available under the Open Government Licence v3.0, except where otherwise stated
+                                            All content is available under the
+                                             
+                                            <FooterLink
+                                              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                              rel="license"
+                                            >
+                                              <Styled(LinkDocumented)
+                                                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                rel="license"
+                                              >
+                                                <StyledComponent
+                                                  forwardedComponent={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "attrs": Array [],
+                                                      "componentStyle": ComponentStyle {
+                                                        "componentId": "sc-bxivhb",
+                                                        "isStatic": true,
+                                                        "lastClassName": "c8",
+                                                        "rules": Array [
+                                                          ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                        ],
+                                                      },
+                                                      "displayName": "Styled(LinkDocumented)",
+                                                      "foldedComponentIds": Array [],
+                                                      "render": [Function],
+                                                      "styledComponentId": "sc-bxivhb",
+                                                      "target": [Function],
+                                                      "toString": [Function],
+                                                      "warnTooManyClasses": [Function],
+                                                      "withComponent": [Function],
+                                                    }
+                                                  }
+                                                  forwardedRef={null}
+                                                  href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                  rel="license"
+                                                >
+                                                  <LinkDocumented
+                                                    className="c8"
+                                                    href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                    muted={false}
+                                                    noVisitedState={false}
+                                                    rel="license"
+                                                    textColour={false}
+                                                  >
+                                                    <styled.a
+                                                      className="c8"
+                                                      href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                      muted={false}
+                                                      noVisitedState={false}
+                                                      rel="license"
+                                                      textColour={false}
+                                                    >
+                                                      <StyledComponent
+                                                        className="c8"
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "sc-htpNat",
+                                                              "isStatic": false,
+                                                              "lastClassName": "c9",
+                                                              "rules": Array [
+                                                                "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+  font-family: sans-serif;
+}",
+                                                                ":link {
+  color: #005ea5;
+} :visited {
+  color: #4c2c92;
+} :hover {
+  color: #2b8cc4;
+} :active {
+  color: #2b8cc4;
+} :focus {
+  color: #0b0c0c;
+}",
+                                                                "&:focus {
+  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+}",
+                                                                "@media print {
+  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
+  &::after {
+  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
+}
+}
+}",
+                                                                [Function],
+                                                                [Function],
+                                                                [Function],
+                                                              ],
+                                                            },
+                                                            "defaultProps": Object {
+                                                              "muted": false,
+                                                              "noVisitedState": false,
+                                                              "textColour": false,
+                                                            },
+                                                            "displayName": "styled.a",
+                                                            "foldedComponentIds": Array [],
+                                                            "propTypes": undefined,
+                                                            "render": [Function],
+                                                            "styledComponentId": "sc-htpNat",
+                                                            "target": "a",
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
+                                                          }
+                                                        }
+                                                        forwardedRef={null}
+                                                        href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                        muted={false}
+                                                        noVisitedState={false}
+                                                        rel="license"
+                                                        textColour={false}
+                                                      >
+                                                        <a
+                                                          className="c8 c9"
+                                                          href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                          muted={false}
+                                                          rel="license"
+                                                        >
+                                                          Open Government Licence v3.0
+                                                        </a>
+                                                      </StyledComponent>
+                                                    </styled.a>
+                                                  </LinkDocumented>
+                                                </StyledComponent>
+                                              </Styled(LinkDocumented)>
+                                            </FooterLink>
+                                            , except where otherwise stated
                                           </span>
                                         </StyledComponent>
                                       </styled.span>
@@ -12465,7 +13842,141 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
                                       <span
                                         className="c14"
                                       >
-                                        All content is available under the Open Government Licence v3.0, except where otherwise stated
+                                        All content is available under the
+                                         
+                                        <FooterLink
+                                          href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                          rel="license"
+                                        >
+                                          <Styled(LinkDocumented)
+                                            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                            rel="license"
+                                          >
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-bxivhb",
+                                                    "isStatic": true,
+                                                    "lastClassName": "c8",
+                                                    "rules": Array [
+                                                      ":link, :visited {
+  color: #454a4c;
+} :hover {
+  color: #171819;
+}",
+                                                    ],
+                                                  },
+                                                  "displayName": "Styled(LinkDocumented)",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-bxivhb",
+                                                  "target": [Function],
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
+                                              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                              rel="license"
+                                            >
+                                              <LinkDocumented
+                                                className="c8"
+                                                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                muted={false}
+                                                noVisitedState={false}
+                                                rel="license"
+                                                textColour={false}
+                                              >
+                                                <styled.a
+                                                  className="c8"
+                                                  href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                  muted={false}
+                                                  noVisitedState={false}
+                                                  rel="license"
+                                                  textColour={false}
+                                                >
+                                                  <StyledComponent
+                                                    className="c8"
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-htpNat",
+                                                          "isStatic": false,
+                                                          "lastClassName": "c9",
+                                                          "rules": Array [
+                                                            "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
+  font-family: sans-serif;
+}",
+                                                            ":link {
+  color: #005ea5;
+} :visited {
+  color: #4c2c92;
+} :hover {
+  color: #2b8cc4;
+} :active {
+  color: #2b8cc4;
+} :focus {
+  color: #0b0c0c;
+}",
+                                                            "&:focus {
+  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+}",
+                                                            "@media print {
+  &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
+  &::after {
+  content: \\" (\\" attr(href) \\")\\"; font-size: 90%; word-wrap: break-word;
+}
+}
+}",
+                                                            [Function],
+                                                            [Function],
+                                                            [Function],
+                                                          ],
+                                                        },
+                                                        "defaultProps": Object {
+                                                          "muted": false,
+                                                          "noVisitedState": false,
+                                                          "textColour": false,
+                                                        },
+                                                        "displayName": "styled.a",
+                                                        "foldedComponentIds": Array [],
+                                                        "propTypes": undefined,
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-htpNat",
+                                                        "target": "a",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                    href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                    muted={false}
+                                                    noVisitedState={false}
+                                                    rel="license"
+                                                    textColour={false}
+                                                  >
+                                                    <a
+                                                      className="c8 c9"
+                                                      href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                                      muted={false}
+                                                      rel="license"
+                                                    >
+                                                      Open Government Licence v3.0
+                                                    </a>
+                                                  </StyledComponent>
+                                                </styled.a>
+                                              </LinkDocumented>
+                                            </StyledComponent>
+                                          </Styled(LinkDocumented)>
+                                        </FooterLink>
+                                        , except where otherwise stated
                                       </span>
                                     </StyledComponent>
                                   </styled.span>

--- a/components/footer/src/atoms/licence/index.js
+++ b/components/footer/src/atoms/licence/index.js
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 import { MEDIA_QUERIES } from '@govuk-react/constants';
 import { spacing } from '@govuk-react/lib';
 
+import Link from '../link';
+
 const LicenceLogo = styled('svg')({
   display: 'inline-block',
   marginRight: spacing.simple(2),
@@ -33,7 +35,11 @@ const Licence = () => (
       />
     </LicenceLogo>
     <LicenceDescription>
-      All content is available under the Open Government Licence v3.0, except where otherwise stated
+      All content is available under the{' '}
+      <Link href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">
+        Open Government Licence v3.0
+      </Link>
+      , except where otherwise stated
     </LicenceDescription>
   </div>
 );

--- a/components/footer/src/atoms/link/index.js
+++ b/components/footer/src/atoms/link/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 import { FOOTER_LINK, FOOTER_LINK_HOVER } from 'govuk-colours';
-import Link from '@govuk-react/link';
+import { LinkDocumented } from '@govuk-react/link';
 
-const StyledFooterLink = styled(Link)({
+const StyledFooterLink = styled(LinkDocumented)({
   ':link, :visited': {
     color: FOOTER_LINK,
   },

--- a/components/footer/src/atoms/meta-item/index.js
+++ b/components/footer/src/atoms/meta-item/index.js
@@ -13,8 +13,8 @@ const MetaItem = styled('div')(
     grow && {
       flex: 1,
       flexBasis: '320px',
-      [MEDIA_QUERIES.TABLET]: {
-        flexBasis: 'auto',
+      [MEDIA_QUERIES.DESKTOP]: {
+        flexBasis: 0,
       },
     }
 );

--- a/components/footer/src/atoms/section-heading/index.js
+++ b/components/footer/src/atoms/section-heading/index.js
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 import { MEDIA_QUERIES } from '@govuk-react/constants';
-import Heading from '@govuk-react/heading';
+import { H2 } from '@govuk-react/heading';
 import { spacing } from '@govuk-react/lib';
 import { BORDER_COLOUR } from 'govuk-colours';
 
-const SectionHeading = styled(Heading)(
+const SectionHeading = styled(H2)(
   {
     borderBottom: `1px solid ${BORDER_COLOUR}`,
     paddingBottom: spacing.simple(2),

--- a/components/footer/src/fixtures.js
+++ b/components/footer/src/fixtures.js
@@ -52,7 +52,7 @@ const metaLinksAndCustom = (
 
 const navigation = (
   <Footer.Navigation>
-    <Footer.NavigationLinks heading="Two column list" listColumns="2">
+    <Footer.NavigationLinks heading="Two column list" listColumns={2}>
       <Footer.Link href="/">Navigation item 1</Footer.Link>
       <Footer.Link to="/footer-nav-item-2" as={Link}>
         Navigation item 2 (Router Link)

--- a/components/footer/src/index.js
+++ b/components/footer/src/index.js
@@ -58,7 +58,7 @@ const FooterContainer = styled('footer')(
  *
  * <Footer>
  *   <Footer.Navigation>
- *     <Footer.NavigationLinks heading="Two column list" listColumns="2">
+ *     <Footer.NavigationLinks heading="Two column list" listColumns={2}>
  *       <Footer.Link href="/">Navigation item 1</Footer.Link>
  *       <Footer.Link to="/footer-nav-item-2" as={Link}>Navigation item 2 (Router Link)</Footer.Link>
  *       <Footer.Link href="/">Navigation item 3</Footer.Link>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,6 +1539,11 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
+"@improved/node@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@improved/node/-/node-1.0.0.tgz#50b1cc6804ffb3d9c86bf91ed1900baa3cd8dd59"
+  integrity sha512-8r6WN+Qp2EsZ6G2F1y0vpJjGFVtoCQQ1aCrvBJ1ofy7SG96nG8FfeXWalxsCbh7zMrieOF45McAb50bYCLCuBQ==
+
 "@jest/console@^24.3.0":
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.3.0.tgz#7bd920d250988ba0bf1352c4493a48e1cb97671e"
@@ -1976,626 +1981,6 @@
   dependencies:
     core-js "^2.5.7"
 
-"@lerna/add@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.13.1.tgz#2cd7838857edb3b43ed73e3c21f69a20beb9b702"
-  integrity sha512-cXk42YbuhzEnADCK8Qte5laC9Qo03eJLVnr0qKY85jQUM/T4URe3IIUemqpg0CpVATrB+Vz+iNdeqw9ng1iALw==
-  dependencies:
-    "@lerna/bootstrap" "3.13.1"
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
-    "@lerna/npm-conf" "3.13.0"
-    "@lerna/validation-error" "3.13.0"
-    dedent "^0.7.0"
-    npm-package-arg "^6.1.0"
-    p-map "^1.2.0"
-    pacote "^9.5.0"
-    semver "^5.5.0"
-
-"@lerna/batch-packages@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/batch-packages/-/batch-packages-3.13.0.tgz#697fde5be28822af9d9dca2f750250b90a89a000"
-  integrity sha512-TgLBTZ7ZlqilGnzJ3xh1KdAHcySfHytgNRTdG9YomfriTU6kVfp1HrXxKJYVGs7ClPUNt2CTFEOkw0tMBronjw==
-  dependencies:
-    "@lerna/package-graph" "3.13.0"
-    "@lerna/validation-error" "3.13.0"
-    npmlog "^4.1.2"
-
-"@lerna/bootstrap@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/bootstrap/-/bootstrap-3.13.1.tgz#f2edd7c8093c8b139e78b0ca5f845f23efd01f08"
-  integrity sha512-mKdi5Ds5f82PZwEFyB9/W60I3iELobi1i87sTeVrbJh/um7GvqpSPy7kG/JPxyOdMpB2njX6LiJgw+7b6BEPWw==
-  dependencies:
-    "@lerna/batch-packages" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
-    "@lerna/has-npm-version" "3.13.0"
-    "@lerna/npm-install" "3.13.0"
-    "@lerna/package-graph" "3.13.0"
-    "@lerna/pulse-till-done" "3.13.0"
-    "@lerna/rimraf-dir" "3.13.0"
-    "@lerna/run-lifecycle" "3.13.0"
-    "@lerna/run-parallel-batches" "3.13.0"
-    "@lerna/symlink-binary" "3.13.0"
-    "@lerna/symlink-dependencies" "3.13.0"
-    "@lerna/validation-error" "3.13.0"
-    dedent "^0.7.0"
-    get-port "^3.2.0"
-    multimatch "^2.1.0"
-    npm-package-arg "^6.1.0"
-    npmlog "^4.1.2"
-    p-finally "^1.0.0"
-    p-map "^1.2.0"
-    p-map-series "^1.0.0"
-    p-waterfall "^1.0.0"
-    read-package-tree "^5.1.6"
-    semver "^5.5.0"
-
-"@lerna/changed@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.13.1.tgz#dc92476aad43c932fe741969bbd0bcf6146a4c52"
-  integrity sha512-BRXitEJGOkoudbxEewW7WhjkLxFD+tTk4PrYpHLyCBk63pNTWtQLRE6dc1hqwh4emwyGncoyW6RgXfLgMZgryw==
-  dependencies:
-    "@lerna/collect-updates" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/listable" "3.13.0"
-    "@lerna/output" "3.13.0"
-    "@lerna/version" "3.13.1"
-
-"@lerna/check-working-tree@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/check-working-tree/-/check-working-tree-3.13.0.tgz#1ddcd4d9b1aceb65efaaa4cd1333a66706d67c9c"
-  integrity sha512-dsdO15NXX5To+Q53SYeCrBEpiqv4m5VkaPZxbGQZNwoRen1MloXuqxSymJANQn+ZLEqarv5V56gydebeROPH5A==
-  dependencies:
-    "@lerna/describe-ref" "3.13.0"
-    "@lerna/validation-error" "3.13.0"
-
-"@lerna/child-process@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/child-process/-/child-process-3.13.0.tgz#84e35adf3217a6983edd28080657b9596a052674"
-  integrity sha512-0iDS8y2jiEucD4fJHEzKoc8aQJgm7s+hG+0RmDNtfT0MM3n17pZnf5JOMtS1FJp+SEXOjMKQndyyaDIPFsnp6A==
-  dependencies:
-    chalk "^2.3.1"
-    execa "^1.0.0"
-    strong-log-transformer "^2.0.0"
-
-"@lerna/clean@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/clean/-/clean-3.13.1.tgz#9a7432efceccd720a51da5c76f849fc59c5a14ce"
-  integrity sha512-myGIaXv7RUO2qCFZXvx8SJeI+eN6y9SUD5zZ4/LvNogbOiEIlujC5lUAqK65rAHayQ9ltSa/yK6Xv510xhZXZQ==
-  dependencies:
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
-    "@lerna/prompt" "3.13.0"
-    "@lerna/pulse-till-done" "3.13.0"
-    "@lerna/rimraf-dir" "3.13.0"
-    p-map "^1.2.0"
-    p-map-series "^1.0.0"
-    p-waterfall "^1.0.0"
-
-"@lerna/cli@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/cli/-/cli-3.13.0.tgz#3d7b357fdd7818423e9681a7b7f2abd106c8a266"
-  integrity sha512-HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==
-  dependencies:
-    "@lerna/global-options" "3.13.0"
-    dedent "^0.7.0"
-    npmlog "^4.1.2"
-    yargs "^12.0.1"
-
-"@lerna/collect-updates@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/collect-updates/-/collect-updates-3.13.0.tgz#f0828d84ff959ff153d006765659ffc4d68cdefc"
-  integrity sha512-uR3u6uTzrS1p46tHQ/mlHog/nRJGBqskTHYYJbgirujxm6FqNh7Do+I1Q/7zSee407G4lzsNxZdm8IL927HemQ==
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/describe-ref" "3.13.0"
-    minimatch "^3.0.4"
-    npmlog "^4.1.2"
-    slash "^1.0.0"
-
-"@lerna/command@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/command/-/command-3.13.1.tgz#b60dda2c0d9ffbb6030d61ddf7cceedc1e8f7e6e"
-  integrity sha512-SYWezxX+iheWvzRoHCrbs8v5zHPaxAx3kWvZhqi70vuGsdOVAWmaG4IvHLn11ztS+Vpd5PM+ztBWSbnykpLFKQ==
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/package-graph" "3.13.0"
-    "@lerna/project" "3.13.1"
-    "@lerna/validation-error" "3.13.0"
-    "@lerna/write-log-file" "3.13.0"
-    dedent "^0.7.0"
-    execa "^1.0.0"
-    is-ci "^1.0.10"
-    lodash "^4.17.5"
-    npmlog "^4.1.2"
-
-"@lerna/conventional-commits@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/conventional-commits/-/conventional-commits-3.13.0.tgz#877aa225ca34cca61c31ea02a5a6296af74e1144"
-  integrity sha512-BeAgcNXuocmLhPxnmKU2Vy8YkPd/Uo+vu2i/p3JGsUldzrPC8iF3IDxH7fuXpEFN2Nfogu7KHachd4tchtOppA==
-  dependencies:
-    "@lerna/validation-error" "3.13.0"
-    conventional-changelog-angular "^5.0.3"
-    conventional-changelog-core "^3.1.6"
-    conventional-recommended-bump "^4.0.4"
-    fs-extra "^7.0.0"
-    get-stream "^4.0.0"
-    npm-package-arg "^6.1.0"
-    npmlog "^4.1.2"
-    pify "^3.0.0"
-    semver "^5.5.0"
-
-"@lerna/create-symlink@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/create-symlink/-/create-symlink-3.13.0.tgz#e01133082fe040779712c960683cb3a272b67809"
-  integrity sha512-PTvg3jAAJSAtLFoZDsuTMv1wTOC3XYIdtg54k7uxIHsP8Ztpt+vlilY/Cni0THAqEMHvfiToel76Xdta4TU21Q==
-  dependencies:
-    cmd-shim "^2.0.2"
-    fs-extra "^7.0.0"
-    npmlog "^4.1.2"
-
-"@lerna/create@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-3.13.1.tgz#2c1284cfdc59f0d2b88286d78bc797f4ab330f79"
-  integrity sha512-pLENMXgTkQuvKxAopjKeoLOv9fVUCnpTUD7aLrY5d95/1xqSZlnsOcQfUYcpMf3GpOvHc8ILmI5OXkPqjAf54g==
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/npm-conf" "3.13.0"
-    "@lerna/validation-error" "3.13.0"
-    camelcase "^5.0.0"
-    dedent "^0.7.0"
-    fs-extra "^7.0.0"
-    globby "^8.0.1"
-    init-package-json "^1.10.3"
-    npm-package-arg "^6.1.0"
-    p-reduce "^1.0.0"
-    pacote "^9.5.0"
-    pify "^3.0.0"
-    semver "^5.5.0"
-    slash "^1.0.0"
-    validate-npm-package-license "^3.0.3"
-    validate-npm-package-name "^3.0.0"
-    whatwg-url "^7.0.0"
-
-"@lerna/describe-ref@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/describe-ref/-/describe-ref-3.13.0.tgz#fb4c3863fd6bcccad67ce7b183887a5fc1942bb6"
-  integrity sha512-UJefF5mLxLae9I2Sbz5RLYGbqbikRuMqdgTam0MS5OhXnyuuKYBUpwBshCURNb1dPBXTQhSwc7+oUhORx8ojCg==
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    npmlog "^4.1.2"
-
-"@lerna/diff@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/diff/-/diff-3.13.1.tgz#5c734321b0f6c46a3c87f55c99afef3b01d46520"
-  integrity sha512-cKqmpONO57mdvxtp8e+l5+tjtmF04+7E+O0QEcLcNUAjC6UR2OSM77nwRCXDukou/1h72JtWs0jjcdYLwAmApg==
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/validation-error" "3.13.0"
-    npmlog "^4.1.2"
-
-"@lerna/exec@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/exec/-/exec-3.13.1.tgz#4439e90fb0877ec38a6ef933c86580d43eeaf81b"
-  integrity sha512-I34wEP9lrAqqM7tTXLDxv/6454WFzrnXDWpNDbiKQiZs6SIrOOjmm6I4FiQsx+rU3o9d+HkC6tcUJRN5mlJUgA==
-  dependencies:
-    "@lerna/batch-packages" "3.13.0"
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
-    "@lerna/run-parallel-batches" "3.13.0"
-    "@lerna/validation-error" "3.13.0"
-
-"@lerna/filter-options@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/filter-options/-/filter-options-3.13.0.tgz#976e3d8b9fcd47001ab981d276565c1e9f767868"
-  integrity sha512-SRp7DCo9zrf+7NkQxZMkeyO1GRN6GICoB9UcBAbXhLbWisT37Cx5/6+jh49gYB63d/0/WYHSEPMlheUrpv1Srw==
-  dependencies:
-    "@lerna/collect-updates" "3.13.0"
-    "@lerna/filter-packages" "3.13.0"
-    dedent "^0.7.0"
-
-"@lerna/filter-packages@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/filter-packages/-/filter-packages-3.13.0.tgz#f5371249e7e1a15928e5e88c544a242e0162c21c"
-  integrity sha512-RWiZWyGy3Mp7GRVBn//CacSnE3Kw82PxE4+H6bQ3pDUw/9atXn7NRX+gkBVQIYeKamh7HyumJtyOKq3Pp9BADQ==
-  dependencies:
-    "@lerna/validation-error" "3.13.0"
-    multimatch "^2.1.0"
-    npmlog "^4.1.2"
-
-"@lerna/get-npm-exec-opts@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.13.0.tgz#d1b552cb0088199fc3e7e126f914e39a08df9ea5"
-  integrity sha512-Y0xWL0rg3boVyJk6An/vurKzubyJKtrxYv2sj4bB8Mc5zZ3tqtv0ccbOkmkXKqbzvNNF7VeUt1OJ3DRgtC/QZw==
-  dependencies:
-    npmlog "^4.1.2"
-
-"@lerna/get-packed@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/get-packed/-/get-packed-3.13.0.tgz#335e40d77f3c1855aa248587d3e0b2d8f4b06e16"
-  integrity sha512-EgSim24sjIjqQDC57bgXD9l22/HCS93uQBbGpkzEOzxAVzEgpZVm7Fm1t8BVlRcT2P2zwGnRadIvxTbpQuDPTg==
-  dependencies:
-    fs-extra "^7.0.0"
-    ssri "^6.0.1"
-    tar "^4.4.8"
-
-"@lerna/github-client@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/github-client/-/github-client-3.13.1.tgz#cb9bf9f01685a0cee0fac63f287f6c3673e45aa3"
-  integrity sha512-iPLUp8FFoAKGURksYEYZzfuo9TRA+NepVlseRXFaWlmy36dCQN20AciINpoXiXGoHcEUHXUKHQvY3ARFdMlf3w==
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@octokit/plugin-enterprise-rest" "^2.1.1"
-    "@octokit/rest" "^16.16.0"
-    git-url-parse "^11.1.2"
-    npmlog "^4.1.2"
-
-"@lerna/global-options@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/global-options/-/global-options-3.13.0.tgz#217662290db06ad9cf2c49d8e3100ee28eaebae1"
-  integrity sha512-SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ==
-
-"@lerna/has-npm-version@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/has-npm-version/-/has-npm-version-3.13.0.tgz#6e1f7e9336cce3e029066f0175f06dd9d51ad09f"
-  integrity sha512-Oqu7DGLnrMENPm+bPFGOHnqxK8lCnuYr6bk3g/CoNn8/U0qgFvHcq6Iv8/Z04TsvleX+3/RgauSD2kMfRmbypg==
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    semver "^5.5.0"
-
-"@lerna/import@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/import/-/import-3.13.1.tgz#69d641341a38b79bd379129da1c717d51dd728c7"
-  integrity sha512-A1Vk1siYx1XkRl6w+zkaA0iptV5TIynVlHPR9S7NY0XAfhykjztYVvwtxarlh6+VcNrO9We6if0+FXCrfDEoIg==
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/prompt" "3.13.0"
-    "@lerna/pulse-till-done" "3.13.0"
-    "@lerna/validation-error" "3.13.0"
-    dedent "^0.7.0"
-    fs-extra "^7.0.0"
-    p-map-series "^1.0.0"
-
-"@lerna/init@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/init/-/init-3.13.1.tgz#0392c822abb3d63a75be4916c5e761cfa7b34dda"
-  integrity sha512-M59WACqim8WkH5FQEGOCEZ89NDxCKBfFTx4ZD5ig3LkGyJ8RdcJq5KEfpW/aESuRE9JrZLzVr0IjKbZSxzwEMA==
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
-    fs-extra "^7.0.0"
-    p-map "^1.2.0"
-    write-json-file "^2.3.0"
-
-"@lerna/link@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/link/-/link-3.13.1.tgz#7d8ed4774bfa198d1780f790a14abb8722a3aad1"
-  integrity sha512-N3h3Fj1dcea+1RaAoAdy4g2m3fvU7m89HoUn5X/Zcw5n2kPoK8kTO+NfhNAatfRV8VtMXst8vbNrWQQtfm0FFw==
-  dependencies:
-    "@lerna/command" "3.13.1"
-    "@lerna/package-graph" "3.13.0"
-    "@lerna/symlink-dependencies" "3.13.0"
-    p-map "^1.2.0"
-    slash "^1.0.0"
-
-"@lerna/list@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/list/-/list-3.13.1.tgz#f9513ed143e52156c10ada4070f903c5847dcd10"
-  integrity sha512-635iRbdgd9gNvYLLIbYdQCQLr+HioM5FGJLFS0g3DPGygr6iDR8KS47hzCRGH91LU9NcM1mD1RoT/AChF+QbiA==
-  dependencies:
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
-    "@lerna/listable" "3.13.0"
-    "@lerna/output" "3.13.0"
-
-"@lerna/listable@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/listable/-/listable-3.13.0.tgz#babc18442c590b549cf0966d20d75fea066598d4"
-  integrity sha512-liYJ/WBUYP4N4MnSVZuLUgfa/jy3BZ02/1Om7xUY09xGVSuNVNEeB8uZUMSC+nHqFHIsMPZ8QK9HnmZb1E/eTA==
-  dependencies:
-    "@lerna/batch-packages" "3.13.0"
-    chalk "^2.3.1"
-    columnify "^1.5.4"
-
-"@lerna/log-packed@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/log-packed/-/log-packed-3.13.0.tgz#497b5f692a8d0e3f669125da97b0dadfd9e480f3"
-  integrity sha512-Rmjrcz+6aM6AEcEVWmurbo8+AnHOvYtDpoeMMJh9IZ9SmZr2ClXzmD7wSvjTQc8BwOaiWjjC/ukcT0UYA2m7wg==
-  dependencies:
-    byte-size "^4.0.3"
-    columnify "^1.5.4"
-    has-unicode "^2.0.1"
-    npmlog "^4.1.2"
-
-"@lerna/npm-conf@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-conf/-/npm-conf-3.13.0.tgz#6b434ed75ff757e8c14381b9bbfe5d5ddec134a7"
-  integrity sha512-Jg2kANsGnhg+fbPEzE0X9nX5oviEAvWj0nYyOkcE+cgWuT7W0zpnPXC4hA4C5IPQGhwhhh0IxhWNNHtjTuw53g==
-  dependencies:
-    config-chain "^1.1.11"
-    pify "^3.0.0"
-
-"@lerna/npm-dist-tag@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-dist-tag/-/npm-dist-tag-3.13.0.tgz#49ecbe0e82cbe4ad4a8ea6de112982bf6c4e6cd4"
-  integrity sha512-mcuhw34JhSRFrbPn0vedbvgBTvveG52bR2lVE3M3tfE8gmR/cKS/EJFO4AUhfRKGCTFn9rjaSEzlFGYV87pemQ==
-  dependencies:
-    figgy-pudding "^3.5.1"
-    npm-package-arg "^6.1.0"
-    npm-registry-fetch "^3.9.0"
-    npmlog "^4.1.2"
-
-"@lerna/npm-install@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-install/-/npm-install-3.13.0.tgz#88f4cc39f4f737c8a8721256b915ea1bcc6a7227"
-  integrity sha512-qNyfts//isYQxore6fsPorNYJmPVKZ6tOThSH97tP0aV91zGMtrYRqlAoUnDwDdAjHPYEM16hNujg2wRmsqqIw==
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/get-npm-exec-opts" "3.13.0"
-    fs-extra "^7.0.0"
-    npm-package-arg "^6.1.0"
-    npmlog "^4.1.2"
-    signal-exit "^3.0.2"
-    write-pkg "^3.1.0"
-
-"@lerna/npm-publish@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-publish/-/npm-publish-3.13.0.tgz#5c74808376e778865ffdc5885fe83935e15e60c3"
-  integrity sha512-y4WO0XTaf9gNRkI7as6P2ItVDOxmYHwYto357fjybcnfXgMqEA94c3GJ++jU41j0A9vnmYC6/XxpTd9sVmH9tA==
-  dependencies:
-    "@lerna/run-lifecycle" "3.13.0"
-    figgy-pudding "^3.5.1"
-    fs-extra "^7.0.0"
-    libnpmpublish "^1.1.1"
-    npmlog "^4.1.2"
-    pify "^3.0.0"
-    read-package-json "^2.0.13"
-
-"@lerna/npm-run-script@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-run-script/-/npm-run-script-3.13.0.tgz#e5997f045402b9948bdc066033ebb36bf94fc9e4"
-  integrity sha512-hiL3/VeVp+NFatBjkGN8mUdX24EfZx9rQlSie0CMgtjc7iZrtd0jCguLomSCRHYjJuvqgbp+LLYo7nHVykfkaQ==
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/get-npm-exec-opts" "3.13.0"
-    npmlog "^4.1.2"
-
-"@lerna/output@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/output/-/output-3.13.0.tgz#3ded7cc908b27a9872228a630d950aedae7a4989"
-  integrity sha512-7ZnQ9nvUDu/WD+bNsypmPG5MwZBwu86iRoiW6C1WBuXXDxM5cnIAC1m2WxHeFnjyMrYlRXM9PzOQ9VDD+C15Rg==
-  dependencies:
-    npmlog "^4.1.2"
-
-"@lerna/pack-directory@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/pack-directory/-/pack-directory-3.13.1.tgz#5ad4d0945f86a648f565e24d53c1e01bb3a912d1"
-  integrity sha512-kXnyqrkQbCIZOf1054N88+8h0ItC7tUN5v9ca/aWpx298gsURpxUx/1TIKqijL5TOnHMyIkj0YJmnH/PyBVLKA==
-  dependencies:
-    "@lerna/get-packed" "3.13.0"
-    "@lerna/package" "3.13.0"
-    "@lerna/run-lifecycle" "3.13.0"
-    figgy-pudding "^3.5.1"
-    npm-packlist "^1.4.1"
-    npmlog "^4.1.2"
-    tar "^4.4.8"
-    temp-write "^3.4.0"
-
-"@lerna/package-graph@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/package-graph/-/package-graph-3.13.0.tgz#607062f8d2ce22b15f8d4a0623f384736e67f760"
-  integrity sha512-3mRF1zuqFE1HEFmMMAIggXy+f+9cvHhW/jzaPEVyrPNLKsyfJQtpTNzeI04nfRvbAh+Gd2aNksvaW/w3xGJnnw==
-  dependencies:
-    "@lerna/validation-error" "3.13.0"
-    npm-package-arg "^6.1.0"
-    semver "^5.5.0"
-
-"@lerna/package@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/package/-/package-3.13.0.tgz#4baeebc49a57fc9b31062cc59f5ee38384429fc8"
-  integrity sha512-kSKO0RJQy093BufCQnkhf1jB4kZnBvL7kK5Ewolhk5gwejN+Jofjd8DGRVUDUJfQ0CkW1o6GbUeZvs8w8VIZDg==
-  dependencies:
-    load-json-file "^4.0.0"
-    npm-package-arg "^6.1.0"
-    write-pkg "^3.1.0"
-
-"@lerna/project@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/project/-/project-3.13.1.tgz#bce890f60187bd950bcf36c04b5260642e295e79"
-  integrity sha512-/GoCrpsCCTyb9sizk1+pMBrIYchtb+F1uCOn3cjn9yenyG/MfYEnlfrbV5k/UDud0Ei75YBLbmwCbigHkAKazQ==
-  dependencies:
-    "@lerna/package" "3.13.0"
-    "@lerna/validation-error" "3.13.0"
-    cosmiconfig "^5.1.0"
-    dedent "^0.7.0"
-    dot-prop "^4.2.0"
-    glob-parent "^3.1.0"
-    globby "^8.0.1"
-    load-json-file "^4.0.0"
-    npmlog "^4.1.2"
-    p-map "^1.2.0"
-    resolve-from "^4.0.0"
-    write-json-file "^2.3.0"
-
-"@lerna/prompt@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/prompt/-/prompt-3.13.0.tgz#53571462bb3f5399cc1ca6d335a411fe093426a5"
-  integrity sha512-P+lWSFokdyvYpkwC3it9cE0IF2U5yy2mOUbGvvE4iDb9K7TyXGE+7lwtx2thtPvBAfIb7O13POMkv7df03HJeA==
-  dependencies:
-    inquirer "^6.2.0"
-    npmlog "^4.1.2"
-
-"@lerna/publish@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.13.1.tgz#217e401dcb5824cdd6d36555a36303fb7520c514"
-  integrity sha512-KhCJ9UDx76HWCF03i5TD7z5lX+2yklHh5SyO8eDaLptgdLDQ0Z78lfGj3JhewHU2l46FztmqxL/ss0IkWHDL+g==
-  dependencies:
-    "@lerna/batch-packages" "3.13.0"
-    "@lerna/check-working-tree" "3.13.0"
-    "@lerna/child-process" "3.13.0"
-    "@lerna/collect-updates" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/describe-ref" "3.13.0"
-    "@lerna/log-packed" "3.13.0"
-    "@lerna/npm-conf" "3.13.0"
-    "@lerna/npm-dist-tag" "3.13.0"
-    "@lerna/npm-publish" "3.13.0"
-    "@lerna/output" "3.13.0"
-    "@lerna/pack-directory" "3.13.1"
-    "@lerna/prompt" "3.13.0"
-    "@lerna/pulse-till-done" "3.13.0"
-    "@lerna/run-lifecycle" "3.13.0"
-    "@lerna/run-parallel-batches" "3.13.0"
-    "@lerna/validation-error" "3.13.0"
-    "@lerna/version" "3.13.1"
-    figgy-pudding "^3.5.1"
-    fs-extra "^7.0.0"
-    libnpmaccess "^3.0.1"
-    npm-package-arg "^6.1.0"
-    npm-registry-fetch "^3.9.0"
-    npmlog "^4.1.2"
-    p-finally "^1.0.0"
-    p-map "^1.2.0"
-    p-pipe "^1.2.0"
-    p-reduce "^1.0.0"
-    pacote "^9.5.0"
-    semver "^5.5.0"
-
-"@lerna/pulse-till-done@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/pulse-till-done/-/pulse-till-done-3.13.0.tgz#c8e9ce5bafaf10d930a67d7ed0ccb5d958fe0110"
-  integrity sha512-1SOHpy7ZNTPulzIbargrgaJX387csN7cF1cLOGZiJQA6VqnS5eWs2CIrG8i8wmaUavj2QlQ5oEbRMVVXSsGrzA==
-  dependencies:
-    npmlog "^4.1.2"
-
-"@lerna/resolve-symlink@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/resolve-symlink/-/resolve-symlink-3.13.0.tgz#3e6809ef53b63fe914814bfa071cd68012e22fbb"
-  integrity sha512-Lc0USSFxwDxUs5JvIisS8JegjA6SHSAWJCMvi2osZx6wVRkEDlWG2B1JAfXUzCMNfHoZX0/XX9iYZ+4JIpjAtg==
-  dependencies:
-    fs-extra "^7.0.0"
-    npmlog "^4.1.2"
-    read-cmd-shim "^1.0.1"
-
-"@lerna/rimraf-dir@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/rimraf-dir/-/rimraf-dir-3.13.0.tgz#bb1006104b4aabcb6985624273254648f872b278"
-  integrity sha512-kte+pMemulre8cmPqljxIYjCmdLByz8DgHBHXB49kz2EiPf8JJ+hJFt0PzEubEyJZ2YE2EVAx5Tv5+NfGNUQyQ==
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    npmlog "^4.1.2"
-    path-exists "^3.0.0"
-    rimraf "^2.6.2"
-
-"@lerna/run-lifecycle@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/run-lifecycle/-/run-lifecycle-3.13.0.tgz#d8835ee83425edee40f687a55f81b502354d3261"
-  integrity sha512-oyiaL1biZdjpmjh6X/5C4w07wNFyiwXSSHH5GQB4Ay4BPwgq9oNhCcxRoi0UVZlZ1YwzSW8sTwLgj8emkIo3Yg==
-  dependencies:
-    "@lerna/npm-conf" "3.13.0"
-    figgy-pudding "^3.5.1"
-    npm-lifecycle "^2.1.0"
-    npmlog "^4.1.2"
-
-"@lerna/run-parallel-batches@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/run-parallel-batches/-/run-parallel-batches-3.13.0.tgz#0276bb4e7cd0995297db82d134ca2bd08d63e311"
-  integrity sha512-bICFBR+cYVF1FFW+Tlm0EhWDioTUTM6dOiVziDEGE1UZha1dFkMYqzqdSf4bQzfLS31UW/KBd/2z8jy2OIjEjg==
-  dependencies:
-    p-map "^1.2.0"
-    p-map-series "^1.0.0"
-
-"@lerna/run@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/run/-/run-3.13.1.tgz#87e174c1d271894ddd29adc315c068fb7b1b0117"
-  integrity sha512-nv1oj7bsqppWm1M4ifN+/IIbVu9F4RixrbQD2okqDGYne4RQPAXyb5cEZuAzY/wyGTWWiVaZ1zpj5ogPWvH0bw==
-  dependencies:
-    "@lerna/batch-packages" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
-    "@lerna/npm-run-script" "3.13.0"
-    "@lerna/output" "3.13.0"
-    "@lerna/run-parallel-batches" "3.13.0"
-    "@lerna/timer" "3.13.0"
-    "@lerna/validation-error" "3.13.0"
-    p-map "^1.2.0"
-
-"@lerna/symlink-binary@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/symlink-binary/-/symlink-binary-3.13.0.tgz#36a9415d468afcb8105750296902f6f000a9680d"
-  integrity sha512-obc4Y6jxywkdaCe+DB0uTxYqP0IQ8mFWvN+k/YMbwH4G2h7M7lCBWgPy8e7xw/50+1II9tT2sxgx+jMus1sTJg==
-  dependencies:
-    "@lerna/create-symlink" "3.13.0"
-    "@lerna/package" "3.13.0"
-    fs-extra "^7.0.0"
-    p-map "^1.2.0"
-
-"@lerna/symlink-dependencies@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/symlink-dependencies/-/symlink-dependencies-3.13.0.tgz#76c23ecabda7824db98a0561364f122b457509cf"
-  integrity sha512-7CyN5WYEPkbPLbqHBIQg/YiimBzb5cIGQB0E9IkLs3+racq2vmUNQZn38LOaazQacAA83seB+zWSxlI6H+eXSg==
-  dependencies:
-    "@lerna/create-symlink" "3.13.0"
-    "@lerna/resolve-symlink" "3.13.0"
-    "@lerna/symlink-binary" "3.13.0"
-    fs-extra "^7.0.0"
-    p-finally "^1.0.0"
-    p-map "^1.2.0"
-    p-map-series "^1.0.0"
-
-"@lerna/timer@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/timer/-/timer-3.13.0.tgz#bcd0904551db16e08364d6c18e5e2160fc870781"
-  integrity sha512-RHWrDl8U4XNPqY5MQHkToWS9jHPnkLZEt5VD+uunCKTfzlxGnRCr3/zVr8VGy/uENMYpVP3wJa4RKGY6M0vkRw==
-
-"@lerna/validation-error@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/validation-error/-/validation-error-3.13.0.tgz#c86b8f07c5ab9539f775bd8a54976e926f3759c3"
-  integrity sha512-SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==
-  dependencies:
-    npmlog "^4.1.2"
-
-"@lerna/version@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@lerna/version/-/version-3.13.1.tgz#5e919d13abb13a663dcc7922bb40931f12fb137b"
-  integrity sha512-WpfKc5jZBBOJ6bFS4atPJEbHSiywQ/Gcd+vrwaEGyQHWHQZnPTvhqLuq3q9fIb9sbuhH5pSY6eehhuBrKqTnjg==
-  dependencies:
-    "@lerna/batch-packages" "3.13.0"
-    "@lerna/check-working-tree" "3.13.0"
-    "@lerna/child-process" "3.13.0"
-    "@lerna/collect-updates" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/conventional-commits" "3.13.0"
-    "@lerna/github-client" "3.13.1"
-    "@lerna/output" "3.13.0"
-    "@lerna/prompt" "3.13.0"
-    "@lerna/run-lifecycle" "3.13.0"
-    "@lerna/validation-error" "3.13.0"
-    chalk "^2.3.1"
-    dedent "^0.7.0"
-    minimatch "^3.0.4"
-    npmlog "^4.1.2"
-    p-map "^1.2.0"
-    p-pipe "^1.2.0"
-    p-reduce "^1.0.0"
-    p-waterfall "^1.0.0"
-    semver "^5.5.0"
-    slash "^1.0.0"
-    temp-write "^3.4.0"
-
-"@lerna/write-log-file@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@lerna/write-log-file/-/write-log-file-3.13.0.tgz#b78d9e4cfc1349a8be64d91324c4c8199e822a26"
-  integrity sha512-RibeMnDPvlL8bFYW5C8cs4mbI3AHfQef73tnJCQ/SgrXZHehmHnsyWUiE7qDQCAo+B1RfTapvSyFF69iPj326A==
-  dependencies:
-    npmlog "^4.1.2"
-    write-file-atomic "^2.3.0"
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -2606,50 +1991,6 @@
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
-
-"@octokit/endpoint@^3.2.0":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-3.2.3.tgz#bd9aea60cd94ce336656b57a5c9cb7f10be8f4f3"
-  integrity sha512-yUPCt4vMIOclox13CUxzuKiPJIFo46b/6GhUnUTw5QySczN1L0DtSxgmIZrZV4SAb9EyAqrceoyrWoYVnfF2AA==
-  dependencies:
-    deepmerge "3.2.0"
-    is-plain-object "^2.0.4"
-    universal-user-agent "^2.0.1"
-    url-template "^2.0.8"
-
-"@octokit/plugin-enterprise-rest@^2.1.1":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.2.2.tgz#c0e22067a043e19f96ff9c7832e2a3019f9be75c"
-  integrity sha512-CTZr64jZYhGWNTDGlSJ2mvIlFsm9OEO3LqWn9I/gmoHI4jRBp4kpHoFYNemG4oA75zUAcmbuWblb7jjP877YZw==
-
-"@octokit/request@2.4.2":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-2.4.2.tgz#87c36e820dd1e43b1629f4f35c95b00cd456320b"
-  integrity sha512-lxVlYYvwGbKSHXfbPk5vxEA8w4zHOH1wobado4a9EfsyD3Cbhuhus1w0Ye9Ro0eMubGO8kNy5d+xNFisM3Tvaw==
-  dependencies:
-    "@octokit/endpoint" "^3.2.0"
-    deprecation "^1.0.1"
-    is-plain-object "^2.0.4"
-    node-fetch "^2.3.0"
-    once "^1.4.0"
-    universal-user-agent "^2.0.1"
-
-"@octokit/rest@^16.16.0":
-  version "16.20.0"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.20.0.tgz#54462b6e540b5d40063850d370ce8e084cf127d6"
-  integrity sha512-tN5j64P6QymlMzKo94DG1LRNHCwMnLg5poZlVhsCfkHhEWKpofZ1qBDr2/0w6qDLav4EA1XXMmZdNpvGhc9BDQ==
-  dependencies:
-    "@octokit/request" "2.4.2"
-    before-after-hook "^1.4.0"
-    btoa-lite "^1.0.0"
-    deprecation "^1.0.1"
-    lodash.get "^4.4.2"
-    lodash.set "^4.3.2"
-    lodash.uniq "^4.5.0"
-    octokit-pagination-methods "^1.1.0"
-    once "^1.4.0"
-    universal-user-agent "^2.0.0"
-    url-template "^2.0.8"
 
 "@reach/router@^1.2.1":
   version "1.2.1"
@@ -3443,7 +2784,7 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-JSONStream@^1.0.4, JSONStream@^1.3.4:
+JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
   integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
@@ -3500,23 +2841,14 @@ acorn@^6.0.5, acorn@^6.0.7:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
+add-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
+  integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
+
 address@1.0.3, address@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/address/-/address-1.0.3.tgz#b5f50631f8d6cec8bd20c963963afb55e06cbce9"
-
-agent-base@4, agent-base@^4.1.0, agent-base@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
-  integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
-  dependencies:
-    es6-promisify "^5.0.0"
-
-agentkeepalive@^3.4.1:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-3.5.2.tgz#a113924dd3fa24a0bc3b78108c450c2abee00f67"
-  integrity sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==
-  dependencies:
-    humanize-ms "^1.2.1"
 
 "airbnb-js-shims@^1 || ^2":
   version "2.1.1"
@@ -3650,11 +2982,6 @@ aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
 
-aproba@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
-  integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
-
 are-we-there-yet@~1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
@@ -3686,10 +3013,6 @@ arr-flatten@^1.1.0:
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
-
-array-differ@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
 
 array-equal@^1.0.0:
   version "1.0.0"
@@ -3760,11 +3083,11 @@ array.prototype.flatmap@^1.2.1:
     es-abstract "^1.10.0"
     function-bind "^1.1.1"
 
-arrify@^1.0.0, arrify@^1.0.1:
+arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@^2.0.0, asap@~2.0.3:
+asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
@@ -3834,6 +3157,11 @@ async-each@^1.0.0:
 async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+
+async@^1.5.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
 async@^2.1.4, async@^2.5.0:
   version "2.6.1"
@@ -4293,11 +3621,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-before-after-hook@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.4.0.tgz#2b6bf23dca4f32e628fd2747c10a37c74a4b484d"
-  integrity sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==
-
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
@@ -4324,7 +3647,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.3.5, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.x:
+bluebird@^3.3.5, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.x:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
 
@@ -4503,11 +3826,6 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-btoa-lite@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
-  integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
-
 buffer-alloc-unsafe@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
@@ -4583,34 +3901,9 @@ byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
 
-byte-size@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-4.0.4.tgz#29d381709f41aae0d89c631f1c81aec88cd40b23"
-  integrity sha512-82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw==
-
 bytes@3.0.0, bytes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
-
-cacache@^11.0.1, cacache@^11.3.2:
-  version "11.3.2"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.2.tgz#2d81e308e3d258ca38125b676b98b2ac9ce69bfa"
-  integrity sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==
-  dependencies:
-    bluebird "^3.5.3"
-    chownr "^1.1.1"
-    figgy-pudding "^3.5.1"
-    glob "^7.1.3"
-    graceful-fs "^4.1.15"
-    lru-cache "^5.1.1"
-    mississippi "^3.0.0"
-    mkdirp "^0.5.1"
-    move-concurrently "^1.0.1"
-    promise-inflight "^1.0.1"
-    rimraf "^2.6.2"
-    ssri "^6.0.1"
-    unique-filename "^1.1.1"
-    y18n "^4.0.0"
 
 cacache@^11.0.2:
   version "11.3.1"
@@ -4753,6 +4046,11 @@ capture-exit@^1.2.0:
   dependencies:
     rsvp "^3.3.3"
 
+capture-stack-trace@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
+  integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
+
 case-sensitive-paths-webpack-plugin@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.2.0.tgz#3371ef6365ef9c25fa4b81c16ace0e9c7dc58c3e"
@@ -4830,6 +4128,11 @@ character-entities@^1.0.0:
 character-reference-invalid@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz#21e421ad3d84055952dab4a43a04e73cd425d3ed"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+  integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -5098,6 +4401,13 @@ comma-separated-tokens@^1.0.0:
   dependencies:
     trim "0.0.1"
 
+command-join@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/command-join/-/command-join-2.0.1.tgz#0a9e58a84e94bd0d1b6c75ce1078723d8a7645cb"
+  integrity sha512-LBA9kSxtg2SA8itaBeuitpn4pZQOhGVP1dyU1cnXLYrBpF3sikaPhjWPqyqVh7oGpneI05RtJs9a0fftIEgXcA==
+  dependencies:
+    "@improved/node" "^1.0.0"
+
 commander@2.15.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
@@ -5144,7 +4454,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6, concat-stream@^1.5.0, concat-stream@^1.6.0:
+concat-stream@^1.4.10, concat-stream@^1.4.6, concat-stream@^1.5.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -5153,7 +4463,7 @@ concat-stream@^1.4.6, concat-stream@^1.5.0, concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-config-chain@^1.1.11, config-chain@^1.1.12:
+config-chain@^1.1.12:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
   integrity sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==
@@ -5192,47 +4502,115 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
-conventional-changelog-angular@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz#299fdd43df5a1f095283ac16aeedfb0a682ecab0"
-  integrity sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==
+conventional-changelog-angular@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz#b27f2b315c16d0a1f23eb181309d0e6a4698ea0f"
+  integrity sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==
   dependencies:
     compare-func "^1.3.1"
     q "^1.5.1"
 
-conventional-changelog-core@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-3.1.6.tgz#ac1731a461c50d150d29c1ad4f33143293bcd32f"
-  integrity sha512-5teTAZOtJ4HLR6384h50nPAaKdDr+IaU0rnD2Gg2C3MS7hKsEPH8pZxrDNqam9eOSPQg9tET6uZY79zzgSz+ig==
+conventional-changelog-atom@^0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz#8037693455990e3256f297320a45fa47ee553a14"
+  integrity sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==
   dependencies:
-    conventional-changelog-writer "^4.0.3"
-    conventional-commits-parser "^3.0.1"
+    q "^1.5.1"
+
+conventional-changelog-cli@^1.3.13:
+  version "1.3.22"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-cli/-/conventional-changelog-cli-1.3.22.tgz#13570fe1728f56f013ff7a88878ff49d5162a405"
+  integrity sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==
+  dependencies:
+    add-stream "^1.0.0"
+    conventional-changelog "^1.1.24"
+    lodash "^4.2.1"
+    meow "^4.0.0"
+    tempfile "^1.1.1"
+
+conventional-changelog-codemirror@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz#a1982c8291f4ee4d6f2f62817c6b2ecd2c4b7b47"
+  integrity sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==
+  dependencies:
+    q "^1.5.1"
+
+conventional-changelog-core@^2.0.11:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz#19b5fbd55a9697773ed6661f4e32030ed7e30287"
+  integrity sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==
+  dependencies:
+    conventional-changelog-writer "^3.0.9"
+    conventional-commits-parser "^2.1.7"
     dateformat "^3.0.0"
     get-pkg-repo "^1.0.0"
-    git-raw-commits "2.0.0"
+    git-raw-commits "^1.3.6"
     git-remote-origin-url "^2.0.0"
-    git-semver-tags "^2.0.2"
+    git-semver-tags "^1.3.6"
     lodash "^4.2.1"
     normalize-package-data "^2.3.5"
     q "^1.5.1"
-    read-pkg "^3.0.0"
-    read-pkg-up "^3.0.0"
+    read-pkg "^1.1.0"
+    read-pkg-up "^1.0.1"
     through2 "^2.0.0"
 
-conventional-changelog-preset-loader@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.0.2.tgz#81d1a07523913f3d17da3a49f0091f967ad345b0"
-  integrity sha512-pBY+qnUoJPXAXXqVGwQaVmcye05xi6z231QM98wHWamGAmu/ghkBprQAwmF5bdmyobdVxiLhPY3PrCfSeUNzRQ==
+conventional-changelog-ember@^0.3.12:
+  version "0.3.12"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz#b7d31851756d0fcb49b031dffeb6afa93b202400"
+  integrity sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==
+  dependencies:
+    q "^1.5.1"
 
-conventional-changelog-writer@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-4.0.3.tgz#916a2b302d0bb5ef18efd236a034c13fb273cde1"
-  integrity sha512-bIlpSiQtQZ1+nDVHEEh798Erj2jhN/wEjyw9sfxY9es6h7pREE5BNJjfv0hXGH/FTrAsEpHUq4xzK99eePpwuA==
+conventional-changelog-eslint@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz#b13cc7e4b472c819450ede031ff1a75c0e3d07d3"
+  integrity sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==
+  dependencies:
+    q "^1.5.1"
+
+conventional-changelog-express@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz#4a6295cb11785059fb09202180d0e59c358b9c2c"
+  integrity sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==
+  dependencies:
+    q "^1.5.1"
+
+conventional-changelog-jquery@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz#0208397162e3846986e71273b6c79c5b5f80f510"
+  integrity sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=
+  dependencies:
+    q "^1.4.1"
+
+conventional-changelog-jscs@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz#0479eb443cc7d72c58bf0bcf0ef1d444a92f0e5c"
+  integrity sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=
+  dependencies:
+    q "^1.4.1"
+
+conventional-changelog-jshint@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz#9051c1ac0767abaf62a31f74d2fe8790e8acc6c8"
+  integrity sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==
   dependencies:
     compare-func "^1.3.1"
-    conventional-commits-filter "^2.0.1"
+    q "^1.5.1"
+
+conventional-changelog-preset-loader@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz#40bb0f142cd27d16839ec6c74ee8db418099b373"
+  integrity sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==
+
+conventional-changelog-writer@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz#4aecdfef33ff2a53bb0cf3b8071ce21f0e994634"
+  integrity sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==
+  dependencies:
+    compare-func "^1.3.1"
+    conventional-commits-filter "^1.1.6"
     dateformat "^3.0.0"
-    handlebars "^4.1.0"
+    handlebars "^4.0.2"
     json-stringify-safe "^5.0.1"
     lodash "^4.2.1"
     meow "^4.0.0"
@@ -5240,18 +4618,35 @@ conventional-changelog-writer@^4.0.3:
     split "^1.0.0"
     through2 "^2.0.0"
 
-conventional-commits-filter@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz#55a135de1802f6510b6758e0a6aa9e0b28618db3"
-  integrity sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==
+conventional-changelog@^1.1.24:
+  version "1.1.24"
+  resolved "https://registry.yarnpkg.com/conventional-changelog/-/conventional-changelog-1.1.24.tgz#3d94c29c960f5261c002678315b756cdd3d7d1f0"
+  integrity sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==
+  dependencies:
+    conventional-changelog-angular "^1.6.6"
+    conventional-changelog-atom "^0.2.8"
+    conventional-changelog-codemirror "^0.3.8"
+    conventional-changelog-core "^2.0.11"
+    conventional-changelog-ember "^0.3.12"
+    conventional-changelog-eslint "^1.0.9"
+    conventional-changelog-express "^0.3.6"
+    conventional-changelog-jquery "^0.1.0"
+    conventional-changelog-jscs "^0.1.0"
+    conventional-changelog-jshint "^0.3.8"
+    conventional-changelog-preset-loader "^1.1.8"
+
+conventional-commits-filter@^1.1.1, conventional-commits-filter@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz#4389cd8e58fe89750c0b5fb58f1d7f0cc8ad3831"
+  integrity sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==
   dependencies:
     is-subset "^0.1.1"
     modify-values "^1.0.0"
 
-conventional-commits-parser@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz#fe1c49753df3f98edb2285a5e485e11ffa7f2e4c"
-  integrity sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==
+conventional-commits-parser@^2.1.1, conventional-commits-parser@^2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz#eca45ed6140d72ba9722ee4132674d639e644e8e"
+  integrity sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==
   dependencies:
     JSONStream "^1.0.4"
     is-text-path "^1.0.0"
@@ -5261,19 +4656,18 @@ conventional-commits-parser@^3.0.1:
     through2 "^2.0.0"
     trim-off-newlines "^1.0.0"
 
-conventional-recommended-bump@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/conventional-recommended-bump/-/conventional-recommended-bump-4.0.4.tgz#05540584641d3da758c8863c09788fcaeb586872"
-  integrity sha512-9mY5Yoblq+ZMqJpBzgS+RpSq+SUfP2miOR3H/NR9drGf08WCrY9B6HAGJZEm6+ThsVP917VHAahSOjM6k1vhPg==
+conventional-recommended-bump@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz#1b7137efb5091f99fe009e2fe9ddb7cc490e9375"
+  integrity sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==
   dependencies:
-    concat-stream "^1.6.0"
-    conventional-changelog-preset-loader "^2.0.2"
-    conventional-commits-filter "^2.0.1"
-    conventional-commits-parser "^3.0.1"
-    git-raw-commits "2.0.0"
-    git-semver-tags "^2.0.2"
-    meow "^4.0.0"
-    q "^1.5.1"
+    concat-stream "^1.4.10"
+    conventional-commits-filter "^1.1.1"
+    conventional-commits-parser "^2.1.1"
+    git-raw-commits "^1.3.0"
+    git-semver-tags "^1.3.0"
+    meow "^3.3.0"
+    object-assign "^4.0.1"
 
 convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.6.0"
@@ -5365,7 +4759,7 @@ cosmiconfig@^5.0.5:
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
 
-cosmiconfig@^5.0.7, cosmiconfig@^5.1.0:
+cosmiconfig@^5.0.7:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.1.0.tgz#6c5c35e97f37f985061cdf653f114784231185cf"
   integrity sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==
@@ -5395,6 +4789,13 @@ create-emotion@^9.2.12:
     csstype "^2.5.2"
     stylis "^3.5.0"
     stylis-rule-sheet "^0.0.10"
+
+create-error-class@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
+  integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
+  dependencies:
+    capture-stack-trace "^1.0.0"
 
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
@@ -5672,7 +5073,7 @@ debug@3.1.0, debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.1, debug@^3.1.0, debug@^3.2.5:
+debug@^3.0.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -5691,11 +5092,6 @@ debug@^4.1.0:
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
   dependencies:
     ms "^2.1.1"
-
-debuglog@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
-  integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
 
 decamelize-keys@^1.0.0:
   version "1.1.0"
@@ -5741,11 +5137,6 @@ deep-object-diff@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
   integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
-
-deepmerge@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
-  integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
 
 default-require-extensions@^2.0.0:
   version "2.0.0"
@@ -5806,11 +5197,6 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
-deprecation@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-1.0.1.tgz#2df79b79005752180816b7b6e079cbd80490d711"
-  integrity sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==
-
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
@@ -5857,14 +5243,6 @@ detect-port@^1.2.3:
     address "^1.0.1"
     debug "^2.6.0"
 
-dezalgo@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
-  integrity sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=
-  dependencies:
-    asap "^2.0.0"
-    wrappy "1"
-
 diff-sequences@^24.3.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
@@ -5882,7 +5260,7 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-dir-glob@2.0.0, dir-glob@^2.0.0:
+dir-glob@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
   integrity sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==
@@ -6017,13 +5395,6 @@ domutils@^1.5.1, domutils@^1.7.0:
 dot-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
-  dependencies:
-    is-obj "^1.0.0"
-
-dot-prop@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
-  integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
   dependencies:
     is-obj "^1.0.0"
 
@@ -6236,11 +5607,6 @@ enzyme@^3.7.0:
     rst-selector-parser "^2.2.3"
     string.prototype.trim "^1.1.2"
 
-err-code@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
-  integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
-
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
@@ -6301,18 +5667,6 @@ es6-map@^0.1.3:
     es6-set "~0.1.5"
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
-
-es6-promise@^4.0.3:
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.6.tgz#b685edd8258886365ea62b57d30de28fadcd974f"
-  integrity sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==
-
-es6-promisify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
-  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
-  dependencies:
-    es6-promise "^4.0.3"
 
 es6-set@~0.1.5:
   version "0.1.5"
@@ -6714,12 +6068,11 @@ exec-sh@^0.3.2:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
   integrity sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==
 
-execa@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
-  integrity sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
   dependencies:
-    cross-spawn "^6.0.0"
+    cross-spawn "^5.0.1"
     get-stream "^3.0.0"
     is-stream "^1.1.0"
     npm-run-path "^2.0.0"
@@ -6727,9 +6080,10 @@ execa@^0.10.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  integrity sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -6855,6 +6209,15 @@ extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
+external-editor@^2.0.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  integrity sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
 external-editor@^3.0.0, external-editor@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
@@ -6953,7 +6316,7 @@ fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.5:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
-figgy-pudding@^3.1.0, figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
+figgy-pudding@^3.1.0, figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
 
@@ -7125,10 +6488,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
-flow-bin@^0.96.0:
-  version "0.96.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.96.0.tgz#3b0379d97304dc1879ae6db627cd2d6819998661"
-  integrity sha512-OSxERs0EdhVxEVCst/HmlT/RcnXsQQIRqcfK9J9wC8/93JQj+xQz4RtlsmYe1PSRYaozuDLyPS5pIA81Zwzaww==
+flow-bin@^0.97.0:
+  version "0.97.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.97.0.tgz#036ffcfc27503367a9d906ec9d843a0aa6f6bb83"
+  integrity sha512-jXjD05gkatLuC4+e28frH1hZoRwr1iASP6oJr61Q64+kR4kmzaS+AdFBhYgoYS5kpoe4UzwDebWK8ETQFNh00w==
 
 flush-write-stream@^1.0.0:
   version "1.0.3"
@@ -7229,7 +6592,16 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-extra@^7.0.0, fs-extra@^7.0.1:
+fs-extra@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -7323,11 +6695,6 @@ generate-object-property@^1.1.0:
   dependencies:
     is-property "^1.0.0"
 
-genfun@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
-  integrity sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==
-
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
@@ -7364,7 +6731,7 @@ get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
   resolved "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
-get-stream@^4.0.0, get-stream@^4.1.0:
+get-stream@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
@@ -7381,10 +6748,10 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-git-raw-commits@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-2.0.0.tgz#d92addf74440c14bcc5c83ecce3fb7f8a79118b5"
-  integrity sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==
+git-raw-commits@^1.3.0, git-raw-commits@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-1.3.6.tgz#27c35a32a67777c1ecd412a239a6c19d71b95aff"
+  integrity sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==
   dependencies:
     dargs "^4.0.1"
     lodash.template "^4.0.2"
@@ -7399,10 +6766,10 @@ git-remote-origin-url@^2.0.0:
     gitconfiglocal "^1.0.0"
     pify "^2.3.0"
 
-git-semver-tags@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-2.0.2.tgz#f506ec07caade191ac0c8d5a21bdb8131b4934e3"
-  integrity sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==
+git-semver-tags@^1.3.0, git-semver-tags@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-1.3.6.tgz#357ea01f7280794fe0927f2806bee6414d2caba5"
+  integrity sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==
   dependencies:
     meow "^4.0.0"
     semver "^5.5.0"
@@ -7414,21 +6781,6 @@ git-up@^2.0.0:
   dependencies:
     is-ssh "^1.3.0"
     parse-url "^3.0.2"
-
-git-up@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/git-up/-/git-up-4.0.1.tgz#cb2ef086653640e721d2042fe3104857d89007c0"
-  integrity sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==
-  dependencies:
-    is-ssh "^1.3.0"
-    parse-url "^5.0.0"
-
-git-url-parse@^11.1.2:
-  version "11.1.2"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.1.2.tgz#aff1a897c36cc93699270587bea3dbcbbb95de67"
-  integrity sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==
-  dependencies:
-    git-up "^4.0.0"
 
 git-url-parse@^8.1.0:
   version "8.3.1"
@@ -7572,23 +6924,39 @@ globby@8.0.2:
     pify "^3.0.0"
     slash "^1.0.0"
 
-globby@^8.0.1:
-  version "8.0.1"
-  resolved "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz#b5ad48b8aa80b35b814fc1281ecc851f1d2b5b50"
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  integrity sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=
   dependencies:
     array-union "^1.0.1"
-    dir-glob "^2.0.0"
-    fast-glob "^2.0.2"
-    glob "^7.1.2"
-    ignore "^3.3.5"
-    pify "^3.0.0"
-    slash "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 good-listener@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
   dependencies:
     delegate "^3.1.2"
+
+got@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
+  integrity sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=
+  dependencies:
+    create-error-class "^3.0.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    unzip-response "^2.0.1"
+    url-parse-lax "^1.0.0"
 
 got@^8.3.2:
   version "8.3.2"
@@ -7659,6 +7027,17 @@ handlebars@^4.0.0:
   optionalDependencies:
     uglify-js "^3.1.4"
 
+handlebars@^4.0.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
+  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+  dependencies:
+    neo-async "^2.6.0"
+    optimist "^0.6.1"
+    source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 handlebars@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.0.tgz#0d6a6f34ff1f63cecec8423aa4169827bf787c3a"
@@ -7711,7 +7090,7 @@ has-to-string-tag-x@^1.2.0:
   dependencies:
     has-symbol-support-x "^1.4.1"
 
-has-unicode@^2.0.0, has-unicode@^2.0.1:
+has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
@@ -7872,7 +7251,7 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
-hosted-git-info@^2.1.4, hosted-git-info@^2.6.0:
+hosted-git-info@^2.1.4, hosted-git-info@^2.5.0:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
@@ -7962,7 +7341,7 @@ htmlparser2@~3.3.0:
     domutils "1.1"
     readable-stream "1.0"
 
-http-cache-semantics@3.8.1, http-cache-semantics@^3.8.1:
+http-cache-semantics@3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
   integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
@@ -7980,14 +7359,6 @@ http-parser-js@>=0.4.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.0.tgz#d65edbede84349d0dc30320815a15d39cc3cbbd8"
 
-http-proxy-agent@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
-  integrity sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==
-  dependencies:
-    agent-base "4"
-    debug "3.1.0"
-
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -8000,28 +7371,13 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
-https-proxy-agent@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
-  integrity sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==
-  dependencies:
-    agent-base "^4.1.0"
-    debug "^3.1.0"
-
-humanize-ms@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
-  integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
-  dependencies:
-    ms "^2.0.0"
-
 iconv-lite@0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
@@ -8107,13 +7463,6 @@ import-from@^2.1.0:
   dependencies:
     resolve-from "^3.0.0"
 
-import-local@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
-  dependencies:
-    pkg-dir "^2.0.0"
-    resolve-cwd "^2.0.0"
-
 import-local@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"
@@ -8164,20 +7513,6 @@ ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
-init-package-json@^1.10.3:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/init-package-json/-/init-package-json-1.10.3.tgz#45ffe2f610a8ca134f2bd1db5637b235070f6cbe"
-  integrity sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==
-  dependencies:
-    glob "^7.1.1"
-    npm-package-arg "^4.0.0 || ^5.0.0 || ^6.0.0"
-    promzard "^0.3.0"
-    read "~1.0.1"
-    read-package-json "1 || 2"
-    semver "2.x || 3.x || 4 || 5"
-    validate-npm-package-license "^3.0.1"
-    validate-npm-package-name "^3.0.0"
-
 inquirer@6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.1.tgz#9943fc4882161bdb0b0c9276769c75b32dbfcd52"
@@ -8213,6 +7548,26 @@ inquirer@^0.11.0:
     rx-lite "^3.1.2"
     string-width "^1.0.1"
     strip-ansi "^3.0.0"
+    through "^2.3.6"
+
+inquirer@^3.2.2:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  integrity sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
     through "^2.3.6"
 
 inquirer@^6.2.0:
@@ -8512,6 +7867,11 @@ is-property@^1.0.0, is-property@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
+is-redirect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+  integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
+
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
@@ -8522,7 +7882,7 @@ is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
-is-retry-allowed@^1.1.0:
+is-retry-allowed@^1.0.0, is-retry-allowed@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
   integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
@@ -8537,7 +7897,7 @@ is-ssh@^1.3.0:
   dependencies:
     protocols "^1.1.0"
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -9238,7 +8598,7 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
-json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
+json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
 
@@ -9419,28 +8779,50 @@ left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
 
-lerna@~3.13.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.13.1.tgz#feaff562176f304bd82329ca29ce46ab6c033463"
-  integrity sha512-7kSz8LLozVsoUNTJzJzy+b8TnV9YdviR2Ee2PwGZSlVw3T1Rn7kOAPZjEi+3IWnOPC96zMPHVmjCmzQ4uubalw==
+lerna@2.11:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.11.0.tgz#89b5681e286d388dda5bbbdbbf6b84c8094eff65"
+  integrity sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==
   dependencies:
-    "@lerna/add" "3.13.1"
-    "@lerna/bootstrap" "3.13.1"
-    "@lerna/changed" "3.13.1"
-    "@lerna/clean" "3.13.1"
-    "@lerna/cli" "3.13.0"
-    "@lerna/create" "3.13.1"
-    "@lerna/diff" "3.13.1"
-    "@lerna/exec" "3.13.1"
-    "@lerna/import" "3.13.1"
-    "@lerna/init" "3.13.1"
-    "@lerna/link" "3.13.1"
-    "@lerna/list" "3.13.1"
-    "@lerna/publish" "3.13.1"
-    "@lerna/run" "3.13.1"
-    "@lerna/version" "3.13.1"
-    import-local "^1.0.0"
+    async "^1.5.0"
+    chalk "^2.1.0"
+    cmd-shim "^2.0.2"
+    columnify "^1.5.4"
+    command-join "^2.0.0"
+    conventional-changelog-cli "^1.3.13"
+    conventional-recommended-bump "^1.2.1"
+    dedent "^0.7.0"
+    execa "^0.8.0"
+    find-up "^2.1.0"
+    fs-extra "^4.0.1"
+    get-port "^3.2.0"
+    glob "^7.1.2"
+    glob-parent "^3.1.0"
+    globby "^6.1.0"
+    graceful-fs "^4.1.11"
+    hosted-git-info "^2.5.0"
+    inquirer "^3.2.2"
+    is-ci "^1.0.10"
+    load-json-file "^4.0.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
     npmlog "^4.1.2"
+    p-finally "^1.0.0"
+    package-json "^4.0.1"
+    path-exists "^3.0.0"
+    read-cmd-shim "^1.0.1"
+    read-pkg "^3.0.0"
+    rimraf "^2.6.1"
+    safe-buffer "^5.1.1"
+    semver "^5.4.1"
+    signal-exit "^3.0.2"
+    slash "^1.0.0"
+    strong-log-transformer "^1.0.6"
+    temp-write "^3.3.0"
+    write-file-atomic "^2.3.0"
+    write-json-file "^2.2.0"
+    write-pkg "^3.1.0"
+    yargs "^8.0.2"
 
 leven@^2.1.0:
   version "2.1.0"
@@ -9459,31 +8841,6 @@ levn@~0.2.5:
   dependencies:
     prelude-ls "~1.1.0"
     type-check "~0.3.1"
-
-libnpmaccess@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-3.0.1.tgz#5b3a9de621f293d425191aa2e779102f84167fa8"
-  integrity sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==
-  dependencies:
-    aproba "^2.0.0"
-    get-stream "^4.0.0"
-    npm-package-arg "^6.1.0"
-    npm-registry-fetch "^3.8.0"
-
-libnpmpublish@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/libnpmpublish/-/libnpmpublish-1.1.1.tgz#ff0c6bb0b4ad2bda2ad1f5fba6760a4af37125f0"
-  integrity sha512-nefbvJd/wY38zdt+b9SHL6171vqBrMtZ56Gsgfd0duEKb/pB8rDT4/ObUQLrHz1tOfht1flt2zM+UGaemzAG5g==
-  dependencies:
-    aproba "^2.0.0"
-    figgy-pudding "^3.5.1"
-    get-stream "^4.0.0"
-    lodash.clonedeep "^4.5.0"
-    normalize-package-data "^2.4.0"
-    npm-package-arg "^6.1.0"
-    npm-registry-fetch "^3.8.0"
-    semver "^5.5.1"
-    ssri "^6.0.1"
 
 load-bmfont@^1.3.1, load-bmfont@^1.4.0:
   version "1.4.0"
@@ -9681,11 +9038,6 @@ lodash.clonedeep@^3.0.1:
     lodash._baseclone "^3.0.0"
     lodash._bindcallback "^3.0.0"
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
-
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -9792,11 +9144,6 @@ lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
-
 lodash.snakecase@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
@@ -9838,16 +9185,11 @@ lodash.toplainobject@^3.0.0:
     lodash._basecopy "^3.0.0"
     lodash.keysin "^3.0.0"
 
-lodash.uniq@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
-  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
-
 lodash.upperfirst@4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
 
-lodash@>4.17.4, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
+lodash@>4.17.4, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -9910,25 +9252,13 @@ lru-cache@^4.0.1, lru-cache@^4.1.3:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lru-cache@^4.1.2, lru-cache@^4.1.5:
+lru-cache@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
-
-lru-cache@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
-  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
-  dependencies:
-    yallist "^3.0.2"
-
-macos-release@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.1.0.tgz#c87935891fbeb0dba7537913fc66f469fee9d662"
-  integrity sha512-8TCbwvN1mfNxbBv0yBtfyIFMo3m1QsNbKHv7PYIp/abRBKVQBXN7ecu3aeGGgT18VC/Tf397LBDGZF9KBGJFFw==
 
 make-dir@^1.0.0, make-dir@^1.3.0:
   version "1.3.0"
@@ -9939,23 +9269,6 @@ make-dir@^1.0.0, make-dir@^1.3.0:
 make-error@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
-
-make-fetch-happen@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz#141497cb878f243ba93136c83d8aba12c216c083"
-  integrity sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==
-  dependencies:
-    agentkeepalive "^3.4.1"
-    cacache "^11.0.1"
-    http-cache-semantics "^3.8.1"
-    http-proxy-agent "^2.1.0"
-    https-proxy-agent "^2.2.1"
-    lru-cache "^4.1.2"
-    mississippi "^3.0.0"
-    node-fetch-npm "^2.0.2"
-    promise-retry "^1.1.1"
-    socks-proxy-agent "^4.0.0"
-    ssri "^6.0.0"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -10242,6 +9555,11 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
+minimist@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
+  integrity sha1-md9lelJXTCHJBXSX33QnkLK0wN4=
+
 minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
@@ -10250,7 +9568,7 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-minipass@^2.2.1, minipass@^2.3.4, minipass@^2.3.5:
+minipass@^2.2.1, minipass@^2.3.4:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
   dependencies:
@@ -10326,7 +9644,7 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
 
-moment@^2.18.1:
+moment@^2.18.1, moment@^2.6.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
@@ -10350,7 +9668,7 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-ms@2.1.1, ms@^2.0.0, ms@^2.1.1:
+ms@2.1.1, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
@@ -10359,16 +9677,6 @@ multi-input-input@0.0.3:
   resolved "https://registry.yarnpkg.com/multi-input-input/-/multi-input-input-0.0.3.tgz#7e23f9d12bd0d7101c7d1658bc460cee9626c4e8"
   integrity sha512-jzpCxDqvyi7eqdgPykDlv11y1CWOS02T+oaSrLlzVeG3mSrQbNi75/QWsWkrgwxvWWvAkq+e0Pk59uN1YaYGLg==
 
-multimatch@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
-  integrity sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=
-  dependencies:
-    array-differ "^1.0.0"
-    array-union "^1.0.1"
-    arrify "^1.0.0"
-    minimatch "^3.0.0"
-
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
@@ -10376,11 +9684,6 @@ mute-stream@0.0.5:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
-
-mute-stream@~0.0.4:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
-  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 nan@^2.6.2, nan@^2.9.2:
   version "2.11.1"
@@ -10432,6 +9735,11 @@ neo-async@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
 
+neo-async@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
+  integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
+
 next-tick@1:
   version "1.0.0"
   resolved "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
@@ -10481,15 +9789,6 @@ node-emoji@1.10.0:
   dependencies:
     lodash.toarray "^4.4.0"
 
-node-fetch-npm@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz#7258c9046182dca345b4208eda918daf33697ff7"
-  integrity sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==
-  dependencies:
-    encoding "^0.1.11"
-    json-parse-better-errors "^1.0.0"
-    safe-buffer "^5.1.1"
-
 node-fetch@1.7.3, node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -10497,11 +9796,11 @@ node-fetch@1.7.3, node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.2.0, node-fetch@^2.3.0:
+node-fetch@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
 
-node-gyp@^3.6.2, node-gyp@^3.8.0:
+node-gyp@^3.6.2:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
   dependencies:
@@ -10637,16 +9936,6 @@ nopt@~1.0.10:
   dependencies:
     abbrev "1"
 
-normalize-package-data@^2.0.0, normalize-package-data@^2.4.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
-  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
-  dependencies:
-    hosted-git-info "^2.1.4"
-    resolve "^1.10.0"
-    semver "2 || 3 || 4 || 5"
-    validate-npm-package-license "^3.0.1"
-
 normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
@@ -10690,11 +9979,6 @@ normalize-url@^1.9.1:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
-normalize-url@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
-  integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
-
 normalize.css@^8.0.0:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
@@ -10704,65 +9988,12 @@ npm-bundled@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
 
-npm-lifecycle@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/npm-lifecycle/-/npm-lifecycle-2.1.0.tgz#1eda2eedb82db929e3a0c50341ab0aad140ed569"
-  integrity sha512-QbBfLlGBKsktwBZLj6AviHC6Q9Y3R/AY4a2PYSIRhSKSS0/CxRyD/PfxEX6tPeOCXQgMSNdwGeECacstgptc+g==
-  dependencies:
-    byline "^5.0.0"
-    graceful-fs "^4.1.11"
-    node-gyp "^3.8.0"
-    resolve-from "^4.0.0"
-    slide "^1.1.6"
-    uid-number "0.0.6"
-    umask "^1.1.0"
-    which "^1.3.1"
-
-"npm-package-arg@^4.0.0 || ^5.0.0 || ^6.0.0", npm-package-arg@^6.0.0, npm-package-arg@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-6.1.0.tgz#15ae1e2758a5027efb4c250554b85a737db7fcc1"
-  integrity sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==
-  dependencies:
-    hosted-git-info "^2.6.0"
-    osenv "^0.1.5"
-    semver "^5.5.0"
-    validate-npm-package-name "^3.0.0"
-
-npm-packlist@^1.1.12, npm-packlist@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.1.tgz#19064cdf988da80ea3cee45533879d90192bbfbc"
-  integrity sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-
 npm-packlist@^1.1.6:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.12.tgz#22bde2ebc12e72ca482abd67afc51eb49377243a"
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
-
-npm-pick-manifest@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz#32111d2a9562638bb2c8f2bf27f7f3092c8fae40"
-  integrity sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==
-  dependencies:
-    figgy-pudding "^3.5.1"
-    npm-package-arg "^6.0.0"
-    semver "^5.4.1"
-
-npm-registry-fetch@^3.8.0, npm-registry-fetch@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-3.9.0.tgz#44d841780e2833f06accb34488f8c7450d1a6856"
-  integrity sha512-srwmt8YhNajAoSAaDWndmZgx89lJwIZ1GWxOuckH4Coek4uHv5S+o/l9FLQe/awA+JwTnj4FJHldxhlXdZEBmw==
-  dependencies:
-    JSONStream "^1.3.4"
-    bluebird "^3.5.1"
-    figgy-pudding "^3.4.1"
-    lru-cache "^4.1.3"
-    make-fetch-happen "^4.0.1"
-    npm-package-arg "^6.1.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -10897,11 +10128,6 @@ object.values@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-octokit-pagination-methods@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
-  integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
-
 omggif@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/omggif/-/omggif-1.0.9.tgz#dcb7024dacd50c52b4d303f04802c91c057c765f"
@@ -11009,19 +10235,11 @@ os-locale@^3.0.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-name@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/os-name/-/os-name-3.0.0.tgz#e1434dbfddb8e74b44c98b56797d951b7648a5d9"
-  integrity sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==
-  dependencies:
-    macos-release "^2.0.0"
-    windows-release "^3.1.0"
-
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
-osenv@0, osenv@^0.1.4, osenv@^0.1.5:
+osenv@0, osenv@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   dependencies:
@@ -11090,23 +10308,6 @@ p-locate@^3.0.0:
   dependencies:
     p-limit "^2.0.0"
 
-p-map-series@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-map-series/-/p-map-series-1.0.0.tgz#bf98fe575705658a9e1351befb85ae4c1f07bdca"
-  integrity sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=
-  dependencies:
-    p-reduce "^1.0.0"
-
-p-map@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
-  integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
-
-p-pipe@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/p-pipe/-/p-pipe-1.2.0.tgz#4b1a11399a11520a67790ee5a0c1d5881d6befe9"
-  integrity sha1-SxoROZoRUgpneQ7loMHViB1r7+k=
-
 p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
@@ -11126,45 +10327,15 @@ p-try@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
-p-waterfall@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-waterfall/-/p-waterfall-1.0.0.tgz#7ed94b3ceb3332782353af6aae11aa9fc235bb00"
-  integrity sha1-ftlLPOszMngjU69qrhGqn8I1uwA=
+package-json@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
+  integrity sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=
   dependencies:
-    p-reduce "^1.0.0"
-
-pacote@^9.5.0:
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/pacote/-/pacote-9.5.0.tgz#85f3013a3f6dd51c108b0ccabd3de8102ddfaeda"
-  integrity sha512-aUplXozRbzhaJO48FaaeClmN+2Mwt741MC6M3bevIGZwdCaP7frXzbUOfOWa91FPHoLITzG0hYaKY363lxO3bg==
-  dependencies:
-    bluebird "^3.5.3"
-    cacache "^11.3.2"
-    figgy-pudding "^3.5.1"
-    get-stream "^4.1.0"
-    glob "^7.1.3"
-    lru-cache "^5.1.1"
-    make-fetch-happen "^4.0.1"
-    minimatch "^3.0.4"
-    minipass "^2.3.5"
-    mississippi "^3.0.0"
-    mkdirp "^0.5.1"
-    normalize-package-data "^2.4.0"
-    npm-package-arg "^6.1.0"
-    npm-packlist "^1.1.12"
-    npm-pick-manifest "^2.2.3"
-    npm-registry-fetch "^3.8.0"
-    osenv "^0.1.5"
-    promise-inflight "^1.0.1"
-    promise-retry "^1.1.1"
-    protoduck "^5.0.1"
-    rimraf "^2.6.2"
-    safe-buffer "^5.1.2"
-    semver "^5.6.0"
-    ssri "^6.0.1"
-    tar "^4.4.8"
-    unique-filename "^1.1.1"
-    which "^1.3.1"
+    got "^6.7.1"
+    registry-auth-token "^3.0.1"
+    registry-url "^3.0.3"
+    semver "^5.1.0"
 
 pako@^1.0.5:
   version "1.0.10"
@@ -11294,14 +10465,6 @@ parse-path@^3.0.1:
     is-ssh "^1.3.0"
     protocols "^1.4.0"
 
-parse-path@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-4.0.1.tgz#0ec769704949778cb3b8eda5e994c32073a1adff"
-  integrity sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==
-  dependencies:
-    is-ssh "^1.3.0"
-    protocols "^1.4.0"
-
 parse-repo@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/parse-repo/-/parse-repo-1.0.4.tgz#74b91d2cb8675d11b99976a0065f6ce17fa1bcc8"
@@ -11315,16 +10478,6 @@ parse-url@^3.0.2:
     is-ssh "^1.3.0"
     normalize-url "^1.9.1"
     parse-path "^3.0.1"
-    protocols "^1.4.0"
-
-parse-url@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-5.0.1.tgz#99c4084fc11be14141efa41b3d117a96fcb9527f"
-  integrity sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==
-  dependencies:
-    is-ssh "^1.3.0"
-    normalize-url "^3.3.0"
-    parse-path "^4.0.0"
     protocols "^1.4.0"
 
 parse5@4.0.0:
@@ -11640,7 +10793,7 @@ prelude-ls@~1.1.0, prelude-ls@~1.1.1, prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
-prepend-http@^1.0.0:
+prepend-http@^1.0.0, prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
@@ -11734,14 +10887,6 @@ promise-polyfill@^6.0.1:
   resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
   integrity sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=
 
-promise-retry@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-1.1.1.tgz#6739e968e3051da20ce6497fb2b50f6911df3d6d"
-  integrity sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=
-  dependencies:
-    err-code "^1.0.0"
-    retry "^0.10.0"
-
 promise.prototype.finally@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz#66f161b1643636e50e7cf201dc1b84a857f3864e"
@@ -11763,13 +10908,6 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
-
-promzard@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/promzard/-/promzard-0.3.0.tgz#26a5d6ee8c7dee4cb12208305acfb93ba382a9ee"
-  integrity sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=
-  dependencies:
-    read "1"
 
 prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
@@ -11793,13 +10931,6 @@ proto-list@~1.2.1:
 protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.6"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.6.tgz#f8bb263ea1b5fd7a7604d26b8be39bd77678bf8a"
-
-protoduck@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/protoduck/-/protoduck-5.0.1.tgz#03c3659ca18007b69a50fd82a7ebcc516261151f"
-  integrity sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==
-  dependencies:
-    genfun "^5.0.0"
 
 proxy-addr@~2.0.4:
   version "2.0.4"
@@ -11872,7 +11003,7 @@ punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-q@^1.1.2, q@^1.5.1:
+q@^1.1.2, q@^1.4.1, q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
@@ -11974,7 +11105,7 @@ raw-loader@^1.0.0:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
-rc@^1.1.6, rc@^1.2.7:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   dependencies:
@@ -12348,29 +11479,6 @@ read-cmd-shim@^1.0.1:
   dependencies:
     graceful-fs "^4.1.2"
 
-"read-package-json@1 || 2", read-package-json@^2.0.0, read-package-json@^2.0.13:
-  version "2.0.13"
-  resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-2.0.13.tgz#2e82ebd9f613baa6d2ebe3aa72cefe3f68e41f4a"
-  integrity sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==
-  dependencies:
-    glob "^7.1.1"
-    json-parse-better-errors "^1.0.1"
-    normalize-package-data "^2.0.0"
-    slash "^1.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.2"
-
-read-package-tree@^5.1.6:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/read-package-tree/-/read-package-tree-5.2.2.tgz#4b6a0ef2d943c1ea36a578214c9a7f6b7424f7a8"
-  integrity sha512-rW3XWUUkhdKmN2JKB4FL563YAgtINifso5KShykufR03nJ5loGFlkUMe1g/yxmqX073SoYYTsgXu7XdDinKZuA==
-  dependencies:
-    debuglog "^1.0.1"
-    dezalgo "^1.0.0"
-    once "^1.3.0"
-    read-package-json "^2.0.0"
-    readdir-scoped-modules "^1.0.0"
-
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -12400,7 +11508,7 @@ read-pkg-up@^4.0.0:
     find-up "^3.0.0"
     read-pkg "^3.0.0"
 
-read-pkg@^1.0.0:
+read-pkg@^1.0.0, read-pkg@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
   dependencies:
@@ -12423,13 +11531,6 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
-
-read@1, read@~1.0.1:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
-  integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
-  dependencies:
-    mute-stream "~0.0.4"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
@@ -12468,16 +11569,6 @@ readable-stream@^3.1.1:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
-
-readdir-scoped-modules@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
-  integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=
-  dependencies:
-    debuglog "^1.0.1"
-    dezalgo "^1.0.0"
-    graceful-fs "^4.1.2"
-    once "^1.3.0"
 
 readdirp@^2.0.0:
   version "2.2.1"
@@ -12675,6 +11766,21 @@ regexpu-core@^4.5.4:
     regjsparser "^0.6.0"
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.1.0"
+
+registry-auth-token@^3.0.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.4.0.tgz#d7446815433f5d5ed6431cd5dca21048f66b397e"
+  integrity sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==
+  dependencies:
+    rc "^1.1.6"
+    safe-buffer "^5.0.1"
+
+registry-url@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
+  integrity sha1-PU74cPc93h138M+aOBQyRE4XSUI=
+  dependencies:
+    rc "^1.0.1"
 
 regjsgen@^0.4.0:
   version "0.4.0"
@@ -12908,11 +12014,6 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
-retry@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
-  integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
-
 rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
@@ -12961,6 +12062,18 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
   dependencies:
     aproba "^1.1.1"
+
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  integrity sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+  integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
 rx-lite@^3.1.2:
   version "3.1.2"
@@ -13063,9 +12176,14 @@ select@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+
+semver@^5.1.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 semver@~5.3.0:
   version "5.3.0"
@@ -13254,16 +12372,6 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-slide@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
-  integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
-
-smart-buffer@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.0.2.tgz#5207858c3815cc69110703c6b94e46c15634395d"
-  integrity sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==
-
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -13302,22 +12410,6 @@ sockjs-client@1.3.0:
     inherits "^2.0.3"
     json3 "^3.3.2"
     url-parse "^1.4.3"
-
-socks-proxy-agent@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz#3c8991f3145b2799e70e11bd5fbc8b1963116386"
-  integrity sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==
-  dependencies:
-    agent-base "~4.2.1"
-    socks "~2.3.2"
-
-socks@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.3.2.tgz#ade388e9e6d87fdb11649c15746c578922a5883e"
-  integrity sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==
-  dependencies:
-    ip "^1.1.5"
-    smart-buffer "4.0.2"
 
 sort-keys@^1.0.0:
   version "1.1.2"
@@ -13450,7 +12542,7 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-ssri@^6.0.0, ssri@^6.0.1:
+ssri@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
   dependencies:
@@ -13707,13 +12799,15 @@ strip-json-comments@~1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
 
-strong-log-transformer@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz#0f5ed78d325e0421ac6f90f7f10e691d6ae3ae10"
-  integrity sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==
+strong-log-transformer@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz#f7fb93758a69a571140181277eea0c2eb1301fa3"
+  integrity sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=
   dependencies:
+    byline "^5.0.0"
     duplexer "^0.1.1"
-    minimist "^1.2.0"
+    minimist "^0.1.0"
+    moment "^2.6.0"
     through "^2.3.4"
 
 style-loader@^0.23.1:
@@ -13863,7 +12957,7 @@ tar@^2.0.0:
     fstream "^1.0.2"
     inherits "2"
 
-tar@^4, tar@^4.4.8:
+tar@^4:
   version "4.4.8"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
   dependencies:
@@ -13893,7 +12987,7 @@ temp-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
 
-temp-write@^3.4.0:
+temp-write@^3.3.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/temp-write/-/temp-write-3.4.0.tgz#8cff630fb7e9da05f047c74ce4ce4d685457d492"
   integrity sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=
@@ -13904,6 +12998,14 @@ temp-write@^3.4.0:
     pify "^3.0.0"
     temp-dir "^1.0.0"
     uuid "^3.0.1"
+
+tempfile@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tempfile/-/tempfile-1.1.1.tgz#5bcc4eaecc4ab2c707d8bc11d99ccc9a2cb287f2"
+  integrity sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=
+  dependencies:
+    os-tmpdir "^1.0.0"
+    uuid "^2.0.1"
 
 term-size@^1.2.0:
   version "1.2.0"
@@ -13988,7 +13090,7 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3.6:
   version "2.3.8"
   resolved "http://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-timed-out@^4.0.1:
+timed-out@^4.0.0, timed-out@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
@@ -14185,16 +13287,6 @@ uglify-js@3.4.x, uglify-js@^3.1.4:
     commander "~2.17.1"
     source-map "~0.6.1"
 
-uid-number@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
-  integrity sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=
-
-umask@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
-  integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
-
 underscore@~1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
@@ -14269,7 +13361,7 @@ uniq@^1.0.1:
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
   integrity sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=
 
-unique-filename@^1.1.0, unique-filename@^1.1.1:
+unique-filename@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
   dependencies:
@@ -14311,13 +13403,6 @@ unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
   dependencies:
     unist-util-visit-parents "^2.0.0"
 
-universal-user-agent@^2.0.0, universal-user-agent@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-2.0.3.tgz#9f6f09f9cc33de867bb720d84c08069b14937c6c"
-  integrity sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==
-  dependencies:
-    os-name "^3.0.0"
-
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -14337,6 +13422,11 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+unzip-response@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
+  integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
 
 upath@^1.0.5:
   version "1.1.0"
@@ -14364,6 +13454,13 @@ url-loader@^1.1.2:
     mime "^2.0.3"
     schema-utils "^1.0.0"
 
+url-parse-lax@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
+  integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
+  dependencies:
+    prepend-http "^1.0.1"
+
 url-parse-lax@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
@@ -14377,11 +13474,6 @@ url-parse@^1.4.3:
   dependencies:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
-
-url-template@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
-  integrity sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
 
 url-to-options@^1.0.1:
   version "1.0.1"
@@ -14443,6 +13535,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
+uuid@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
+  integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
+
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
@@ -14458,7 +13555,7 @@ v8flags@^3.1.1:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3:
+validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   dependencies:
@@ -14737,13 +13834,6 @@ widest-line@^2.0.0:
   dependencies:
     string-width "^2.1.1"
 
-windows-release@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-3.1.0.tgz#8d4a7e266cbf5a233f6c717dac19ce00af36e12e"
-  integrity sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==
-  dependencies:
-    execa "^0.10.0"
-
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
@@ -14786,7 +13876,7 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-write-json-file@^2.2.0, write-json-file@^2.3.0:
+write-json-file@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/write-json-file/-/write-json-file-2.3.0.tgz#2b64c8a33004d54b8698c76d585a77ceb61da32f"
   dependencies:
@@ -14899,6 +13989,13 @@ yargs-parser@^4.2.0:
   dependencies:
     camelcase "^3.0.0"
 
+yargs-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
+  integrity sha1-jQrELxbqVd69MyyvTEA4s+P139k=
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs-parser@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
@@ -14943,7 +14040,7 @@ yargs@^11.0.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
-yargs@^12.0.1, yargs@^12.0.2, yargs@^12.0.5:
+yargs@^12.0.2, yargs@^12.0.5:
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
   integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
@@ -14960,3 +14057,22 @@ yargs@^12.0.1, yargs@^12.0.2, yargs@^12.0.5:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+  integrity sha1-YpmpBVsc78lp/355wdkY3Osiw2A=
+  dependencies:
+    camelcase "^4.1.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^7.0.0"


### PR DESCRIPTION
- Fixed an incorrect type for `listColumns` which was shown and used in documentation causing a propType error in the console.
- Changed `<FooterLink>` to use `<LinkDocumented>` from `<Link>`.  This was causing issues with noVisitedState and textColour props getting passed down to the rendered dom element.
- `yarn.lock` also updated from previous commit related to the lerna version change in `package.json`
- Set Footer section headings to be a `h2`.  Not specified at the moment so are defaulting to `h1`.
- Added OGL Link to License information
- Fixed responsive issue with Meta content wrapping too soon.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
