### PR TITLE
Updated govuk-colours to 1.1.0 and updated snapshot tests

### DIFF
--- a/components/back-link/package.json
+++ b/components/back-link/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/back-link/package.json
+++ b/components/back-link/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-   "govuk-colours": "^1.1.0"
+    "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/back-link/src/__snapshots__/test.js.snap
+++ b/components/back-link/src/__snapshots__/test.js.snap
@@ -22,9 +22,9 @@ exports[`Back Link matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c0:link,
@@ -108,7 +108,7 @@ exports[`Back Link matches wrapper snapshot: wrapper mount 1`] = `
   font-family: sans-serif;
 }",
               "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
               "&:link, &:visited, &:hover, &:active, &:focus {
   color: #0b0c0c; @media print {

--- a/components/breadcrumb/package.json
+++ b/components/breadcrumb/package.json
@@ -5,7 +5,7 @@
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/hoc": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/breadcrumbs/package.json
+++ b/components/breadcrumbs/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/breadcrumbs/src/__snapshots__/test.js.snap
+++ b/components/breadcrumbs/src/__snapshots__/test.js.snap
@@ -16,9 +16,9 @@ exports[`breadcrumbs matches snapshot: breadcrumbs 1`] = `
 }
 
 .c3:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c0 {
@@ -239,7 +239,7 @@ exports[`breadcrumbs matches snapshot: breadcrumbs 1`] = `
 }
 }",
                                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                               ],
                             },
@@ -326,7 +326,7 @@ exports[`breadcrumbs matches snapshot: breadcrumbs 1`] = `
 }
 }",
                                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                               ],
                             },

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -5,7 +5,7 @@
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/icons": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-   "govuk-colours": "^1.1.0",
+    "govuk-colours": "^1.1.0",
     "polished": "^3.0.3"
   },
   "peerDependencies": {

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -5,7 +5,7 @@
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/icons": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3",
+   "govuk-colours": "^1.1.0",
     "polished": "^3.0.3"
   },
   "peerDependencies": {

--- a/components/button/src/__snapshots__/test.js.snap
+++ b/components/button/src/__snapshots__/test.js.snap
@@ -17,8 +17,8 @@ exports[`button basics matches snapshot 1`] = `
   border: 2px solid transparent;
   border-radius: 0;
   color: #ffffff;
-  background-color: #00823b;
-  box-shadow: 0 2px 0 #003618;
+  background-color: #00703c;
+  box-shadow: 0 2px 0 #002413;
   text-align: center;
   vertical-align: top;
   cursor: pointer;
