### PR TITLE
Fix radio button white-dot bug

### DIFF
--- a/components/radio/src/__snapshots__/test.tsx.snap
+++ b/components/radio/src/__snapshots__/test.tsx.snap
@@ -86,6 +86,7 @@ exports[`Radio can render with hint text: hint text 1`] = `
   height: 0;
   border: 10px solid;
   border-radius: 50%;
+  background: currentColor;
   opacity: 0;
 }
 
@@ -240,6 +241,7 @@ exports[`Radio disabled: disabled 1`] = `
   height: 0;
   border: 10px solid;
   border-radius: 50%;
+  background: currentColor;
   opacity: 0;
 }
 
@@ -369,6 +371,7 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   height: 0;
   border: 10px solid;
   border-radius: 50%;
+  background: currentColor;
   opacity: 0;
 }
 
@@ -506,6 +509,7 @@ exports[`Radio matches snapshot: standard mount 1`] = `
   height: 0;
   border: 10px solid;
   border-radius: 50%;
+  background: currentColor;
   opacity: 0;
 }
 

--- a/components/radio/src/index.tsx
+++ b/components/radio/src/index.tsx
@@ -101,6 +101,7 @@ const LabelText = styled('span')({
     height: 0,
     border: `${SPACING_POINTS[2]}px solid`,
     borderRadius: '50%',
+    background: 'currentColor',
     opacity: 0,
   },
 });


### PR DESCRIPTION
**Checklist**:

* [x] Documentation (N/A)
* [x] Tests
* [x] Ready to be merged

**Motivation**:

Fixes #378. I'm not sure it was ever previously fixed - while the bug went away for most people, at different zoom levels browsers can render this weirdly and cause a white dot to appear in the center of the radio circle. In particular, I find this very reproducable in Chrome at 125% and 175% zoom levels. It's common for users with HiDPI displays for their browser to automatically scale things, e.g. phones and 4k displays, and therefore this bug is most prominent there.

Before:

![image](https://user-images.githubusercontent.com/4953590/166119102-776abedb-389d-49e5-b9fd-c6e35abc9b67.png)

![image](https://user-images.githubusercontent.com/4953590/166119109-000120ab-464a-415e-9f66-1cc3d6315a7b.png)


After:

![image](https://user-images.githubusercontent.com/4953590/166119092-8ac6a992-bdfc-480c-b1d6-7c0c82e15c42.png)

![image](https://user-images.githubusercontent.com/4953590/166119129-dee6b38d-d4d2-4b88-b52e-28f28c476db1.png)