### PR TITLE
Remove WithDocsCustom from tabs examples

### DIFF
--- a/components/tabs/src/stories.js
+++ b/components/tabs/src/stories.js
@@ -21,8 +21,6 @@ const examples = storiesOf('Tabs/Examples', module);
 stories.addDecorator(withDocsCustom(ReadMe));
 stories.addDecorator(withKnobs);
 
-examples.addDecorator(withDocsCustom());
-
 stories.add('Component default', () => <TableTabs />);
 
 examples.add('simple', () => <SimpleTabs />);


### PR DESCRIPTION
I don't think it's doing anything and we don't do it anywhere else

Fixes #635