@@ -27,7 +27,7 @@ exports[`button basics matches snapshot 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -47,7 +47,7 @@ exports[`button basics matches snapshot 1`] = `
 
 .c0:hover,
 .c0:focus {
-  background-color: #00692f;
+  background-color: #00572e;
 }
 
 .c0:active {
@@ -72,11 +72,11 @@ exports[`button basics matches snapshot 1`] = `
 
 .c0:disabled {
   opacity: 0.5;
-  background: #00823b;
+  background: #00703c;
 }
 
 .c0:disabled:hover {
-  background-color: #00823b;
+  background-color: #00703c;
   cursor: default;
 }
 
@@ -86,7 +86,7 @@ exports[`button basics matches snapshot 1`] = `
 
 .c0:disabled:active {
   top: 0;
-  box-shadow: 0 2px 0 #003618;
+  box-shadow: 0 2px 0 #002413;
 }
 
 .c0 svg {
@@ -146,7 +146,7 @@ exports[`button basics matches snapshot 1`] = `
             "rules": Array [
               [Function],
               "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
               [Function],
               [Function],
@@ -194,8 +194,8 @@ exports[`button blue button, with automatic colours matches snapshot 1`] = `
   border: 2px solid transparent;
   border-radius: 0;
   color: #ffffff;
-  background-color: #005ea5;
-  box-shadow: 0 2px 0 #003259;
+  background-color: #1d70b8;
+  box-shadow: 0 2px 0 #134876;
   text-align: center;
   vertical-align: top;
   cursor: pointer;
@@ -204,7 +204,7 @@ exports[`button blue button, with automatic colours matches snapshot 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -224,7 +224,7 @@ exports[`button blue button, with automatic colours matches snapshot 1`] = `
 
 .c0:hover,
 .c0:focus {
-  background-color: #004f8c;
+  background-color: #1a63a2;
 }
 
 .c0:active {
@@ -249,11 +249,11 @@ exports[`button blue button, with automatic colours matches snapshot 1`] = `
 
 .c0:disabled {
   opacity: 0.5;
-  background: #005ea5;
+  background: #1d70b8;
 }
 
 .c0:disabled:hover {
-  background-color: #005ea5;
+  background-color: #1d70b8;
   cursor: default;
 }
 
@@ -263,7 +263,7 @@ exports[`button blue button, with automatic colours matches snapshot 1`] = `
 
 .c0:disabled:active {
   top: 0;
-  box-shadow: 0 2px 0 #003259;
+  box-shadow: 0 2px 0 #134876;
 }
 
 .c0 svg {
@@ -304,17 +304,17 @@ exports[`button blue button, with automatic colours matches snapshot 1`] = `
 
 <ButtonBlue>
   <ForwardRef
-    buttonColour="#005ea5"
+    buttonColour="#1d70b8"
     disabled={false}
     start={false}
   >
     <styled.button
-      buttonColour="#005ea5"
+      buttonColour="#1d70b8"
       disabled={false}
       isStart={false}
     >
       <StyledComponent
-        buttonColour="#005ea5"
+        buttonColour="#1d70b8"
         disabled={false}
         forwardedComponent={
           Object {
@@ -327,7 +327,7 @@ exports[`button blue button, with automatic colours matches snapshot 1`] = `
               "rules": Array [
                 [Function],
                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                 [Function],
                 [Function],
@@ -376,8 +376,8 @@ exports[`button button with icon matches snapshot 1`] = `
   border: 2px solid transparent;
   border-radius: 0;
   color: #ffffff;
-  background-color: #00823b;
-  box-shadow: 0 2px 0 #003618;
+  background-color: #00703c;
+  box-shadow: 0 2px 0 #002413;
   text-align: center;
   vertical-align: top;
   cursor: pointer;
@@ -398,7 +398,7 @@ exports[`button button with icon matches snapshot 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -418,7 +418,7 @@ exports[`button button with icon matches snapshot 1`] = `
 
 .c0:hover,
 .c0:focus {
-  background-color: #00692f;
+  background-color: #00572e;
 }
 
 .c0:active {
@@ -443,11 +443,11 @@ exports[`button button with icon matches snapshot 1`] = `
 
 .c0:disabled {
   opacity: 0.5;
-  background: #00823b;
+  background: #00703c;
 }
 
 .c0:disabled:hover {
-  background-color: #00823b;
+  background-color: #00703c;
   cursor: default;
 }
 
@@ -457,7 +457,7 @@ exports[`button button with icon matches snapshot 1`] = `
 
 .c0:disabled:active {
   top: 0;
-  box-shadow: 0 2px 0 #003618;
+  box-shadow: 0 2px 0 #002413;
 }
 
 .c0 svg {
@@ -537,7 +537,7 @@ exports[`button button with icon matches snapshot 1`] = `
               "rules": Array [
                 [Function],
                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                 [Function],
                 [Function],
@@ -660,7 +660,7 @@ exports[`button custom colours matches snapshot 1`] = `
   border: 2px solid transparent;
   border-radius: 0;
   color: #0b0c0c;
-  background-color: #dee0e2;
+  background-color: #f3f2f1;
   box-shadow: 0 2px 0 #f47738;
   text-align: center;
   vertical-align: top;
@@ -670,7 +670,7 @@ exports[`button custom colours matches snapshot 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -690,7 +690,7 @@ exports[`button custom colours matches snapshot 1`] = `
 
 .c0:hover,
 .c0:focus {
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c0:active {
@@ -715,11 +715,11 @@ exports[`button custom colours matches snapshot 1`] = `
 
 .c0:disabled {
   opacity: 0.5;
-  background: #dee0e2;
+  background: #f3f2f1;
 }
 
 .c0:disabled:hover {
-  background-color: #dee0e2;
+  background-color: #f3f2f1;
   cursor: default;
 }
 
@@ -770,24 +770,24 @@ exports[`button custom colours matches snapshot 1`] = `
 
 <ButtonWacky>
   <ForwardRef
-    buttonColour="#dee0e2"
-    buttonHoverColour="#ffbf47"
+    buttonColour="#f3f2f1"
+    buttonHoverColour="#ffdd00"
     buttonShadowColour="#f47738"
     buttonTextColour="#0b0c0c"
     disabled={false}
     start={false}
   >
     <styled.button
-      buttonColour="#dee0e2"
-      buttonHoverColour="#ffbf47"
+      buttonColour="#f3f2f1"
+      buttonHoverColour="#ffdd00"
       buttonShadowColour="#f47738"
       buttonTextColour="#0b0c0c"
       disabled={false}
       isStart={false}
     >
       <StyledComponent
-        buttonColour="#dee0e2"
-        buttonHoverColour="#ffbf47"
+        buttonColour="#f3f2f1"
+        buttonHoverColour="#ffdd00"
         buttonShadowColour="#f47738"
         buttonTextColour="#0b0c0c"
         disabled={false}
@@ -802,7 +802,7 @@ exports[`button custom colours matches snapshot 1`] = `
               "rules": Array [
                 [Function],
                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                 [Function],
                 [Function],
@@ -851,8 +851,8 @@ exports[`button disabled matches snapshot 1`] = `
   border: 2px solid transparent;
   border-radius: 0;
   color: #ffffff;
-  background-color: #00823b;
-  box-shadow: 0 2px 0 #003618;
+  background-color: #00703c;
+  box-shadow: 0 2px 0 #002413;
   text-align: center;
   vertical-align: top;
   cursor: pointer;
@@ -861,7 +861,7 @@ exports[`button disabled matches snapshot 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -881,7 +881,7 @@ exports[`button disabled matches snapshot 1`] = `
 
 .c0:hover,
 .c0:focus {
-  background-color: #00692f;
+  background-color: #00572e;
 }
 
 .c0:active {
@@ -906,11 +906,11 @@ exports[`button disabled matches snapshot 1`] = `
 
 .c0:disabled {
   opacity: 0.5;
-  background: #00823b;
+  background: #00703c;
 }
 
 .c0:disabled:hover {
-  background-color: #00823b;
+  background-color: #00703c;
   cursor: default;
 }
 
@@ -920,7 +920,7 @@ exports[`button disabled matches snapshot 1`] = `
 
 .c0:disabled:active {
   top: 0;
-  box-shadow: 0 2px 0 #003618;
+  box-shadow: 0 2px 0 #002413;
 }
 
 .c0 svg {
@@ -981,7 +981,7 @@ exports[`button disabled matches snapshot 1`] = `
               "rules": Array [
                 [Function],
                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                 [Function],
                 [Function],
@@ -1030,8 +1030,8 @@ exports[`button start button matches snapshot 1`] = `
   border: 2px solid transparent;
   border-radius: 0;
   color: #ffffff;
-  background-color: #00823b;
-  box-shadow: 0 2px 0 #003618;
+  background-color: #00703c;
+  box-shadow: 0 2px 0 #002413;
   text-align: center;
   vertical-align: top;
   cursor: pointer;
@@ -1040,7 +1040,7 @@ exports[`button start button matches snapshot 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -1060,7 +1060,7 @@ exports[`button start button matches snapshot 1`] = `
 
 .c0:hover,
 .c0:focus {
-  background-color: #00692f;
+  background-color: #00572e;
 }
 
 .c0:active {
@@ -1085,11 +1085,11 @@ exports[`button start button matches snapshot 1`] = `
 
 .c0:disabled {
   opacity: 0.5;
-  background: #00823b;
+  background: #00703c;
 }
 
 .c0:disabled:hover {
-  background-color: #00823b;
+  background-color: #00703c;
   cursor: default;
 }
 
@@ -1099,7 +1099,7 @@ exports[`button start button matches snapshot 1`] = `
 
 .c0:disabled:active {
   top: 0;
-  box-shadow: 0 2px 0 #003618;
+  box-shadow: 0 2px 0 #002413;
 }
 
 .c0 svg {
@@ -1160,7 +1160,7 @@ exports[`button start button matches snapshot 1`] = `
               "rules": Array [
                 [Function],
                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                 [Function],
                 [Function],

--- a/components/caption/package.json
+++ b/components/caption/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -6,7 +6,7 @@
     "@govuk-react/hint-text": "^0.7.1",
     "@govuk-react/hoc": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/checkbox/src/__snapshots__/test.js.snap
+++ b/components/checkbox/src/__snapshots__/test.js.snap
@@ -46,7 +46,7 @@ exports[`Checkbox can render with hint text: hint text 1`] = `
 .c1:focus + span:before {
   outline: 3px solid transparent;
   outline-offset: 3px;
-  box-shadow: 0 0 0 3px #ffbf47;
+  box-shadow: 0 0 0 3px #ffdd00;
 }
 
 .c1 + span {
@@ -185,7 +185,7 @@ exports[`Checkbox can render with hint text: hint text 1`] = `
                     "position: absolute; z-index: 1; top: 0; left: 0; width: 40px; height: 40px; opacity: 0; :checked + span:after {
   opacity: 1;
 } :focus + span:before {
-  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 3px #ffbf47;
+  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 3px #ffdd00;
 }",
                     [Function],
                   ],
@@ -360,7 +360,7 @@ exports[`Checkbox matches wrapper snapshot: wrapper mount 1`] = `
 .c1:focus + span:before {
   outline: 3px solid transparent;
   outline-offset: 3px;
-  box-shadow: 0 0 0 3px #ffbf47;
+  box-shadow: 0 0 0 3px #ffdd00;
 }
 
 .c1 + span {
@@ -477,7 +477,7 @@ exports[`Checkbox matches wrapper snapshot: wrapper mount 1`] = `
                     "position: absolute; z-index: 1; top: 0; left: 0; width: 40px; height: 40px; opacity: 0; :checked + span:after {
   opacity: 1;
 } :focus + span:before {
-  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 3px #ffbf47;
+  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 3px #ffdd00;
 }",
                     [Function],
                   ],
@@ -578,7 +578,7 @@ exports[`Checkbox renders disabled checkbox: disabled 1`] = `
 .c1:focus + span:before {
   outline: 3px solid transparent;
   outline-offset: 3px;
-  box-shadow: 0 0 0 3px #ffbf47;
+  box-shadow: 0 0 0 3px #ffdd00;
 }
 
 .c1 + span {
@@ -699,7 +699,7 @@ exports[`Checkbox renders disabled checkbox: disabled 1`] = `
                     "position: absolute; z-index: 1; top: 0; left: 0; width: 40px; height: 40px; opacity: 0; :checked + span:after {
   opacity: 1;
 } :focus + span:before {
-  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 3px #ffbf47;
+  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 3px #ffdd00;
 }",
                     [Function],
                   ],

--- a/components/date-field/package.json
+++ b/components/date-field/package.json
@@ -9,7 +9,7 @@
     "@govuk-react/label": "^0.7.1",
     "@govuk-react/label-text": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3",
+   "govuk-colours": "^1.1.0",
     "multi-input-input": "0.0.3"
   },
   "peerDependencies": {

--- a/components/date-field/src/__snapshots__/test.js.snap
+++ b/components/date-field/src/__snapshots__/test.js.snap
@@ -25,7 +25,7 @@ exports[`DateField matches wrappersnapshot: wrapper mount 1`] = `
   display: block;
   margin-bottom: 15px;
   clear: both;
-  color: #b10e1e;
+  color: #d4351c;
 }
 
 .c6 {
@@ -45,12 +45,12 @@ exports[`DateField matches wrappersnapshot: wrapper mount 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  border: 4px solid #b10e1e;
+  border: 4px solid #d4351c;
   margin-bottom: 0;
 }
 
 .c6:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -109,7 +109,7 @@ exports[`DateField matches wrappersnapshot: wrapper mount 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  border-left: 4px solid #b10e1e;
+  border-left: 4px solid #d4351c;
   margin-right: 15px;
   padding-left: 10px;
   margin-bottom: 20px;
@@ -310,7 +310,7 @@ exports[`DateField matches wrappersnapshot: wrapper mount 1`] = `
 } font-weight: 700; font-size: 16px; line-height: 1.25; @media only screen and (min-width: 641px) {
   font-size: 19px; line-height: 1.3157894736842106;
 }",
-                      "display: block; margin-bottom: 15px; clear: both; color: #b10e1e;",
+                      "display: block; margin-bottom: 15px; clear: both; color: #d4351c;",
                       [Function],
                     ],
                   },
@@ -557,7 +557,7 @@ exports[`DateField matches wrappersnapshot: wrapper mount 1`] = `
   font-size: 19px; line-height: 1.3157894736842106;
 }",
                                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                                           "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;
@@ -743,7 +743,7 @@ exports[`DateField matches wrappersnapshot: wrapper mount 1`] = `
   font-size: 19px; line-height: 1.3157894736842106;
 }",
                                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                                           "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;
@@ -929,7 +929,7 @@ exports[`DateField matches wrappersnapshot: wrapper mount 1`] = `
   font-size: 19px; line-height: 1.3157894736842106;
 }",
                                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                                           "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;
@@ -1018,7 +1018,7 @@ exports[`DateField should support null value: null value 1`] = `
 }
 
 .c5:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -1456,7 +1456,7 @@ exports[`DateField should support null value: null value 1`] = `
   font-size: 19px; line-height: 1.3157894736842106;
 }",
                                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                                           "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;
@@ -1642,7 +1642,7 @@ exports[`DateField should support null value: null value 1`] = `
   font-size: 19px; line-height: 1.3157894736842106;
 }",
                                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                                           "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;
@@ -1828,7 +1828,7 @@ exports[`DateField should support null value: null value 1`] = `
   font-size: 19px; line-height: 1.3157894736842106;
 }",
                                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                                           "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;
@@ -1917,7 +1917,7 @@ exports[`DateField should support setting value: value 1 2 3 1`] = `
 }
 
 .c5:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -2372,7 +2372,7 @@ exports[`DateField should support setting value: value 1 2 3 1`] = `
   font-size: 19px; line-height: 1.3157894736842106;
 }",
                                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                                           "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;
@@ -2561,7 +2561,7 @@ exports[`DateField should support setting value: value 1 2 3 1`] = `
   font-size: 19px; line-height: 1.3157894736842106;
 }",
                                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                                           "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;
