### PR TITLE
Don't return error if can't publish module

### DIFF
--- a/scripts/npmPublish.sh
+++ b/scripts/npmPublish.sh
@@ -2,7 +2,7 @@
 # detect pre-release based on version including a '-' character
 PRERELEASE=$(node -e 'console.log(require(`${process.env.LERNA_ROOT_PATH}/lerna.json`).version.split("-").length > 1)')
 if [ "$PRERELEASE" = "true" ]; then
-  yarn can-npm-publish --verbose && npm publish --tag next
+  yarn can-npm-publish --verbose && npm publish --tag next || true
 else
-  yarn can-npm-publish --verbose && npm publish
+  yarn can-npm-publish --verbose && npm publish || true
 fi


### PR DESCRIPTION
e.g. if @govuk-react/images has not been bumped and is already published, don't report failure on ci