### PR TITLE
Change Chromatic to run on pull_request_target

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - master
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - master
@@ -23,7 +23,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3.1.0
         with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
       - run: yarn
       - run: yarn build:storybook
@@ -35,4 +35,3 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           storybookBuildDir: packages/storybook/storybook-static
           # preserveMissing: true # uncomment this line when we are partially disabling tests to save on usage
-  


### PR DESCRIPTION
This will (hopefully) allow Chromatic to run against PRs from external sources, without risk of revealing the GitHub secrets to 3rd parties.

See:

- https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
- https://github.com/chromaui/chromatic-cli/issues/196