@@ -2750,7 +2750,7 @@ exports[`DateField should support setting value: value 1 2 3 1`] = `
   font-size: 19px; line-height: 1.3157894736842106;
 }",
                                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                                           "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;

--- a/components/details/package.json
+++ b/components/details/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3",
+   "govuk-colours": "^1.1.0",
     "polished": "^3.0.3"
   },
   "peerDependencies": {

--- a/components/details/src/__snapshots__/test.js.snap
+++ b/components/details/src/__snapshots__/test.js.snap
@@ -18,7 +18,7 @@ exports[`details matches the Details snapshot: details 1`] = `
   position: relative;
   margin-bottom: 5px;
   padding-left: 25px;
-  color: #005ea5;
+  color: #1d70b8;
   cursor: pointer;
 }
 
@@ -27,10 +27,10 @@ exports[`details matches the Details snapshot: details 1`] = `
 }
 
 .c1:focus {
-  outline: 4px solid #ffbf47;
+  outline: 4px solid #ffdd00;
   outline-offset: -1px;
   color: #0b0c0c;
-  background: #ffbf47;
+  background: #ffdd00;
 }
 
 .c1::-webkit-details-marker {
@@ -172,10 +172,10 @@ exports[`details matches the Details snapshot: details 1`] = `
                     "isStatic": true,
                     "lastClassName": "c1",
                     "rules": Array [
-                      "display: inline-block; position: relative; margin-bottom: 5px; padding-left: 25px; color: #005ea5; cursor: pointer; :hover {
+                      "display: inline-block; position: relative; margin-bottom: 5px; padding-left: 25px; color: #1d70b8; cursor: pointer; :hover {
   color: #2b8cc4;
 } :focus {
-  outline: 4px solid #ffbf47; outline-offset: -1px; color: #0b0c0c; background: #ffbf47;
+  outline: 4px solid #ffdd00; outline-offset: -1px; color: #0b0c0c; background: #ffdd00;
 } ::-webkit-details-marker {
   display: none;
 } :before {

--- a/components/error-summary/package.json
+++ b/components/error-summary/package.json
@@ -11,7 +11,7 @@
     "@govuk-react/paragraph": "^0.7.1",
     "@govuk-react/text-area": "^0.7.1",
     "@govuk-react/unordered-list": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=15",

--- a/components/error-summary/src/__snapshots__/test.js.snap
+++ b/components/error-summary/src/__snapshots__/test.js.snap
@@ -106,13 +106,13 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
   cursor: pointer;
   font-size: 16px;
   line-height: 1.25;
-  color: #b10e1e;
+  color: #d4351c;
   padding-top: 4px;
   padding-bottom: 2px;
 }
 
 .c7:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c7:visited {
@@ -132,24 +132,24 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
 }
 
 .c7:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c7:visited {
-  color: #b10e1e;
+  color: #d4351c;
 }
 
 .c0 {
   color: #0b0c0c;
   padding: 15px;
-  border: 4px solid #b10e1e;
+  border: 4px solid #d4351c;
   margin-bottom: 20px;
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -218,7 +218,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
 }
 
 .c11:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -245,7 +245,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
 }
 
 .c12:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -367,7 +367,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
 @media only screen and (min-width:641px) {
   .c0 {
     padding: 20px;
-    border: 5px solid #b10e1e;
+    border: 5px solid #d4351c;
   }
 }
 
@@ -483,10 +483,10 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
                 "isStatic": false,
                 "lastClassName": "c0",
                 "rules": Array [
-                  "color: #0b0c0c; padding: 15px; border: 4px solid #b10e1e; &:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+                  "color: #0b0c0c; padding: 15px; border: 4px solid #d4351c; &:focus {
+  outline: 3px solid #ffdd00; outline-offset: 0;
 } @media only screen and (min-width: 641px) {
-  padding: 20px; border: 5px solid #b10e1e;
+  padding: 20px; border: 5px solid #d4351c;
 }",
                   [Function],
                 ],
@@ -876,7 +876,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
   font-family: sans-serif;
 }",
                                       ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -887,7 +887,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
   color: #0b0c0c;
 }",
                                       "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                       "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -900,10 +900,10 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
                                       [Function],
                                       [Function],
                                       "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; font-weight: 700; margin-bottom: 5px; text-decoration: underline; text-decoration-skip-ink: none; text-transform: none; cursor: pointer; font-size: 16px; line-height: 1.25; :visited {
-  color: #b10e1e;
+  color: #d4351c;
 } @media only screen and (min-width: 641px) {
   font-size: 19px; line-height: 1.3;
-} color: #b10e1e; padding-top: 4px; padding-bottom: 2px;",
+} color: #d4351c; padding-top: 4px; padding-bottom: 2px;",
                                     ],
                                   },
                                   "defaultProps": Object {
@@ -1003,7 +1003,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
   font-family: sans-serif;
 }",
                                       ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -1014,7 +1014,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
   color: #0b0c0c;
 }",
                                       "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                       "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -1027,10 +1027,10 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
                                       [Function],
                                       [Function],
                                       "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; font-weight: 700; margin-bottom: 5px; text-decoration: underline; text-decoration-skip-ink: none; text-transform: none; cursor: pointer; font-size: 16px; line-height: 1.25; :visited {
-  color: #b10e1e;
+  color: #d4351c;
 } @media only screen and (min-width: 641px) {
   font-size: 19px; line-height: 1.3;
-} color: #b10e1e; padding-top: 4px; padding-bottom: 2px;",
+} color: #d4351c; padding-top: 4px; padding-bottom: 2px;",
                                     ],
                                   },
                                   "defaultProps": Object {
@@ -1236,7 +1236,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
   font-size: 19px; line-height: 1.3157894736842106;
 }",
                             "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                             "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;
@@ -1383,7 +1383,7 @@ exports[`error summary matches the ErrorSummary snapshot: error summary 1`] = `
                           "box-sizing: border-box; font-family: \\"nta\\", Arial, sans-serif; font-weight: 400; text-transform: none; font-size: 16px; line-height: 1.25; @media only screen and (min-width: 641px) {
   font-size: 19px; line-height: 1.3; width: 75%;
 } width: 100%; padding: 5px 4px 4px; border: 2px solid #0b0c0c; :focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                           [Function],
                         ],

--- a/components/error-text/package.json
+++ b/components/error-text/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/error-text/src/__snapshots__/test.js.snap
+++ b/components/error-text/src/__snapshots__/test.js.snap
@@ -11,7 +11,7 @@ exports[`ErrorText matches wrapper snapshot: wrapper mount 1`] = `
   display: block;
   margin-bottom: 15px;
   clear: both;
-  color: #b10e1e;
+  color: #d4351c;
 }
 
 @media print {
@@ -45,7 +45,7 @@ exports[`ErrorText matches wrapper snapshot: wrapper mount 1`] = `
 } font-weight: 700; font-size: 16px; line-height: 1.25; @media only screen and (min-width: 641px) {
   font-size: 19px; line-height: 1.3157894736842106;
 }",
-              "display: block; margin-bottom: 15px; clear: both; color: #b10e1e;",
+              "display: block; margin-bottom: 15px; clear: both; color: #d4351c;",
               [Function],
             ],
           },

--- a/components/fieldset/package.json
+++ b/components/fieldset/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/footer/package.json
+++ b/components/footer/package.json
@@ -8,7 +8,7 @@
     "@govuk-react/lib": "^0.7.1",
     "@govuk-react/link": "^0.7.1",
     "@govuk-react/visually-hidden": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/footer/src/__snapshots__/test.js.snap
+++ b/components/footer/src/__snapshots__/test.js.snap
@@ -13,7 +13,7 @@ exports[`Footer matches default snapshot: Footer 1`] = `
 }
 
 .c7:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c7:visited {
@@ -33,9 +33,9 @@ exports[`Footer matches default snapshot: Footer 1`] = `
 }
 
 .c7:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c6:link,
@@ -95,7 +95,7 @@ exports[`Footer matches default snapshot: Footer 1`] = `
 
 .c0 {
   border-top: 1px solid #a1acb2;
-  background: #dee0e2;
+  background: #f3f2f1;
   color: #454a4c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -224,7 +224,7 @@ exports[`Footer matches default snapshot: Footer 1`] = `
               "isStatic": false,
               "lastClassName": "c0",
               "rules": Array [
-                "border-top: 1px solid #a1acb2; background: #dee0e2; color: #454a4c;",
+                "border-top: 1px solid #a1acb2; background: #f3f2f1; color: #454a4c;",
                 "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-size: 14px; line-height: 1.2;
 } font-weight: 400; font-size: 14px; line-height: 1.1428571428571428; @media only screen and (min-width: 641px) {
@@ -516,7 +516,7 @@ exports[`Footer matches default snapshot: Footer 1`] = `
   font-family: sans-serif;
 }",
                                                             ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -527,7 +527,7 @@ exports[`Footer matches default snapshot: Footer 1`] = `
   color: #0b0c0c;
 }",
                                                             "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                             "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -614,7 +614,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
 }
 
 .c7:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c7:visited {
@@ -634,9 +634,9 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
 }
 
 .c7:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c6:link,
@@ -718,7 +718,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
 }
 
 .c9:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c9:visited {
@@ -738,9 +738,9 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
 }
 
 .c9:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c9:link,
