### PR TITLE
Only underline backlink if it has an href

### DIFF
--- a/components/back-link/src/index.js
+++ b/components/back-link/src/index.js
@@ -16,8 +16,10 @@ const Anchor = styled('a')(
     marginTop: SPACING_POINTS[3],
     marginBottom: SPACING_POINTS[3],
     paddingLeft: '14px',
-    borderBottom: `1px solid ${BLACK}`,
     textDecoration: 'none',
+    '&[href]': {
+      borderBottom: `1px solid ${BLACK}`,
+    },
     '::before': {
       ...shape.arrow({ direction: 'left', base: 10, height: 6 }),
 


### PR DESCRIPTION
Fixes:  #449

Revist: #1171

To match: https://github.com/alphagov/govuk-frontend/pull/1620

React Router would provide an href.

If no href is provided, the absense of an underline would be a prompt for the developer to add one.

This mirrors user agent stylesheets for an anchor.