### PR TITLE
Review use of forwardRef

### DIFF
--- a/API.md
+++ b/API.md
@@ -295,7 +295,7 @@ With custom input name props
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
  `children` | true | `````` | node | 
- `defaultValues` |  | ```{   day: undefined,   month: undefined,   year: undefined, }``` | custom | 
+ `defaultValues` |  | ```{   day: undefined,   month: undefined,   year: undefined, }``` | shape[object Object] | 
  `errorText` |  | ```undefined``` | string | Error text
  `hintText` |  | ```undefined``` | string | Optional hint text
  `input` |  | ```undefined``` | shape[object Object] | Properties that are sent to the input, matching final form and redux form input type
@@ -637,6 +637,8 @@ Prop | Required | Default | Type | Description
  `children` | true | `````` | node | 
  `hint` |  | ```undefined``` | string | Optional hint text
  `meta` |  | ```{}``` | shape[object Object] | Final form meta object, pending adjustment/removal
+ `name` |  | ```undefined``` | string | 
+ `onChange` |  | ```undefined``` | func | 
 
 
 

--- a/components/date-field/README.md
+++ b/components/date-field/README.md
@@ -58,7 +58,7 @@ With custom input name props
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
  `children` | true | `````` | node | 
- `defaultValues` |  | ```{   day: undefined,   month: undefined,   year: undefined, }``` | custom | 
+ `defaultValues` |  | ```{   day: undefined,   month: undefined,   year: undefined, }``` | shape[object Object] | 
  `errorText` |  | ```undefined``` | string | Error text
  `hintText` |  | ```undefined``` | string | Optional hint text
  `input` |  | ```undefined``` | shape[object Object] | Properties that are sent to the input, matching final form and redux form input type

--- a/components/file-upload/README.md
+++ b/components/file-upload/README.md
@@ -58,5 +58,7 @@ Prop | Required | Default | Type | Description
  `children` | true | `````` | node | 
  `hint` |  | ```undefined``` | string | Optional hint text
  `meta` |  | ```{}``` | shape[object Object] | Final form meta object, pending adjustment/removal
+ `name` |  | ```undefined``` | string | 
+ `onChange` |  | ```undefined``` | func | 
 
 

--- a/components/input-field/src/__snapshots__/test.tsx.snap
+++ b/components/input-field/src/__snapshots__/test.tsx.snap
@@ -120,7 +120,7 @@ exports[`InputField matches wrapper snapshot: wrapper mount 1`] = `
   }
 }
 
-<ForwardRef
+<InputField
   input={Object {}}
   meta={Object {}}
 >
@@ -159,5 +159,5 @@ exports[`InputField matches wrapper snapshot: wrapper mount 1`] = `
       </label>
     </src__StyledLabel>
   </Label>
-</ForwardRef>
+</InputField>
 `;

--- a/components/input-field/src/index.tsx
+++ b/components/input-field/src/index.tsx
@@ -62,14 +62,14 @@ import Input from '@govuk-react/input';
  * - https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/components/input/_input.scss
  * - https://github.com/alphagov/govuk_elements/blob/master/assets/sass/elements/_forms.scss
  */
-const InputField = React.forwardRef(({ meta, children, hint, input, ...props }, ref) => (
+const InputField = ({ meta, children, hint, input, ...props }) => (
   <Label {...props} error={meta.touched && !!meta.error}>
     <LabelText>{children}</LabelText>
     {hint && <HintText>{hint}</HintText>}
     {meta.touched && meta.error && <ErrorText>{meta.error}</ErrorText>}
-    <Input error={meta.touched && !!meta.error} ref={ref} {...input} />
+    <Input error={meta.touched && !!meta.error} {...input} />
   </Label>
-));
+);
 
 InputField.defaultProps = {
   hint: undefined,

--- a/components/search-box/src/__snapshots__/test.tsx.snap
+++ b/components/search-box/src/__snapshots__/test.tsx.snap
@@ -66,7 +66,7 @@ exports[`SearchBox matches wrapper snapshot: wrapper mount 1`] = `
   }
 }
 
-<SearchBox>
+<ForwardRef>
   <src__StyledSearchBox>
     <div
       className="c0"
@@ -124,5 +124,5 @@ exports[`SearchBox matches wrapper snapshot: wrapper mount 1`] = `
       </Button>
     </div>
   </src__StyledSearchBox>
-</SearchBox>
+</ForwardRef>
 `;

--- a/components/search-box/src/index.tsx
+++ b/components/search-box/src/index.tsx
@@ -94,7 +94,7 @@ const StyledSearchBox = styled('div')(
  * - https://govuk-static.herokuapp.com/component-guide/search
  *
  */
-const SearchBox = (props) => <StyledSearchBox {...props} />;
+const SearchBox = React.forwardRef((props, ref) => <StyledSearchBox {...props} ref={ref} />);
 
 SearchBox.Input = Input;
 SearchBox.Button = Button;

--- a/packages/example-application/src/forms/react-hook-form.tsx
+++ b/packages/example-application/src/forms/react-hook-form.tsx
@@ -141,7 +141,6 @@ const ReactHookForm = () => {
               <DateField
                 errorText={submitCount > 0 ? errors?.dob?.message : undefined}
                 input={register('dob', {
-                  // TODO: should check for valid date via extracted and shared function
                   validate: validateDateOfBirth,
                 })}
               >


### PR DESCRIPTION
Fixes  #921

> components that take an input prop and spread it to the input, don't need forwardRef as it can be done via the input prop.
>
> I'll remove it for InputField, add it to SearchBox and not touch Select and TextArea

https://github.com/govuk-react/govuk-react/issues/921#issuecomment-913180653