@@ -754,7 +754,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
 
 .c0 {
   border-top: 1px solid #a1acb2;
-  background: #dee0e2;
+  background: #f3f2f1;
   color: #454a4c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -910,7 +910,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
               "isStatic": false,
               "lastClassName": "c0",
               "rules": Array [
-                "border-top: 1px solid #a1acb2; background: #dee0e2; color: #454a4c;",
+                "border-top: 1px solid #a1acb2; background: #f3f2f1; color: #454a4c;",
                 "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-size: 14px; line-height: 1.2;
 } font-weight: 400; font-size: 14px; line-height: 1.1428571428571428; @media only screen and (min-width: 641px) {
@@ -1214,7 +1214,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
   font-family: sans-serif;
 }",
                                                             ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -1225,7 +1225,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
   color: #0b0c0c;
 }",
                                                             "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                             "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -1362,7 +1362,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
   font-family: sans-serif;
 }",
                                             ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -1373,7 +1373,7 @@ exports[`Footer matches with copyright snapshot: FooterWithCopyright 1`] = `
   color: #0b0c0c;
 }",
                                             "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                             "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -1460,7 +1460,7 @@ exports[`Footer matches with custom width snapshot: FooterWithCustomWidth 1`] = 
 }
 
 .c7:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c7:visited {
@@ -1480,9 +1480,9 @@ exports[`Footer matches with custom width snapshot: FooterWithCustomWidth 1`] = 
 }
 
 .c7:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c6:link,
@@ -1542,7 +1542,7 @@ exports[`Footer matches with custom width snapshot: FooterWithCustomWidth 1`] = 
 
 .c0 {
   border-top: 1px solid #a1acb2;
-  background: #dee0e2;
+  background: #f3f2f1;
   color: #454a4c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -1688,7 +1688,7 @@ exports[`Footer matches with custom width snapshot: FooterWithCustomWidth 1`] = 
               "isStatic": false,
               "lastClassName": "c0",
               "rules": Array [
-                "border-top: 1px solid #a1acb2; background: #dee0e2; color: #454a4c;",
+                "border-top: 1px solid #a1acb2; background: #f3f2f1; color: #454a4c;",
                 "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-size: 14px; line-height: 1.2;
 } font-weight: 400; font-size: 14px; line-height: 1.1428571428571428; @media only screen and (min-width: 641px) {
@@ -1985,7 +1985,7 @@ exports[`Footer matches with custom width snapshot: FooterWithCustomWidth 1`] = 
   font-family: sans-serif;
 }",
                                                             ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -1996,7 +1996,7 @@ exports[`Footer matches with custom width snapshot: FooterWithCustomWidth 1`] = 
   color: #0b0c0c;
 }",
                                                             "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                             "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -2083,7 +2083,7 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
 }
 
 .c6:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c6:visited {
@@ -2103,9 +2103,9 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
 }
 
 .c6:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c5:link,
@@ -2169,7 +2169,7 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
 
 .c0 {
   border-top: 1px solid #a1acb2;
-  background: #dee0e2;
+  background: #f3f2f1;
   color: #454a4c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -2308,7 +2308,7 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
               "isStatic": false,
               "lastClassName": "c0",
               "rules": Array [
-                "border-top: 1px solid #a1acb2; background: #dee0e2; color: #454a4c;",
+                "border-top: 1px solid #a1acb2; background: #f3f2f1; color: #454a4c;",
                 "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-size: 14px; line-height: 1.2;
 } font-weight: 400; font-size: 14px; line-height: 1.1428571428571428; @media only screen and (min-width: 641px) {
@@ -2535,7 +2535,7 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
   font-family: sans-serif;
 }",
                                                         ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -2546,7 +2546,7 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
   color: #0b0c0c;
 }",
                                                         "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                         "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -2758,7 +2758,7 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
   font-family: sans-serif;
 }",
                                                             ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -2769,7 +2769,7 @@ exports[`Footer matches with meta custom snapshot: FooterWithMetaCustom 1`] = `
   color: #0b0c0c;
 }",
                                                             "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                             "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -2856,7 +2856,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
 }
 
 .c9:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c9:visited {
@@ -2876,9 +2876,9 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
 }
 
 .c9:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c8:link,
@@ -2986,7 +2986,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
 
 .c0 {
   border-top: 1px solid #a1acb2;
-  background: #dee0e2;
+  background: #f3f2f1;
   color: #454a4c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -3196,7 +3196,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
                   "isStatic": false,
                   "lastClassName": "c0",
                   "rules": Array [
-                    "border-top: 1px solid #a1acb2; background: #dee0e2; color: #454a4c;",
+                    "border-top: 1px solid #a1acb2; background: #f3f2f1; color: #454a4c;",
                     "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-size: 14px; line-height: 1.2;
 } font-weight: 400; font-size: 14px; line-height: 1.1428571428571428; @media only screen and (min-width: 641px) {
@@ -3576,7 +3576,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
   font-family: sans-serif;
 }",
                                                                     ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -3587,7 +3587,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
   color: #0b0c0c;
 }",
                                                                     "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                     "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -3845,7 +3845,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
   font-family: sans-serif;
 }",
                                                                     ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -3856,7 +3856,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
   color: #0b0c0c;
 }",
                                                                     "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                     "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -4007,7 +4007,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
   font-family: sans-serif;
 }",
                                                             ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -4018,7 +4018,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
   color: #0b0c0c;
 }",
                                                             "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                             "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -4230,7 +4230,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
   font-family: sans-serif;
 }",
                                                                 ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -4241,7 +4241,7 @@ exports[`Footer matches with meta links and custom snapshot: FooterWithMetaLinks
   color: #0b0c0c;
 }",
                                                                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                 "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -4338,7 +4338,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
 }
 
 .c9:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c9:visited {
@@ -4358,9 +4358,9 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
 }
 
 .c9:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c8:link,
@@ -4464,7 +4464,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
 
 .c0 {
   border-top: 1px solid #a1acb2;
-  background: #dee0e2;
+  background: #f3f2f1;
   color: #454a4c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -4664,7 +4664,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
                   "isStatic": false,
                   "lastClassName": "c0",
                   "rules": Array [
-                    "border-top: 1px solid #a1acb2; background: #dee0e2; color: #454a4c;",
+                    "border-top: 1px solid #a1acb2; background: #f3f2f1; color: #454a4c;",
                     "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-size: 14px; line-height: 1.2;
 } font-weight: 400; font-size: 14px; line-height: 1.1428571428571428; @media only screen and (min-width: 641px) {
@@ -5044,7 +5044,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
   font-family: sans-serif;
 }",
                                                                     ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -5055,7 +5055,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
   color: #0b0c0c;
 }",
                                                                     "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                     "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -5313,7 +5313,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
   font-family: sans-serif;
 }",
                                                                     ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -5324,7 +5324,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
   color: #0b0c0c;
 }",
                                                                     "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                     "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -5540,7 +5540,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
   font-family: sans-serif;
 }",
                                                                 ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -5551,7 +5551,7 @@ exports[`Footer matches with meta links snapshot: FooterWithMetaLinks 1`] = `
   color: #0b0c0c;
 }",
                                                                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                 "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -5660,7 +5660,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 }
 
 .c9:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c9:visited {
@@ -5680,9 +5680,9 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 }
 
 .c9:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c8:link,
@@ -5859,7 +5859,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
 
 .c0 {
   border-top: 1px solid #a1acb2;
-  background: #dee0e2;
+  background: #f3f2f1;
   color: #454a4c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -6141,7 +6141,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
                   "isStatic": false,
                   "lastClassName": "c0",
                   "rules": Array [
-                    "border-top: 1px solid #a1acb2; background: #dee0e2; color: #454a4c;",
+                    "border-top: 1px solid #a1acb2; background: #f3f2f1; color: #454a4c;",
                     "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-size: 14px; line-height: 1.2;
 } font-weight: 400; font-size: 14px; line-height: 1.1428571428571428; @media only screen and (min-width: 641px) {
@@ -6509,7 +6509,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -6520,7 +6520,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -6778,7 +6778,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -6789,7 +6789,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -6948,7 +6948,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -6959,7 +6959,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -7118,7 +7118,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -7129,7 +7129,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -7288,7 +7288,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -7299,7 +7299,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -7637,7 +7637,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -7648,7 +7648,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -7807,7 +7807,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -7818,7 +7818,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -7977,7 +7977,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -7988,7 +7988,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -8402,7 +8402,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   font-family: sans-serif;
 }",
                                                                     ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -8413,7 +8413,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   color: #0b0c0c;
 }",
                                                                     "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                     "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -8671,7 +8671,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   font-family: sans-serif;
 }",
                                                                     ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -8682,7 +8682,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   color: #0b0c0c;
 }",
                                                                     "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                     "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -8833,7 +8833,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   font-family: sans-serif;
 }",
                                                             ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -8844,7 +8844,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   color: #0b0c0c;
 }",
                                                             "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                             "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -9056,7 +9056,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   font-family: sans-serif;
 }",
                                                                 ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -9067,7 +9067,7 @@ exports[`Footer matches with navigation and meta snapshot: FooterWithNavigationA
   color: #0b0c0c;
 }",
                                                                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                 "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -9176,7 +9176,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 }
 
 .c9:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c9:visited {
@@ -9196,9 +9196,9 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 }
 
 .c9:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c8:link,
@@ -9327,7 +9327,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
 
 .c0 {
   border-top: 1px solid #a1acb2;
-  background: #dee0e2;
+  background: #f3f2f1;
   color: #454a4c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -9551,7 +9551,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
                   "isStatic": false,
                   "lastClassName": "c0",
                   "rules": Array [
-                    "border-top: 1px solid #a1acb2; background: #dee0e2; color: #454a4c;",
+                    "border-top: 1px solid #a1acb2; background: #f3f2f1; color: #454a4c;",
                     "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-size: 14px; line-height: 1.2;
 } font-weight: 400; font-size: 14px; line-height: 1.1428571428571428; @media only screen and (min-width: 641px) {
@@ -9919,7 +9919,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -9930,7 +9930,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -10188,7 +10188,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -10199,7 +10199,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -10358,7 +10358,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -10369,7 +10369,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -10528,7 +10528,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -10539,7 +10539,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -10698,7 +10698,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -10709,7 +10709,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -11047,7 +11047,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -11058,7 +11058,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -11217,7 +11217,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -11228,7 +11228,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -11387,7 +11387,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   font-family: sans-serif;
 }",
                                                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -11398,7 +11398,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   color: #0b0c0c;
 }",
                                                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -11724,7 +11724,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   font-family: sans-serif;
 }",
                                                                 ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -11735,7 +11735,7 @@ exports[`Footer matches with navigation snapshot: FooterWithNavigation 1`] = `
   color: #0b0c0c;
 }",
                                                                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                 "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -11832,7 +11832,7 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
 }
 
 .c9:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c9:visited {
@@ -11852,9 +11852,9 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
 }
 
 .c9:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c8:link,
