### PR TITLE
accessibility: set StyledErrorText tabindex to 0

### DIFF
--- a/components/error-summary/src/index.tsx
+++ b/components/error-summary/src/index.tsx
@@ -104,7 +104,7 @@ export const ErrorSummary: React.FC<ErrorSummaryProps> = ({
       <UnorderedList mb={0} listStyleType="none">
         {errors.map((error, index) => (
           <ListItem key={error.targetName}>
-            <StyledErrorText tabIndex={index + 1} onClick={() => onHandleErrorClick?.(error.targetName)}>
+            <StyledErrorText tabIndex={0} onClick={() => onHandleErrorClick?.(error.targetName)}>
               {error.text}
             </StyledErrorText>
           </ListItem>


### PR DESCRIPTION
A tab index greater than 0 violates the axe-core 4.4 tabindex rule.
See https://dequeuniversity.com/rules/axe/4.4/tabindex?application=AxeChrome
Looks like this was previously flagged in issue  https://github.com/govuk-react/govuk-react/issues/642 but never resolved.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
