### PR TITLE
Regenerate docs

### DIFF
--- a/components/paragraph/README.md
+++ b/components/paragraph/README.md
@@ -64,7 +64,7 @@ const ReactRouterLinkRenderer = ({ href, children }) => (
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
  `children` |  | ```''``` | node | Text content supporting markdown
- `linkRenderer` |  | ```props => <Link {...props} />``` | func | 
+ `linkRenderer` |  | ```(props) => <Link {...props} />``` | func | 
  `supportingText` |  | ```false``` | bool | Is this paragraph supporting text for another element?
 
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "start": "cd packages/storybook && npm start",
     "bootstrap": "lerna bootstrap",
-    "docs": "doc-component './components/**/lib/index.js' './API.md'",
+    "docs": "yarn docs:components && doc-component './components/**/lib/index.js' './API.md'",
     "docs:components": "lerna run docs --parallel",
     "eslint": "eslint \"./{components,packages}/*/src/**/*.js\"",
     "eslint:fix": "eslint --fix \"./{components,packages}/*/src/**/*.js\"",


### PR DESCRIPTION
We now generate sub docs on `yarn docs` to ensure this step isn't missed.