@@ -11958,7 +11958,7 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
 
 .c0 {
   border-top: 1px solid #a1acb2;
-  background: #dee0e2;
+  background: #f3f2f1;
   color: #454a4c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -12147,7 +12147,7 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
                   "isStatic": false,
                   "lastClassName": "c0",
                   "rules": Array [
-                    "border-top: 1px solid #a1acb2; background: #dee0e2; color: #454a4c;",
+                    "border-top: 1px solid #a1acb2; background: #f3f2f1; color: #454a4c;",
                     "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-size: 14px; line-height: 1.2;
 } font-weight: 400; font-size: 14px; line-height: 1.1428571428571428; @media only screen and (min-width: 641px) {
@@ -12526,7 +12526,7 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
   font-family: sans-serif;
 }",
                                                                     ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -12537,7 +12537,7 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
   color: #0b0c0c;
 }",
                                                                     "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                     "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -12753,7 +12753,7 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
   font-family: sans-serif;
 }",
                                                                 ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -12764,7 +12764,7 @@ exports[`Footer matches with single meta link snapshot: FooterWithSingleMetaLink
   color: #0b0c0c;
 }",
                                                                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                                 "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -12873,7 +12873,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
 }
 
 .c9:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c9:visited {
@@ -12893,9 +12893,9 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
 }
 
 .c9:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c8:link,
@@ -13016,7 +13016,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
 
 .c0 {
   border-top: 1px solid #a1acb2;
-  background: #dee0e2;
+  background: #f3f2f1;
   color: #454a4c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -13210,7 +13210,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
               "isStatic": false,
               "lastClassName": "c0",
               "rules": Array [
-                "border-top: 1px solid #a1acb2; background: #dee0e2; color: #454a4c;",
+                "border-top: 1px solid #a1acb2; background: #f3f2f1; color: #454a4c;",
                 "font-family: \\"nta\\", Arial, sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; @media print {
   font-size: 14px; line-height: 1.2;
 } font-weight: 400; font-size: 14px; line-height: 1.1428571428571428; @media only screen and (min-width: 641px) {
@@ -13577,7 +13577,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
   font-family: sans-serif;
 }",
                                                               ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -13588,7 +13588,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
   color: #0b0c0c;
 }",
                                                               "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                               "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -13914,7 +13914,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
   font-family: sans-serif;
 }",
                                                             ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -13925,7 +13925,7 @@ exports[`Footer matches with single navigation link snapshot: FooterWithSingleNa
   color: #0b0c0c;
 }",
                                                             "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                                             "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {

--- a/components/form-group/package.json
+++ b/components/form-group/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/form-group/src/__snapshots__/test.js.snap
+++ b/components/form-group/src/__snapshots__/test.js.snap
@@ -8,7 +8,7 @@ exports[`FormGroup matches snapshot with error prop set: with error prop 1`] = `
 .c1 {
   margin-bottom: 20px;
   padding-left: 15px;
-  border-left: 5px solid #b10e1e;
+  border-left: 5px solid #d4351c;
 }
 
 .c1 .c0:last-of-type {

--- a/components/hint-text/package.json
+++ b/components/hint-text/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/input-field/src/__snapshots__/test.js.snap
+++ b/components/input-field/src/__snapshots__/test.js.snap
@@ -54,7 +54,7 @@ exports[`InputField matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .c2:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -230,7 +230,7 @@ exports[`InputField matches wrapper snapshot: wrapper mount 1`] = `
   font-size: 19px; line-height: 1.3157894736842106;
 }",
                         "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                         "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;

--- a/components/input/package.json
+++ b/components/input/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/input/src/__snapshots__/test.js.snap
+++ b/components/input/src/__snapshots__/test.js.snap
@@ -23,7 +23,7 @@ exports[`Input matches withColouredError snapshot: with coloured error mount 1`]
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -85,7 +85,7 @@ exports[`Input matches withColouredError snapshot: with coloured error mount 1`]
   font-size: 19px; line-height: 1.3157894736842106;
 }",
               "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
               "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;
@@ -136,12 +136,12 @@ exports[`Input matches withError snapshot: with error mount 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  border: 4px solid #b10e1e;
+  border: 4px solid #d4351c;
   margin-bottom: 0;
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -200,7 +200,7 @@ exports[`Input matches withError snapshot: with error mount 1`] = `
   font-size: 19px; line-height: 1.3157894736842106;
 }",
               "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
               "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;
@@ -255,7 +255,7 @@ exports[`Input matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -311,7 +311,7 @@ exports[`Input matches wrapper snapshot: wrapper mount 1`] = `
   font-size: 19px; line-height: 1.3157894736842106;
 }",
               "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
               "box-sizing: border-box; width: 100%; height: 40px; margin-top: 0; padding: 5px; border: 2px solid #0b0c0c; border-radius: 0; appearance: none; &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
   margin: 0; -webkit-appearance: none;

--- a/components/inset-text/package.json
+++ b/components/inset-text/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=15",

--- a/components/label/package.json
+++ b/components/label/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/label/src/__snapshots__/test.js.snap
+++ b/components/label/src/__snapshots__/test.js.snap
@@ -10,7 +10,7 @@ exports[`Label matches withError snapshot: with error mount 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   box-sizing: border-box;
-  border-left: 4px solid #b10e1e;
+  border-left: 4px solid #d4351c;
   margin-right: 15px;
   padding-left: 10px;
   margin-bottom: 0;

--- a/components/link/package.json
+++ b/components/link/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.1",
   "dependencies": {
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/link/src/__snapshots__/test.js.snap
+++ b/components/link/src/__snapshots__/test.js.snap
@@ -8,7 +8,7 @@ exports[`Link all options view matches snapshot: link with all options 1`] = `
 }
 
 .c0:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c0:visited {
@@ -28,9 +28,9 @@ exports[`Link all options view matches snapshot: link with all options 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c0:link,
@@ -53,11 +53,11 @@ exports[`Link all options view matches snapshot: link with all options 1`] = `
 }
 
 .c0:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c0:visited {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c0:hover {
@@ -125,7 +125,7 @@ exports[`Link all options view matches snapshot: link with all options 1`] = `
   font-family: sans-serif;
 }",
                 ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -136,7 +136,7 @@ exports[`Link all options view matches snapshot: link with all options 1`] = `
   color: #0b0c0c;
 }",
                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                 "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -193,7 +193,7 @@ exports[`Link basic view matches snapshot: plain link 1`] = `
 }
 
 .c0:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c0:visited {
@@ -213,9 +213,9 @@ exports[`Link basic view matches snapshot: plain link 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 @media print {
@@ -261,7 +261,7 @@ exports[`Link basic view matches snapshot: plain link 1`] = `
   font-family: sans-serif;
 }",
                 ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -272,7 +272,7 @@ exports[`Link basic view matches snapshot: plain link 1`] = `
   color: #0b0c0c;
 }",
                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                 "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {

--- a/components/loading-box/package.json
+++ b/components/loading-box/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/icons": "^0.7.1",
-    "govuk-colours": "^1.0.3",
+   "govuk-colours": "^1.1.0",
     "hex-rgb": "^4.0.0",
     "react-transition-group": "^4.2.1"
   },

--- a/components/multi-choice/package.json
+++ b/components/multi-choice/package.json
@@ -7,7 +7,7 @@
     "@govuk-react/hint-text": "^0.7.1",
     "@govuk-react/label-text": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/multi-choice/src/__snapshots__/test.js.snap
+++ b/components/multi-choice/src/__snapshots__/test.js.snap
@@ -25,7 +25,7 @@ exports[`MultiChoice matches snapshot 1`] = `
   display: block;
   margin-bottom: 15px;
   clear: both;
-  color: #b10e1e;
+  color: #d4351c;
 }
 
 .c2 {
@@ -46,7 +46,7 @@ exports[`MultiChoice matches snapshot 1`] = `
   border: 0;
   box-sizing: border-box;
   width: 100%;
-  border-left: 4px solid #b10e1e;
+  border-left: 4px solid #d4351c;
   margin-right: 15px;
   padding-left: 10px;
   margin-bottom: 0;
@@ -267,7 +267,7 @@ exports[`MultiChoice matches snapshot 1`] = `
 } font-weight: 700; font-size: 16px; line-height: 1.25; @media only screen and (min-width: 641px) {
   font-size: 19px; line-height: 1.3157894736842106;
 }",
-                      "display: block; margin-bottom: 15px; clear: both; color: #b10e1e;",
+                      "display: block; margin-bottom: 15px; clear: both; color: #d4351c;",
                       [Function],
                     ],
                   },

