### PR TITLE
Accessibility compliance: Button focus contrast

### DIFF
--- a/components/button/src/__snapshots__/test.js.snap
+++ b/components/button/src/__snapshots__/test.js.snap
@@ -27,7 +27,7 @@ exports[`button basics matches snapshot 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #A89200;
   outline-offset: 0;
 }
 
@@ -146,7 +146,7 @@ exports[`button basics matches snapshot 1`] = `
             "rules": Array [
               [Function],
               "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #A89200; outline-offset: 0;
 }",
               [Function],
               [Function],
@@ -204,7 +204,7 @@ exports[`button blue button, with automatic colours matches snapshot 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #A89200;
   outline-offset: 0;
 }
 
@@ -327,7 +327,7 @@ exports[`button blue button, with automatic colours matches snapshot 1`] = `
               "rules": Array [
                 [Function],
                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #A89200; outline-offset: 0;
 }",
                 [Function],
                 [Function],
@@ -398,7 +398,7 @@ exports[`button button with icon matches snapshot 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #A89200;
   outline-offset: 0;
 }
 
@@ -537,7 +537,7 @@ exports[`button button with icon matches snapshot 1`] = `
               "rules": Array [
                 [Function],
                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #A89200; outline-offset: 0;
 }",
                 [Function],
                 [Function],
@@ -670,7 +670,7 @@ exports[`button custom colours matches snapshot 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #A89200;
   outline-offset: 0;
 }
 
@@ -802,7 +802,7 @@ exports[`button custom colours matches snapshot 1`] = `
               "rules": Array [
                 [Function],
                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #A89200; outline-offset: 0;
 }",
                 [Function],
                 [Function],
@@ -861,7 +861,7 @@ exports[`button disabled matches snapshot 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #A89200;
   outline-offset: 0;
 }
 
@@ -981,7 +981,7 @@ exports[`button disabled matches snapshot 1`] = `
               "rules": Array [
                 [Function],
                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #A89200; outline-offset: 0;
 }",
                 [Function],
                 [Function],
@@ -1040,7 +1040,7 @@ exports[`button start button matches snapshot 1`] = `
 }
 
 .c0:focus {
-  outline: 3px solid #ffbf47;
+  outline: 3px solid #A89200;
   outline-offset: 0;
 }
 
@@ -1160,7 +1160,7 @@ exports[`button start button matches snapshot 1`] = `
               "rules": Array [
                 [Function],
                 "&:focus {
-  outline: 3px solid #ffbf47; outline-offset: 0;
+  outline: 3px solid #A89200; outline-offset: 0;
 }",
                 [Function],
                 [Function],

--- a/components/button/src/index.js
+++ b/components/button/src/index.js
@@ -1,10 +1,19 @@
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { BORDER_WIDTH_FORM_ELEMENT, FOCUSABLE, MEDIA_QUERIES, SPACING_POINTS } from '@govuk-react/constants';
+import { BORDER_WIDTH_FORM_ELEMENT, MEDIA_QUERIES, SPACING_POINTS } from '@govuk-react/constants';
 import { spacing, typography } from '@govuk-react/lib';
 import { BUTTON_COLOUR, BUTTON_COLOUR_DARKEN_15, WHITE } from 'govuk-colours';
 import { darken, stripUnit } from 'polished';
+
+var FOCUS_WIDTH = '3px';
+
+var FOCUSABLE = {
+  '&:focus': {
+    outline: FOCUS_WIDTH + " solid " + "#A89200",
+    outlineOffset: 0
+  }
+};
 
 const BUTTON_SHADOW_SIZE = BORDER_WIDTH_FORM_ELEMENT;
 const RAW_SPACING_2 = SPACING_POINTS[2];

--- a/components/button/src/index.js
+++ b/components/button/src/index.js
@@ -6,13 +6,13 @@ import { spacing, typography } from '@govuk-react/lib';
 import { BUTTON_COLOUR, BUTTON_COLOUR_DARKEN_15, WHITE } from 'govuk-colours';
 import { darken, stripUnit } from 'polished';
 
-var FOCUS_WIDTH = '3px';
+const FOCUS_WIDTH = '3px';
 
-var FOCUSABLE = {
+const FOCUSABLE = {
   '&:focus': {
-    outline: FOCUS_WIDTH + " solid " + "#A89200",
-    outlineOffset: 0
-  }
+    outline: `${FOCUS_WIDTH} solid #A89200`,
+    outlineOffset: 0,
+  },
 };
 
 const BUTTON_SHADOW_SIZE = BORDER_WIDTH_FORM_ELEMENT;


### PR DESCRIPTION
* [ ] Documentation
* [x] Tests
* [] Ready to be merged 

We've had an accessibility report on a website using this control and they highlighted:

The visible focus indicator used on this page does not meet the required colour contrast ratio of 3:1 to pass the WCAG 2.1 success criteria. Clear focus indicators are crucial for low vision, and or, keyboard only users to be able to navigate the page and determine where their focus is on the page. Failing to meet the minimum ratio could mean that users are unable to complete the service without support, leading to confidential information being shared. This focus indicator does not conform with the GOV.UK Design System. 

I have updated the contrast to meet the required contrast ratio but if you prefer, this could be updated on the repository which the Focus colour came from (govuk-colours).
