### PR TITLE
Only publish to GitHub pages on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
       - master
+      - main
 jobs:
   build-lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,8 +1,8 @@
 name: GitHub Pages
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     
     - name: Read .nvmrc
       run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"

--- a/components/back-link/package.json
+++ b/components/back-link/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/back-link",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/back-link",
   "description": "Styled anchor with left-pointing triangle, children rendered as text and optional click handler.",
   "private": false,
   "publishConfig": {

--- a/components/breadcrumbs/package.json
+++ b/components/breadcrumbs/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/breadcrumbs",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/breadcrumbs",
   "description": "Displays a list of breadcrumbs.",
   "private": false,
   "publishConfig": {

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -22,7 +22,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/button",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/button",
   "description": "Styled button component with configurable properties.",
   "private": false,
   "publishConfig": {

--- a/components/caption/package.json
+++ b/components/caption/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Steve Sims",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/caption",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/caption",
   "description": "Renders children passed inside a styled span element.",
   "private": false,
   "publishConfig": {

--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -22,7 +22,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/checkbox",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/checkbox",
   "description": "Styled checkbox component, also displaying label.",
   "private": false,
   "publishConfig": {

--- a/components/date-field/package.json
+++ b/components/date-field/package.json
@@ -26,7 +26,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/date-field",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/date-field",
   "description": "Date field component displaying day, month and year and featuring several configurable options.",
   "private": false,
   "publishConfig": {

--- a/components/details/package.json
+++ b/components/details/package.json
@@ -21,7 +21,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/details",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/details",
   "description": "Renders a styled details element along with summary from prop and children rendered as contents.",
   "private": false,
   "publishConfig": {

--- a/components/document-footer-metadata/package.json
+++ b/components/document-footer-metadata/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/document-footer-metadata",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/document-footer-metadata",
   "description": "Renders styled document footer metadata from props provided.",
   "private": false,
   "publishConfig": {

--- a/components/error-summary/package.json
+++ b/components/error-summary/package.json
@@ -27,7 +27,7 @@
   "module": "es/index.js",
   "author": "Tarandeep Singh Chauhan",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/error-summary",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/error-summary",
   "description": "Notice used to display form errors to user - also includes anchors to jump to relevant form sections.",
   "private": false,
   "publishConfig": {

--- a/components/error-text/package.json
+++ b/components/error-text/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/error-text",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/error-text",
   "description": "Renders a styled span element containing children provided.",
   "private": false,
   "publishConfig": {

--- a/components/fieldset/package.json
+++ b/components/fieldset/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Steve Sims",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/fieldset",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/fieldset",
   "description": "govuk-react Fieldset component.",
   "private": false,
   "publishConfig": {

--- a/components/file-upload/package.json
+++ b/components/file-upload/package.json
@@ -22,7 +22,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/file-upload",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/file-upload",
   "description": "File input component with label expected as children.",
   "private": false,
   "publishConfig": {

--- a/components/footer/package.json
+++ b/components/footer/package.json
@@ -24,7 +24,7 @@
   "module": "es/index.js",
   "author": "John Robertson",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/footer",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/footer",
   "description": "govuk-react Footer component.",
   "private": false,
   "publishConfig": {

--- a/components/form-group/package.json
+++ b/components/form-group/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Steve Sims",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/form-group",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/form-group",
   "description": "govuk-react FormGroup component.",
   "private": false,
   "publishConfig": {

--- a/components/global-style/package.json
+++ b/components/global-style/package.json
@@ -15,7 +15,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/global-style",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/global-style",
   "description": "A Styled Component to apply global style for use with govuk-react.",
   "private": false,
   "publishConfig": {

--- a/components/grid-col/package.json
+++ b/components/grid-col/package.json
@@ -19,7 +19,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/grid-col",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/grid-col",
   "description": "GridCol component for use inside GridRow component - includes media query breakpoints.",
   "private": false,
   "publishConfig": {

--- a/components/grid-row/package.json
+++ b/components/grid-row/package.json
@@ -19,7 +19,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/grid-row",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/grid-row",
   "description": "GridRow component for use around GridCol components - includes media query breakpoints.",
   "private": false,
   "publishConfig": {

--- a/components/heading/package.json
+++ b/components/heading/package.json
@@ -19,7 +19,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/heading",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/heading",
   "description": "Outputs a styled heading tag of provided level, rendering children as contents.",
   "private": false,
   "publishConfig": {

--- a/components/hint-text/package.json
+++ b/components/hint-text/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/hint-text",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/hint-text",
   "description": "Renders a styled span element with children provided.",
   "private": false,
   "publishConfig": {

--- a/components/input-field/package.json
+++ b/components/input-field/package.json
@@ -24,7 +24,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/input-field",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/input-field",
   "description": "Styled composite component displaying an input with a label and hint text and error text depending on props.",
   "private": false,
   "publishConfig": {

--- a/components/input/package.json
+++ b/components/input/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/input",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/input",
   "description": "Styled input component with optional type prop, defaulting to 'text'.",
   "private": false,
   "publishConfig": {

--- a/components/inset-text/package.json
+++ b/components/inset-text/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/inset-text",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/inset-text",
   "description": "Renders a styled div containing children with a left hand border, wide or narrow depending on prop passed.",
   "private": false,
   "publishConfig": {

--- a/components/label-text/package.json
+++ b/components/label-text/package.json
@@ -18,7 +18,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/label-text",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/label-text",
   "description": "Styled span element with children displayed as text.",
   "private": false,
   "publishConfig": {

--- a/components/label/package.json
+++ b/components/label/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/label",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/label",
   "description": "Styled label with children displayed as text.",
   "private": false,
   "publishConfig": {

--- a/components/layout/package.json
+++ b/components/layout/package.json
@@ -18,7 +18,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/layout",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/layout",
   "description": "Component intended to surround grid layouts but now no longer used/required.",
   "private": false,
   "publishConfig": {

--- a/components/lead-paragraph/package.json
+++ b/components/lead-paragraph/package.json
@@ -18,7 +18,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/lead-paragraph",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/lead-paragraph",
   "description": "Renders children passed inside a styled paragraph element.",
   "private": false,
   "publishConfig": {

--- a/components/link/package.json
+++ b/components/link/package.json
@@ -19,7 +19,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/link",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/link",
   "description": "govuk-react Link component.",
   "private": false,
   "publishConfig": {

--- a/components/list-item/package.json
+++ b/components/list-item/package.json
@@ -19,7 +19,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/list-item",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/list-item",
   "description": "Renders a styled list item containing children passed.",
   "private": false,
   "publishConfig": {

--- a/components/list-navigation/package.json
+++ b/components/list-navigation/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/list-navigation",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/list-navigation",
   "description": "Renders ListItems in an UnorderedList from children sent, with optional list style type.",
   "private": false,
   "publishConfig": {

--- a/components/loading-box/package.json
+++ b/components/loading-box/package.json
@@ -25,7 +25,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/loading-box",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/loading-box",
   "description": "Absolutely positioned loading overlay with spinner and numerous configurable options.",
   "private": false,
   "publishConfig": {

--- a/components/main/package.json
+++ b/components/main/package.json
@@ -18,7 +18,7 @@
   "module": "es/index.js",
   "author": "Toby Brancher",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/main",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/main",
   "description": "Styled container which aligns to topNav component, is centered, and provides top padding.",
   "private": false,
   "publishConfig": {

--- a/components/multi-choice/package.json
+++ b/components/multi-choice/package.json
@@ -23,7 +23,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/multi-choice",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/multi-choice",
   "description": "Styled container for a group of radio buttons (the children), also accepting label, meta and hint props.",
   "private": false,
   "publishConfig": {

--- a/components/ordered-list/package.json
+++ b/components/ordered-list/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/ordered-list",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/ordered-list",
   "description": "Renders an ordered list containing children passed - also supports listStyleType prop.",
   "private": false,
   "publishConfig": {

--- a/components/page/package.json
+++ b/components/page/package.json
@@ -21,7 +21,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/page",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/page",
   "description": "Provides Page wrapper components.",
   "private": false,
   "publishConfig": {

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -21,7 +21,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/pagination",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/pagination",
   "description": "Renders a styled list using flexbox, along with PaginationAnchor items expected to be provided as children.",
   "private": false,
   "publishConfig": {

--- a/components/panel/package.json
+++ b/components/panel/package.json
@@ -21,7 +21,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/panel",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/panel",
   "description": "Styled panel accepting a heading string and an array of body text as strings or mark-up.",
   "private": false,
   "publishConfig": {

--- a/components/paragraph/package.json
+++ b/components/paragraph/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/paragraph",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/paragraph",
   "description": "Renders a styled paragraph around children, also supporting and styling sub-elements from markdown and accepting several optional props.",
   "private": false,
   "publishConfig": {

--- a/components/phase-banner/package.json
+++ b/components/phase-banner/package.json
@@ -21,7 +21,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/phase-banner",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/phase-banner",
   "description": "Banner with solid background and bold text, rendered from children.",
   "private": false,
   "publishConfig": {

--- a/components/radio/package.json
+++ b/components/radio/package.json
@@ -21,7 +21,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/radio",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/radio",
   "description": "Styled radio button with several configurable props.",
   "private": false,
   "publishConfig": {

--- a/components/related-items/package.json
+++ b/components/related-items/package.json
@@ -24,6 +24,6 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "author": "Alasdair McLeay",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/related-items",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/related-items",
   "description": "Container which expects to receive a heading and list and styles them accordingly."
 }

--- a/components/search-box/package.json
+++ b/components/search-box/package.json
@@ -21,7 +21,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/search-box",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/search-box",
   "description": "Styled input and button, also accepting placeholder text.",
   "private": false,
   "publishConfig": {

--- a/components/section-break/package.json
+++ b/components/section-break/package.json
@@ -19,7 +19,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/section-break",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/section-break",
   "description": "govuk-react SectionBreak component.",
   "private": false,
   "publishConfig": {

--- a/components/select/package.json
+++ b/components/select/package.json
@@ -24,7 +24,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/select",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/select",
   "description": "Styled select menu, taking its options as children and with various configurable parameters via props.",
   "private": false,
   "publishConfig": {

--- a/components/skip-link/package.json
+++ b/components/skip-link/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/skip-link",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/skip-link",
   "description": "govuk-react SkipLink component.",
   "private": false,
   "publishConfig": {

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/table",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/table",
   "description": "A styled table supporting a 'construction kit' approach and rendering children as constituent parts.",
   "private": false,
   "publishConfig": {

--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -20,7 +20,7 @@
   "module": "es/index.js",
   "author": "David Murdoch",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/tabs",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/tabs",
   "description": "govuk-react Tabs component.",
   "private": false,
   "publishConfig": {

--- a/components/tag/package.json
+++ b/components/tag/package.json
@@ -19,7 +19,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/tag",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/tag",
   "description": "Badge with solid background and bold text, rendered from children.",
   "private": false,
   "publishConfig": {

--- a/components/text-area/package.json
+++ b/components/text-area/package.json
@@ -24,7 +24,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/text-area",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/text-area",
   "description": "Styled textarea supporting additional parameters via props.",
   "private": false,
   "publishConfig": {

--- a/components/top-nav/package.json
+++ b/components/top-nav/package.json
@@ -25,7 +25,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/top-nav",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/top-nav",
   "description": "Styled top navigation header with numerous constituent parts input as props.",
   "private": false,
   "publishConfig": {

--- a/components/unordered-list/package.json
+++ b/components/unordered-list/package.json
@@ -18,7 +18,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/unordered-list",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/unordered-list",
   "description": "Renders an unordered list containing children passed - also supports listStyleType prop.",
   "private": false,
   "publishConfig": {

--- a/components/visually-hidden/package.json
+++ b/components/visually-hidden/package.json
@@ -19,7 +19,7 @@
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/visually-hidden",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/visually-hidden",
   "description": "govuk-react VisuallyHidden component.",
   "private": false,
   "publishConfig": {

--- a/components/warning-text/package.json
+++ b/components/warning-text/package.json
@@ -21,7 +21,7 @@
   "module": "es/index.js",
   "author": "Gavin Orland",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/warning-text",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/warning-text",
   "description": "Styles children passed within a div and strong element, also positioning an 'Important' icon to the left.",
   "private": false,
   "publishConfig": {

--- a/scripts/createComponent.js
+++ b/scripts/createComponent.js
@@ -50,7 +50,7 @@ const packageJson = () => {
   "module": "es/index.js",
   "author": "Alasdair McLeay",
   "license": "MIT",
-  "homepage": "https://github.com/govuk-react/govuk-react/tree/master/components/${componentFolderName}",
+  "homepage": "https://github.com/govuk-react/govuk-react/tree/main/components/${componentFolderName}",
   "description": "govuk-react ${componentName} component.",
   "private": false,
   "publishConfig": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # requires https://hub.github.com
 git remote get-url origin | grep -q 'govuk-react/govuk-react' || exit 1 # ensure origin doesn't point to a fork
-git checkout -b release/next origin/master # make a new branch for next version from master
+git checkout -b release/next origin/main # make a new branch for next version from main
 git fetch --tags # lerna uses tags to determine what has changed, we need to make sure we have all tags locally
 yarn lerna publish --skip-npm # update version numbers
 VERSION=$(node -e 'console.log(require("./lerna.json").version)') # get new version number


### PR DESCRIPTION
Only publish to GitHub pages on tags.

This is so that our documentation on GitHub pages shows the _released_ version and not what is in development.