--- a/components/ordered-list/src/__snapshots__/test.js.snap
+++ b/components/ordered-list/src/__snapshots__/test.js.snap
@@ -8,7 +8,7 @@ exports[`OrderedList matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .c4:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c4:visited {
@@ -28,9 +28,9 @@ exports[`OrderedList matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .c4:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c3 {
@@ -244,7 +244,7 @@ exports[`OrderedList matches wrapper snapshot: wrapper mount 1`] = `
   font-family: sans-serif;
 }",
                           ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -255,7 +255,7 @@ exports[`OrderedList matches wrapper snapshot: wrapper mount 1`] = `
   color: #0b0c0c;
 }",
                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                           "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -359,7 +359,7 @@ exports[`OrderedList matches wrapper snapshot: wrapper mount 1`] = `
   font-family: sans-serif;
 }",
                           ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -370,7 +370,7 @@ exports[`OrderedList matches wrapper snapshot: wrapper mount 1`] = `
   color: #0b0c0c;
 }",
                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                           "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -474,7 +474,7 @@ exports[`OrderedList matches wrapper snapshot: wrapper mount 1`] = `
   font-family: sans-serif;
 }",
                           ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -485,7 +485,7 @@ exports[`OrderedList matches wrapper snapshot: wrapper mount 1`] = `
   color: #0b0c0c;
 }",
                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                           "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {

--- a/components/panel/package.json
+++ b/components/panel/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3",
+   "govuk-colours": "^1.1.0",
     "polished": "^3.0.3"
   },
   "peerDependencies": {

--- a/components/phase-banner/package.json
+++ b/components/phase-banner/package.json
@@ -5,7 +5,7 @@
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
     "@govuk-react/tag": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/phase-banner/src/__snapshots__/test.js.snap
+++ b/components/phase-banner/src/__snapshots__/test.js.snap
@@ -14,7 +14,7 @@ exports[`PhaseBanner matches wrapper snapshot: wrapper mount 1`] = `
   outline: 2px solid transparent;
   outline-offset: -2px;
   color: #ffffff;
-  background-color: #005ea5;
+  background-color: #1d70b8;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
   -ms-letter-spacing: 1px;
