### PR TITLE
TypeScript: Enable explicit-module-boundary-types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,7 +54,6 @@ module.exports = {
       files: ['**/*.ts', '**/*.tsx'],
       extends: ['plugin:@typescript-eslint/recommended'],
       rules: {
-        '@typescript-eslint/explicit-module-boundary-types': 0,
         '@typescript-eslint/no-explicit-any': 0,
       },
     },

--- a/API.md
+++ b/API.md
@@ -36,9 +36,11 @@ With `href` attribute
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` |  | ```'Back'``` | string | Text that will appear in the back link
- `href` |  | ```undefined``` | string | 
- `onClick` |  | ```undefined``` | func | Custom function to run when the `onClick` event is fired
+ `as` |  | ```undefined``` |  | 
+ `children` |  | ```'Back'``` |  | 
+ `href` |  | ```undefined``` |  | 
+ `onClick` |  | ```undefined``` |  | 
+ `to` |  | ```undefined``` |  | 
 
 
 
@@ -1248,8 +1250,8 @@ import { Label, LabelText, HintText, ErrorText, Input } from 'govuk-react'
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true | `````` | node | Text for the label
- `error` |  | ```false``` | bool | Apply error state styling to the component
+ `children` | true | `````` |  | Text for the label
+ `error` |  | ```false``` |  | Apply error state styling to the component
 
 
 

--- a/components/back-link/README.md
+++ b/components/back-link/README.md
@@ -36,8 +36,10 @@ With `href` attribute
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` |  | ```'Back'``` | string | Text that will appear in the back link
- `href` |  | ```undefined``` | string | 
- `onClick` |  | ```undefined``` | func | Custom function to run when the `onClick` event is fired
+ `as` |  | ```undefined``` |  | 
+ `children` |  | ```'Back'``` |  | 
+ `href` |  | ```undefined``` |  | 
+ `onClick` |  | ```undefined``` |  | 
+ `to` |  | ```undefined``` |  | 
 
 

--- a/components/back-link/src/index.tsx
+++ b/components/back-link/src/index.tsx
@@ -62,7 +62,7 @@ const Anchor = styled('a')(
  * - https://github.com/alphagov/govuk-frontend/tree/main/src/govuk/components/back-link
  *
  */
-const BackLink = (props: BackLinkProps) => <Anchor {...props} />;
+const BackLink: React.FC<BackLinkProps> = (props) => <Anchor {...props} />;
 
 interface BackLinkProps {
   /** Text that will appear in the back link */

--- a/components/label/README.md
+++ b/components/label/README.md
@@ -31,7 +31,7 @@ import { Label, LabelText, HintText, ErrorText, Input } from 'govuk-react'
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true | `````` | node | Text for the label
- `error` |  | ```false``` | bool | Apply error state styling to the component
+ `children` | true | `````` |  | Text for the label
+ `error` |  | ```false``` |  | Apply error state styling to the component
 
 

--- a/components/tabs/src/atoms/tab/index.tsx
+++ b/components/tabs/src/atoms/tab/index.tsx
@@ -64,7 +64,7 @@ const StyledHyperLink = styled('a')(
   })
 );
 
