### PR TITLE
Set storybook to be based on light theme

### DIFF
--- a/packages/storybook/.storybook/manager.js
+++ b/packages/storybook/.storybook/manager.js
@@ -3,6 +3,7 @@ import { addons } from '@storybook/addons';
 import { create } from '@storybook/theming';
 
 const theme = create({
+  base: 'light',
   brandTitle: 'govuk-react',
   sortStoriesByKind: true,
   brandUrl: 'https://github.com/govuk-react/govuk-react',


### PR DESCRIPTION
If your OS (such as macOS) is set to use the dark theme, some browsers (like Firefox) pass this through to Storybook which will then use the dark theme as default. This means components will then not have a white background when viewing them within Storybook.

This PR sets the base theme to be the `light` Storybook theme, regardless of what your OS setting is, as the components are meant to be placed on a white background.

Changed from:

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/9681/141113191-9c7f0646-6d61-4df3-bd8a-8cc122e30df0.png">

To:

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/9681/141113227-97ff7e4a-94ed-456f-bd58-47a1facb5a61.png">


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