@@ -175,7 +175,7 @@ exports[`PhaseBanner matches wrapper snapshot: wrapper mount 1`] = `
 } font-weight: 700; font-size: 14px; line-height: 1.25; @media only screen and (min-width: 641px) {
   font-size: 16px; line-height: 1.25;
 }",
-                          "display: inline-block; padding: 4px 8px; padding-bottom: 1px; outline: 2px solid transparent; outline-offset: -2px; color: #ffffff; background-color: #005ea5; letter-spacing: 1px; text-decoration: none; text-transform: uppercase;",
+                          "display: inline-block; padding: 4px 8px; padding-bottom: 1px; outline: 2px solid transparent; outline-offset: -2px; color: #ffffff; background-color: #1d70b8; letter-spacing: 1px; text-decoration: none; text-transform: uppercase;",
                           [Function],
                         ],
                       },

--- a/components/radio/package.json
+++ b/components/radio/package.json
@@ -5,7 +5,7 @@
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/hint-text": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/radio/src/__snapshots__/test.js.snap
+++ b/components/radio/src/__snapshots__/test.js.snap
@@ -47,7 +47,7 @@ exports[`Radio can render with hint text: hint text 1`] = `
 .c1:focus + span::before {
   outline: 3px solid transparent;
   outline-offset: 3px;
-  box-shadow: 0 0 0 4px #ffbf47;
+  box-shadow: 0 0 0 4px #ffdd00;
 }
 
 .c1 + span {
@@ -188,7 +188,7 @@ exports[`Radio can render with hint text: hint text 1`] = `
                     "position: absolute; z-index: 1; top: 0; left: 0; width: 40px; height: 40px; cursor: pointer; opacity: 0; :checked + span::after {
   opacity: 1;
 } :focus + span::before {
-  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 4px #ffbf47;
+  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 4px #ffdd00;
 }",
                     [Function],
                   ],
@@ -364,7 +364,7 @@ exports[`Radio disabled: disabled 1`] = `
 .c1:focus + span::before {
   outline: 3px solid transparent;
   outline-offset: 3px;
-  box-shadow: 0 0 0 4px #ffbf47;
+  box-shadow: 0 0 0 4px #ffdd00;
 }
 
 .c1 + span {
@@ -487,7 +487,7 @@ exports[`Radio disabled: disabled 1`] = `
                     "position: absolute; z-index: 1; top: 0; left: 0; width: 40px; height: 40px; cursor: pointer; opacity: 0; :checked + span::after {
   opacity: 1;
 } :focus + span::before {
-  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 4px #ffbf47;
+  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 4px #ffdd00;
 }",
                     [Function],
                   ],
@@ -590,7 +590,7 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
 .c1:focus + span::before {
   outline: 3px solid transparent;
   outline-offset: 3px;
-  box-shadow: 0 0 0 4px #ffbf47;
+  box-shadow: 0 0 0 4px #ffdd00;
 }
 
 .c1 + span {
@@ -720,7 +720,7 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
                     "position: absolute; z-index: 1; top: 0; left: 0; width: 40px; height: 40px; cursor: pointer; opacity: 0; :checked + span::after {
   opacity: 1;
 } :focus + span::before {
-  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 4px #ffbf47;
+  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 4px #ffdd00;
 }",
                     [Function],
                   ],
@@ -824,7 +824,7 @@ exports[`Radio matches snapshot: standard mount 1`] = `
 .c1:focus + span::before {
   outline: 3px solid transparent;
   outline-offset: 3px;
-  box-shadow: 0 0 0 4px #ffbf47;
+  box-shadow: 0 0 0 4px #ffdd00;
 }
 
 .c1 + span {
@@ -946,7 +946,7 @@ exports[`Radio matches snapshot: standard mount 1`] = `
                     "position: absolute; z-index: 1; top: 0; left: 0; width: 40px; height: 40px; cursor: pointer; opacity: 0; :checked + span::after {
   opacity: 1;
 } :focus + span::before {
-  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 4px #ffbf47;
+  outline: 3px solid transparent; outline-offset: 3px; box-shadow: 0 0 0 4px #ffdd00;
 }",
                     [Function],
                   ],

--- a/components/related-items/package.json
+++ b/components/related-items/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/related-items/src/__snapshots__/test.js.snap
+++ b/components/related-items/src/__snapshots__/test.js.snap
@@ -53,7 +53,7 @@ exports[`RelatedItems matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .c6:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c6:visited {
@@ -73,13 +73,13 @@ exports[`RelatedItems matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .c6:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c0 {
-  border-top: 10px solid #005ea5;
+  border-top: 10px solid #1d70b8;
   padding-top: 5px;
   width: 100%;
   margin-bottom: 0;
@@ -204,7 +204,7 @@ exports[`RelatedItems matches wrapper snapshot: wrapper mount 1`] = `
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
-              "border-top: 10px solid #005ea5; padding-top: 5px; width: 100%; @media only screen and (min-width: 641px) {
+              "border-top: 10px solid #1d70b8; padding-top: 5px; width: 100%; @media only screen and (min-width: 641px) {
   font-size: 16px; line-height: 1.25;
 } > h3 {
   margin-bottom: 10px;
@@ -392,7 +392,7 @@ exports[`RelatedItems matches wrapper snapshot: wrapper mount 1`] = `
   font-family: sans-serif;
 }",
                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -403,7 +403,7 @@ exports[`RelatedItems matches wrapper snapshot: wrapper mount 1`] = `
   color: #0b0c0c;
 }",
                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -507,7 +507,7 @@ exports[`RelatedItems matches wrapper snapshot: wrapper mount 1`] = `
   font-family: sans-serif;
 }",
                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -518,7 +518,7 @@ exports[`RelatedItems matches wrapper snapshot: wrapper mount 1`] = `
   color: #0b0c0c;
 }",
                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -622,7 +622,7 @@ exports[`RelatedItems matches wrapper snapshot: wrapper mount 1`] = `
   font-family: sans-serif;
 }",
                                   ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -633,7 +633,7 @@ exports[`RelatedItems matches wrapper snapshot: wrapper mount 1`] = `
   color: #0b0c0c;
 }",
                                   "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                                   "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {

--- a/components/search-box/package.json
+++ b/components/search-box/package.json
@@ -5,7 +5,7 @@
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/icons": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/search-box/src/__snapshots__/test.js.snap
+++ b/components/search-box/src/__snapshots__/test.js.snap
@@ -32,7 +32,7 @@ exports[`SearchBox matches wrapper snapshot: wrapper mount 1`] = `
 
 .c1:focus {
   margin-right: 3px;
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -56,7 +56,7 @@ exports[`SearchBox matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .c2:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -114,7 +114,7 @@ exports[`SearchBox matches wrapper snapshot: wrapper mount 1`] = `
                   "lastClassName": "c1",
                   "rules": Array [
                     "width: 100%; height: 40px; padding: 6px; margin: 0; border: solid 1px #bfc1c3; border-right: 0; box-sizing: border-box; font-family: \\"nta\\", Arial, sans-serif; font-weight: 400; text-transform: none; font-size: 16px; line-height: 1.75; background: #ffffff; border-radius: 0; -webkit-appearance: none; :focus {
-  margin-right: 3px; outline: 3px solid #ffbf47; outline-offset: 0;  ~ button {
+  margin-right: 3px; outline: 3px solid #ffdd00; outline-offset: 0;  ~ button {
   width: 46px;
 }
 }",
@@ -155,7 +155,7 @@ exports[`SearchBox matches wrapper snapshot: wrapper mount 1`] = `
                   "lastClassName": "c2",
                   "rules": Array [
                     "background-color: #2b8cc4; border: 0; display: block; color: #ffffff; position: relative; padding: 10px; width: 45px; height: 40px; background-repeat: no-repeat; background-position: 2px 50%; text-indent: -999em; overflow: hidden; :focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                   ],
                 },

--- a/components/section-break/package.json
+++ b/components/section-break/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.1",
   "dependencies": {
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/select/package.json
+++ b/components/select/package.json
@@ -8,7 +8,7 @@
     "@govuk-react/label": "^0.7.1",
     "@govuk-react/label-text": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/select/src/__snapshots__/test.js.snap
+++ b/components/select/src/__snapshots__/test.js.snap
@@ -10,7 +10,7 @@ exports[`Select matches snapshot for errorText: errorText mount 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   box-sizing: border-box;
-  border-left: 4px solid #b10e1e;
+  border-left: 4px solid #d4351c;
   margin-right: 15px;
   padding-left: 10px;
   margin-bottom: 0;
@@ -46,7 +46,7 @@ exports[`Select matches snapshot for errorText: errorText mount 1`] = `
   display: block;
   margin-bottom: 15px;
   clear: both;
-  color: #b10e1e;
+  color: #d4351c;
 }
 
 .c2 {
@@ -73,11 +73,11 @@ exports[`Select matches snapshot for errorText: errorText mount 1`] = `
   height: 33px;
   padding: 5px 4px 4px;
   border: 2px solid #0b0c0c;
-  border: 4px solid #b10e1e;
+  border: 4px solid #d4351c;
 }
 
 .c4:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -319,7 +319,7 @@ exports[`Select matches snapshot for errorText: errorText mount 1`] = `
 } font-weight: 700; font-size: 16px; line-height: 1.25; @media only screen and (min-width: 641px) {
   font-size: 19px; line-height: 1.3157894736842106;
 }",
-                        "display: block; margin-bottom: 15px; clear: both; color: #b10e1e;",
+                        "display: block; margin-bottom: 15px; clear: both; color: #d4351c;",
                         [Function],
                       ],
                     },
@@ -365,7 +365,7 @@ exports[`Select matches snapshot for errorText: errorText mount 1`] = `
                       "box-sizing: border-box; width: 100%; height: 33px; padding: 5px 4px 4px; border: 2px solid #0b0c0c; @media only screen and (min-width: 641px) {
   width: 50%; height: 38px;
 } :focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                       [Function],
                     ],
@@ -444,7 +444,7 @@ exports[`Select matches snapshot: enzyme.mount 1`] = `
 }
 
 .c2:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -609,7 +609,7 @@ exports[`Select matches snapshot: enzyme.mount 1`] = `
                       "box-sizing: border-box; width: 100%; height: 33px; padding: 5px 4px 4px; border: 2px solid #0b0c0c; @media only screen and (min-width: 641px) {
   width: 50%; height: 38px;
 } :focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                       [Function],
                     ],

--- a/components/skip-link/package.json
+++ b/components/skip-link/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/skip-link/src/__snapshots__/test.js.snap
+++ b/components/skip-link/src/__snapshots__/test.js.snap
@@ -37,9 +37,9 @@ exports[`SkipLink matches snapshot: SkipLink 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c0:link,
@@ -110,7 +110,7 @@ exports[`SkipLink matches snapshot: SkipLink 1`] = `
   font-family: sans-serif;
 }",
               "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
               "&:link, &:visited, &:hover, &:active, &:focus {
   color: #0b0c0c; @media print {

--- a/components/supporting-header/package.json
+++ b/components/supporting-header/package.json
@@ -5,7 +5,7 @@
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/hoc": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/tabs/src/__snapshots__/test.js.snap
+++ b/components/tabs/src/__snapshots__/test.js.snap
@@ -48,13 +48,13 @@ exports[`Tabs matches wrapper snapshot 1`] = `
 }
 
 .c4:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c4:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c4:visited {
@@ -89,13 +89,13 @@ exports[`Tabs matches wrapper snapshot 1`] = `
 }
 
 .c5:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c5:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c5:visited {

--- a/components/tag/package.json
+++ b/components/tag/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.1",
   "dependencies": {
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/tag/src/__snapshots__/test.js.snap
+++ b/components/tag/src/__snapshots__/test.js.snap
@@ -14,7 +14,7 @@ exports[`Tag matches wrapper snapshot: wrapper mount 1`] = `
   outline: 2px solid transparent;
   outline-offset: -2px;
   color: #ffffff;
-  background-color: #005ea5;
+  background-color: #1d70b8;
   -webkit-letter-spacing: 1px;
   -moz-letter-spacing: 1px;
   -ms-letter-spacing: 1px;
@@ -59,7 +59,7 @@ exports[`Tag matches wrapper snapshot: wrapper mount 1`] = `
 } font-weight: 700; font-size: 14px; line-height: 1.25; @media only screen and (min-width: 641px) {
   font-size: 16px; line-height: 1.25;
 }",
-              "display: inline-block; padding: 4px 8px; padding-bottom: 1px; outline: 2px solid transparent; outline-offset: -2px; color: #ffffff; background-color: #005ea5; letter-spacing: 1px; text-decoration: none; text-transform: uppercase;",
+              "display: inline-block; padding: 4px 8px; padding-bottom: 1px; outline: 2px solid transparent; outline-offset: -2px; color: #ffffff; background-color: #1d70b8; letter-spacing: 1px; text-decoration: none; text-transform: uppercase;",
               [Function],
             ],
           },

--- a/components/text-area/package.json
+++ b/components/text-area/package.json
@@ -8,7 +8,7 @@
     "@govuk-react/hoc": "^0.7.1",
     "@govuk-react/label": "^0.7.1",
     "@govuk-react/label-text": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/text-area/src/__snapshots__/test.js.snap
+++ b/components/text-area/src/__snapshots__/test.js.snap
@@ -10,7 +10,7 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   box-sizing: border-box;
-  border-left: 4px solid #b10e1e;
+  border-left: 4px solid #d4351c;
   margin-right: 15px;
   padding-left: 10px;
   margin-bottom: 0;
@@ -46,7 +46,7 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
   display: block;
   margin-bottom: 15px;
   clear: both;
-  color: #b10e1e;
+  color: #d4351c;
 }
 
 .c3 {
@@ -59,11 +59,11 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
   width: 100%;
   padding: 5px 4px 4px;
   border: 2px solid #0b0c0c;
-  border: 4px solid #b10e1e;
+  border: 4px solid #d4351c;
 }
 
 .c3:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -235,7 +235,7 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
 } font-weight: 700; font-size: 16px; line-height: 1.25; @media only screen and (min-width: 641px) {
   font-size: 19px; line-height: 1.3157894736842106;
 }",
-                        "display: block; margin-bottom: 15px; clear: both; color: #b10e1e;",
+                        "display: block; margin-bottom: 15px; clear: both; color: #d4351c;",
                         [Function],
                       ],
                     },
@@ -278,7 +278,7 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
                       "box-sizing: border-box; font-family: \\"nta\\", Arial, sans-serif; font-weight: 400; text-transform: none; font-size: 16px; line-height: 1.25; @media only screen and (min-width: 641px) {
   font-size: 19px; line-height: 1.3; width: 75%;
 } width: 100%; padding: 5px 4px 4px; border: 2px solid #0b0c0c; :focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                       [Function],
                     ],
@@ -369,7 +369,7 @@ exports[`Textarea matches snapshot for hint: wrapperHint mount 1`] = `
 }
 
 .c3:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -574,7 +574,7 @@ exports[`Textarea matches snapshot for hint: wrapperHint mount 1`] = `
                       "box-sizing: border-box; font-family: \\"nta\\", Arial, sans-serif; font-weight: 400; text-transform: none; font-size: 16px; line-height: 1.25; @media only screen and (min-width: 641px) {
   font-size: 19px; line-height: 1.3; width: 75%;
 } width: 100%; padding: 5px 4px 4px; border: 2px solid #0b0c0c; :focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                       [Function],
                     ],
@@ -653,7 +653,7 @@ exports[`Textarea matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .c2:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
 }
 
@@ -802,7 +802,7 @@ exports[`Textarea matches wrapper snapshot: wrapper mount 1`] = `
                       "box-sizing: border-box; font-family: \\"nta\\", Arial, sans-serif; font-weight: 400; text-transform: none; font-size: 16px; line-height: 1.25; @media only screen and (min-width: 641px) {
   font-size: 19px; line-height: 1.3; width: 75%;
 } width: 100%; padding: 5px 4px 4px; border: 2px solid #0b0c0c; :focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #ffdd00; outline-offset: 0;
 }",
                       [Function],
                     ],

--- a/components/top-nav/package.json
+++ b/components/top-nav/package.json
@@ -9,7 +9,7 @@
     "@govuk-react/icons": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
     "@govuk-react/search-box": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2",

--- a/components/top-nav/src/__snapshots__/test.js.snap
+++ b/components/top-nav/src/__snapshots__/test.js.snap
@@ -33,7 +33,7 @@ exports[`TopNav matches the <TopNav> with a <NavLinkAnchor> tag snapshot: enzyme
 }
 
 .c17 {
-  border-bottom: 10px solid #005ea5;
+  border-bottom: 10px solid #1d70b8;
   max-width: 960px;
   margin: 0 auto;
   width: calc(100% - 30px);
@@ -212,13 +212,13 @@ exports[`TopNav matches the <TopNav> with a <NavLinkAnchor> tag snapshot: enzyme
 }
 
 .c16:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
 }
 
 .c16:focus {
   color: #0b0c0c;
-  background-color: #ffbf47;
-  outline: 3px solid #ffbf47;
+  background-color: #ffdd00;
+  outline: 3px solid #ffdd00;
 }
 
 .c16:focus:hover {
@@ -982,10 +982,10 @@ exports[`TopNav matches the <TopNav> with a <NavLinkAnchor> tag snapshot: enzyme
                                             "color: #ffffff; text-decoration: none; text-decoration-skip-ink: none; border-bottom: 1px solid transparent; font-weight: 700; line-height: 1; :hover {
   border-bottom-color: #ffffff;
 } :focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
 }",
                                             "display: inline-block; :focus {
