### PR TITLE
Add props for children to headers

### DIFF
--- a/components/heading/src/heading.tsx
+++ b/components/heading/src/heading.tsx
@@ -69,6 +69,7 @@ export const Heading: HeadingType = ({ level, size, ...props }: HeadingOwnProps 
 Heading.defaultProps = {
   level: undefined,
   size: 'XLARGE',
+  children: undefined,
 };
 
 Heading.displayName = 'Heading';
@@ -116,6 +117,7 @@ export interface HeadingOwnProps {
    *    or a numeric size that fits in the GDS font scale list
    */
   size?: number | string;
+  children?: React.ReactNode;
 }
 
 export default Heading;


### PR DESCRIPTION
Fix for https://github.com/govuk-react/govuk-react/issues/1138

Some thoughts:

- I tested this by temporarily upgrading the React type defs to v18 and then reverted as the upgrade to React 18 seemed like a fairly big job
- I don't know what other components will also have a missing `children` prop. I've only fixed headers.
- I don't know what an appropriate comment for the property would be

**Checklist**:

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