-const Tab = (props: TabProps) => (
+const Tab: React.FC<TabProps> = (props) => (
   <StyledListItem>
     <StyledHyperLink {...props} />
   </StyledListItem>
@@ -76,18 +76,11 @@ Tab.defaultProps = {
   // TODO: #953
   to: undefined,
   href: undefined,
-  onClick: undefined,
 };
 
 interface TabProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   /** Different stylings for the Tab displaying content */
   selected?: boolean;
-  /** Join the panel and header together with corresponding panel id. Required for mobile use  */
-  href?: string;
-  /** The content to display within the Tab Header */
-  children: React.ReactNode;
-  /** The function to passed to prevent default href behaviour */
-  onClick?: (...args: unknown[]) => unknown;
 
   as?: React.ElementType;
   // TODO: #953

--- a/components/tabs/src/fixtures.tsx
+++ b/components/tabs/src/fixtures.tsx
@@ -12,13 +12,13 @@ import Tabs from '.';
 
 const flip2dArray = (prev, next) => next.map((item, index) => [...(prev[index] || []), next[index]]);
 
-function setTabIndex(tabIndex) {
+function setTabIndex(tabIndex: number): void {
   return this.setState({
     tabIndex,
   });
 }
 
-function handleClick({ event: e, index }) {
+function handleClick({ event: e, index }: { event: React.MouseEvent<HTMLAnchorElement>; index: number }): void {
   /* eslint-disable-next-line no-undef */
   const mql = window.matchMedia(`(min-width: ${BREAKPOINTS.TABLET})`);
   if (mql.matches) {
@@ -78,7 +78,7 @@ const arrTabularTabs = [
   },
 ];
 
-class TableTabs extends Component<any, { tabIndex: number }> {
+class TableTabs extends Component<Record<string, never>, { tabIndex: number }> {
   static defaultProps = sharedDefaultProps;
 
   static propTypes = sharedPropTypes;
@@ -87,14 +87,14 @@ class TableTabs extends Component<any, { tabIndex: number }> {
 
   handleClick;
 
-  constructor(props) {
+  constructor(props: Record<string, never>) {
     super(props);
     this.state = { tabIndex: props.defaultIndex };
     this.setTabIndex = setTabIndex.bind(this);
     this.handleClick = handleClick.bind(this);
   }
 
-  render() {
+  render(): JSX.Element {
     const { tabIndex } = this.state;
     return (
       <Tabs>
@@ -131,7 +131,7 @@ class TableTabs extends Component<any, { tabIndex: number }> {
 }
 
 /* eslint-disable-next-line react/no-multi-comp */
-class SimpleTabs extends Component<any, { tabIndex: number }> {
+class SimpleTabs extends Component<Record<string, never>, { tabIndex: number }> {
   static defaultProps = sharedDefaultProps;
 
   static propTypes = sharedPropTypes;
@@ -140,14 +140,14 @@ class SimpleTabs extends Component<any, { tabIndex: number }> {
 
   handleClick;
 
-  constructor(props) {
+  constructor(props: Record<string, never>) {
     super(props);
     this.state = { tabIndex: props.defaultIndex };
     this.setTabIndex = setTabIndex.bind(this);
     this.handleClick = handleClick.bind(this);
   }
 
-  render() {
+  render(): JSX.Element {
     const { tabIndex } = this.state;
     return (
       <Tabs>
@@ -193,7 +193,7 @@ const arrSimpleMapped = [
 ];
 
 /* eslint-disable-next-line react/no-multi-comp */
-class SimpleMapTabs extends Component<any, { tabIndex: number }> {
+class SimpleMapTabs extends Component<Record<string, never>, { tabIndex: number }> {
   static defaultProps = sharedDefaultProps;
 
   static propTypes = sharedPropTypes;
@@ -202,14 +202,14 @@ class SimpleMapTabs extends Component<any, { tabIndex: number }> {
 
   handleClick;
 
-  constructor(props) {
+  constructor(props: Record<string, never>) {
     super(props);
     this.state = { tabIndex: props.defaultIndex };
     this.setTabIndex = setTabIndex.bind(this);
     this.handleClick = handleClick.bind(this);
   }
 
-  render() {
+  render(): JSX.Element {
     const { tabIndex } = this.state;
     return (
       <Tabs>
@@ -259,13 +259,13 @@ class ProposedClassPropertiesPlugin extends Component<{ defaultIndex: number }, 
 
   handleClick = handleClick;
 
-  constructor(props) {
+  constructor(props: { defaultIndex: number }) {
     super(props);
     const { defaultIndex } = this.props;
     this.state = { tabIndex: defaultIndex };
   }
 
-  render() {
+  render(): JSX.Element {
     const { tabIndex } = this.state;
     return (
       <Tabs>
@@ -294,7 +294,7 @@ class ProposedClassPropertiesPlugin extends Component<{ defaultIndex: number }, 
   }
 }
 
-const HooksExample = ({ defaultIndex }) => {
+const HooksExample: React.FC<{ defaultIndex: number }> = ({ defaultIndex }) => {
   const [tabIndex, setHooksTabIndex] = React.useState(defaultIndex);
 
   const handleTabChange = (newTabIndex) => setHooksTabIndex(newTabIndex);
@@ -410,7 +410,7 @@ const RouterTabs = ({
   );
 };
 
-const ReactRouterExample = () => (
+const ReactRouterExample: React.FC = () => (
   <MemoryRouter>
     <div>
       <Route path="/:section?" component={RouterTabs} />
@@ -444,7 +444,7 @@ const RouterTabsSSR = ({
   </Tabs>
 );
 
-const ReactRouterSSRExample = () => (
+const ReactRouterSSRExample: React.FC = () => (
   <MemoryRouter>
     <div>
       <Route path="/:section?" component={RouterTabsSSR} />
@@ -493,7 +493,7 @@ const RouterTabsSSRSinglePanel = ({
   </Tabs>
 );
 
-const ReactRouterSSRSinglePanelExample = () => (
+const ReactRouterSSRSinglePanelExample: React.FC = () => (
   <MemoryRouter>
     <div>
       <Route path="/:section?" component={RouterTabsSSRSinglePanel} />

--- a/components/top-nav/src/atoms/menu-button/index.tsx
+++ b/components/top-nav/src/atoms/menu-button/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { MouseEventHandler } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { MEDIA_QUERIES } from '@govuk-react/constants';
@@ -35,7 +35,11 @@ const ButtonIcon = styled('div')(({ open }) => ({
   borderBottomColor: 'inherit',
 }));
 
-const MenuButton = ({ title, open, onClick }) => (
+const MenuButton: React.FC<{ title: string; open: boolean; onClick: MouseEventHandler<HTMLButtonElement> }> = ({
+  title,
+  open,
+  onClick,
+}) => (
   <Button onClick={onClick} htmlFor="govuk-react-menu-button">
     <ButtonText>{title}</ButtonText>
     <ButtonIcon open={open} />

--- a/components/top-nav/src/atoms/menu-button/index.tsx
+++ b/components/top-nav/src/atoms/menu-button/index.tsx
@@ -1,5 +1,4 @@
 import React, { MouseEventHandler } from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { MEDIA_QUERIES } from '@govuk-react/constants';
 
@@ -35,22 +34,19 @@ const ButtonIcon = styled('div')(({ open }) => ({
   borderBottomColor: 'inherit',
 }));
 
-const MenuButton: React.FC<{ title: string; open: boolean; onClick: MouseEventHandler<HTMLButtonElement> }> = ({
-  title,
-  open,
-  onClick,
-}) => (
+const MenuButton: React.FC<MenuButtonProps> = ({ title, open, onClick }: MenuButtonProps) => (
   <Button onClick={onClick} htmlFor="govuk-react-menu-button">
     <ButtonText>{title}</ButtonText>
     <ButtonIcon open={open} />
   </Button>
 );
 
-MenuButton.propTypes = {
-  title: PropTypes.string,
-  open: PropTypes.bool,
-  onClick: PropTypes.func,
-};
+interface MenuButtonProps {
+  title?: string;
+  open?: boolean;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+}
+
 MenuButton.defaultProps = {
   title: 'Menu',
   open: false,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:debug": "node --inspect-brk ./node_modules/.bin/jest --runInBand",
     "test:snapshot": "yarn test:unit -u",
     "test:unit": "jest",
-    "test": "cross-env CI=true yarn test:unit --coverage && yarn eslint",
+    "test:types": "tsc --noEmit -p ./tsconfig.json",
+    "test": "cross-env CI=true yarn test:unit --coverage && yarn eslint && yarn test:types",
     "watch:es": "cross-env BABEL_ENV=es lerna exec --ignore @govuk-react/images --parallel -- babel src -x .js,jsx,.ts,.tsx -d es -w --source-maps",
     "watch:lib": "lerna exec --ignore @govuk-react/images --parallel -- babel src -x .js,jsx,.ts,.tsx -d lib -w --source-maps",
     "watch": "yarn watch:lib"

--- a/packages/api-docs/src/index.tsx
+++ b/packages/api-docs/src/index.tsx
@@ -83,7 +83,7 @@ function dequote(string) {
   return string.replace(/^'(.*)'$/, '$1');
 }
 
-async function apiDocs(relDir, outputMd) {
+async function apiDocs(relDir: string, outputMd: string): Promise<void> {
   const relDirNoQuotation = dequote(relDir);
   const outputMdNoQuotation = dequote(outputMd);
 

--- a/packages/example-application/src/forms/components/results.tsx
+++ b/packages/example-application/src/forms/components/results.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import * as GovUK from 'govuk-react';
 import { Link } from 'react-router-dom';
 
-const Results = ({
+const Results: React.FC<ResultsProps> = ({
   backLink,
   onBackClick,
   firstName,


### PR DESCRIPTION
Fixes #952 (combined with #972)

Enabling this results in almost 400 warnings, but does fail on CI.

These warnings will be used as part of #949 at which point they should hopefully be drastically reduced and any remaining warnings can be tackled at that point if needed.