-  color: #0b0c0c; background-color: #ffbf47; outline: 3px solid #ffbf47; :hover {
+  color: #0b0c0c; background-color: #ffdd00; outline: 3px solid #ffdd00; :hover {
   border-bottom-color: #0b0c0c;
 }
 }",
@@ -1045,7 +1045,7 @@ exports[`TopNav matches the <TopNav> with a <NavLinkAnchor> tag snapshot: enzyme
             "isStatic": true,
             "lastClassName": "c17",
             "rules": Array [
-              "border-bottom: 10px solid #005ea5; max-width: 960px; margin: 0 auto; width: calc(100% - 30px); @media only screen and (min-width: 641px) {
+              "border-bottom: 10px solid #1d70b8; max-width: 960px; margin: 0 auto; width: calc(100% - 30px); @media only screen and (min-width: 641px) {
   width: calc(100% - 60px);
 }",
             ],
@@ -1103,7 +1103,7 @@ exports[`TopNav matches the <TopNav> with multiple <Anchor> tags snapshot: enzym
 }
 
 .c17 {
-  border-bottom: 10px solid #005ea5;
+  border-bottom: 10px solid #1d70b8;
   max-width: 960px;
   margin: 0 auto;
   width: calc(100% - 30px);
@@ -1281,7 +1281,7 @@ exports[`TopNav matches the <TopNav> with multiple <Anchor> tags snapshot: enzym
 }
 
 .c16:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
 }
 
 @media only screen and (min-width:641px) {
@@ -2046,7 +2046,7 @@ exports[`TopNav matches the <TopNav> with multiple <Anchor> tags snapshot: enzym
                                             "color: #ffffff; text-decoration: none; text-decoration-skip-ink: none; border-bottom: 1px solid transparent; font-weight: 700; line-height: 1; :hover {
   border-bottom-color: #ffffff;
 } :focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
 }",
                                           ],
                                         },
@@ -2128,7 +2128,7 @@ exports[`TopNav matches the <TopNav> with multiple <Anchor> tags snapshot: enzym
                                             "color: #ffffff; text-decoration: none; text-decoration-skip-ink: none; border-bottom: 1px solid transparent; font-weight: 700; line-height: 1; :hover {
   border-bottom-color: #ffffff;
 } :focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
 }",
                                           ],
                                         },
@@ -2184,7 +2184,7 @@ exports[`TopNav matches the <TopNav> with multiple <Anchor> tags snapshot: enzym
             "isStatic": true,
             "lastClassName": "c17",
             "rules": Array [
-              "border-bottom: 10px solid #005ea5; max-width: 960px; margin: 0 auto; width: calc(100% - 30px); @media only screen and (min-width: 641px) {
+              "border-bottom: 10px solid #1d70b8; max-width: 960px; margin: 0 auto; width: calc(100% - 30px); @media only screen and (min-width: 641px) {
   width: calc(100% - 60px);
 }",
             ],
@@ -2242,7 +2242,7 @@ exports[`TopNav with icon title: icon title 1`] = `
 }
 
 .c9 {
-  border-bottom: 10px solid #005ea5;
+  border-bottom: 10px solid #1d70b8;
   max-width: 960px;
   margin: 0 auto;
   width: calc(100% - 30px);
@@ -2777,7 +2777,7 @@ exports[`TopNav with icon title: icon title 1`] = `
             "isStatic": true,
             "lastClassName": "c9",
             "rules": Array [
-              "border-bottom: 10px solid #005ea5; max-width: 960px; margin: 0 auto; width: calc(100% - 30px); @media only screen and (min-width: 641px) {
+              "border-bottom: 10px solid #1d70b8; max-width: 960px; margin: 0 auto; width: calc(100% - 30px); @media only screen and (min-width: 641px) {
   width: calc(100% - 60px);
 }",
             ],

--- a/components/unordered-list/src/__snapshots__/test.js.snap
+++ b/components/unordered-list/src/__snapshots__/test.js.snap
@@ -8,7 +8,7 @@ exports[`UnorderedList matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .c4:link {
-  color: #005ea5;
+  color: #1d70b8;
 }
 
 .c4:visited {
@@ -28,9 +28,9 @@ exports[`UnorderedList matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .c4:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #ffdd00;
   outline-offset: 0;
-  background-color: #ffbf47;
+  background-color: #ffdd00;
 }
 
 .c3 {
@@ -239,7 +239,7 @@ exports[`UnorderedList matches wrapper snapshot: wrapper mount 1`] = `
   font-family: sans-serif;
 }",
                           ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -250,7 +250,7 @@ exports[`UnorderedList matches wrapper snapshot: wrapper mount 1`] = `
   color: #0b0c0c;
 }",
                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                           "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -354,7 +354,7 @@ exports[`UnorderedList matches wrapper snapshot: wrapper mount 1`] = `
   font-family: sans-serif;
 }",
                           ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -365,7 +365,7 @@ exports[`UnorderedList matches wrapper snapshot: wrapper mount 1`] = `
   color: #0b0c0c;
 }",
                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                           "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {
@@ -469,7 +469,7 @@ exports[`UnorderedList matches wrapper snapshot: wrapper mount 1`] = `
   font-family: sans-serif;
 }",
                           ":link {
-  color: #005ea5;
+  color: #1d70b8;
 } :visited {
   color: #4c2c92;
 } :hover {
@@ -480,7 +480,7 @@ exports[`UnorderedList matches wrapper snapshot: wrapper mount 1`] = `
   color: #0b0c0c;
 }",
                           "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0; background-color: #ffbf47;
+  outline: 3px solid #ffdd00; outline-offset: 0; background-color: #ffdd00;
 }",
                           "@media print {
   &[href^=\\"/\\"], &[href^=\\"http://\\"], &[href^=\\"https://\\"] {

--- a/components/visually-hidden/package.json
+++ b/components/visually-hidden/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.1",
   "dependencies": {
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/components/warning-text/package.json
+++ b/components/warning-text/package.json
@@ -5,7 +5,7 @@
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/icons": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=15",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "dependencies": {
-    "govuk-colours": "^1.0.3",
+    "govuk-colours": "^1.1.0",
     "react-markdown": "^4.0.6"
   },
   "peerDependencies": {

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -2,7 +2,7 @@
   "name": "@govuk-react/constants",
   "version": "0.7.1",
   "dependencies": {
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0"

--- a/packages/govuk-react/package.json
+++ b/packages/govuk-react/package.json
@@ -59,7 +59,7 @@
     "@govuk-react/unordered-list": "^0.7.1",
     "@govuk-react/visually-hidden": "^0.7.1",
     "@govuk-react/warning-text": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/packages/hoc/package.json
+++ b/packages/hoc/package.json
@@ -6,7 +6,7 @@
     "@govuk-react/icons": "^0.7.1",
     "@govuk-react/lib": "^0.7.1",
     "@govuk-react/link": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.1",
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=16.2.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.1",
   "dependencies": {
     "@govuk-react/constants": "^0.7.1",
-    "govuk-colours": "^1.0.3"
+   "govuk-colours": "^1.1.0"
   },
   "scripts": {
     "build": "yarn build:lib && yarn build:es",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -59,7 +59,7 @@
     "@storybook/addons": "^5.0.3",
     "@storybook/react": "^5.0.3",
     "@storybook/storybook-deployer": "^2.8.1",
-    "govuk-colours": "^1.0.3",
+   "govuk-colours": "^1.1.0",
     "normalize.css": "^8.0.0",
     "react-final-form": "^4.1.0",
     "storybook-readme": "^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6420,9 +6420,10 @@ got@^8.3.2:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
-govuk-colours@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/govuk-colours/-/govuk-colours-1.0.3.tgz#41d983693626dbaadb05594c5931a51696f79488"
+govuk-colours@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/govuk-colours/-/govuk-colours-1.1.0.tgz#71afae4ed7e9d61c5e230cb61f0f00fa410a76a7"
+  integrity sha512-EcwnP9PsWubmTcsJtLF8w0D5b69j43LwYtSqGyPtO3903J0bbwB2t5ujWZ9UhsbLamuUmigBkNpLItU3/KuFqw==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.15"


### PR DESCRIPTION
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

This PR applies the update of govuk-colours from 1.0.3 to 1.1.0

I'm not too familiar with Lerna so the approach I took was to search and replace the instances of  `"govuk-colours": "^1.0.3"` with `"govuk-colours": "^1.1.0"` in all the package.json files. If there is a better way of doing this do let me know.

I then updated the snapshot files which highlight the colour differences between the existing colours and the new ones from the 1.1.0 update to govuk-colours. 