### PR TITLE
Chore/panel colour

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,10 +21,10 @@ yarn start
 ## Creating a new component
 
 To create a new component:
+
 - `yarn create-component -- my-new-component` where _my-new-component_ is the name of your new component.
 
 This creates a folder named _my-new-component_ in `src/components` with the component file (index.js), a basic render test (test.js), and a default story (stories.js). You will need to add this to `src/stories/index.js` to view it in storybook.
-
 
 ## Unit testing
 
@@ -98,7 +98,7 @@ For the purpose of this project:
 - A field is the combination of a label, input(s) and validation/error messages. The Field components used by this project should follow the prop structure of Final Form and Redux Form fields, in that they accept an `input` prop and a `meta` prop.
 - An input is just the form control that the user enters data in to, without a label or error/validation message. Inputs are normally associated with a Field and should be used on their own by importing the Field then using `<FieldName.Input />`. Inputs follow the prop structure of Final Form and Redux Form inputs.
 
-More details in https://github.com/govuk-react/govuk-react/issues/164.
+More details in [issues/164](https://github.com/govuk-react/govuk-react/issues/164.)
 
 ### Anchors
 
@@ -116,5 +116,5 @@ Components are built to have white space around them to match their equivalents 
 
 The `withWhiteSpace` function accepts default values for both `padding` and `margin`, and also provides support for overriding those defaults with equivalently named props. Spacing styles created are responsive and adjust for mobile/tablet sizes. For backward compatibility with the `withWhiteSpace` HOC it also supports a `marginBottom` config and `mb` prop.
 
-More details in https://github.com/govuk-react/govuk-react/issues/173
-and https://github.com/govuk-react/govuk-react/pull/523
+More details in [issues/173](https://github.com/govuk-react/govuk-react/issues/173)
+and [pull/523](https://github.com/govuk-react/govuk-react/pull/523)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Use of these components assumes the following from the peer project:
 
 - The govuk-react `GlobalStyle` component is included on all pages.
 - The GDS Transport font face is included ([for gov.uk domains only](https://www.gov.uk/service-manual/design/making-your-service-look-like-govuk))
-- Optionally, either [normalize.css](https://necolas.github.io/normalize.css/) or [sanitize.css](https://csstools.github.io/sanitize.css/) is used as a CSS reset. We don't test for this, so please raise an issue if you find any problems with compatability.
+- Optionally, either [normalize.css](https://necolas.github.io/normalize.css/) or [sanitize.css](https://csstools.github.io/sanitize.css/) is used as a CSS reset. We don't test for this, so please raise an issue if you find any problems with compatibility.
 - Other than the reset, no other styles affecting generic elements (without classes, IDs etc) are present in the CSS.
 
 ## Why CSS-in-JS?
@@ -118,7 +118,7 @@ Then in your package.json, you can update govuk-react, but specify the older ver
 
 ## About the GDS font
 
-Unfortuantely the GDS transport font has a relatively restrictive license [described on the gov.uk blog](https://designnotes.blog.gov.uk/2015/03/11/can-i-use-the-gov-uk-fonts/). We are investigating rendering an elegant alternative before falling back to Arial on [issue 272](https://github.com/govuk-react/govuk-react/issues/272).
+Unfortunately the GDS transport font has a relatively restrictive license [described on the gov.uk blog](https://designnotes.blog.gov.uk/2015/03/11/can-i-use-the-gov-uk-fonts/). We are investigating rendering an elegant alternative before falling back to Arial on [issue 272](https://github.com/govuk-react/govuk-react/issues/272).
 
 ## Related sites and projects
 

--- a/components/panel/src/__snapshots__/test.tsx.snap
+++ b/components/panel/src/__snapshots__/test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Panel matches wrapper snapshot: wrapper mount 1`] = `
   border: 5px solid transparent;
   text-align: center;
   color: #ffffff;
-  background: #28a197;
+  background: #00703c;
 }
 
 .c1 {

--- a/components/panel/src/index.tsx
+++ b/components/panel/src/index.tsx
@@ -5,7 +5,7 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
-import { BUTTON_COLOUR, WHITE } from 'govuk-colours';
+import { WHITE } from 'govuk-colours';
 import { spacing, typography } from '@govuk-react/lib';
 import { BORDER_WIDTH, MEDIA_QUERIES, SPACING_POINTS } from '@govuk-react/constants';
 import { stripUnit } from 'polished';
@@ -31,7 +31,7 @@ const StyledPanel = styled('div')(
     },
 
     color: WHITE,
-    background: BUTTON_COLOUR,
+    background: '#00703c',
   },
   spacing.withWhiteSpace()
 );

--- a/components/panel/src/index.tsx
+++ b/components/panel/src/index.tsx
@@ -5,7 +5,7 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
-import { TURQUOISE, WHITE } from 'govuk-colours';
+import { BUTTON_COLOUR, WHITE } from 'govuk-colours';
 import { spacing, typography } from '@govuk-react/lib';
 import { BORDER_WIDTH, MEDIA_QUERIES, SPACING_POINTS } from '@govuk-react/constants';
 import { stripUnit } from 'polished';
@@ -31,7 +31,7 @@ const StyledPanel = styled('div')(
     },
 
     color: WHITE,
-    background: TURQUOISE,
+    background: BUTTON_COLOUR,
   },
   spacing.withWhiteSpace()
 );


### PR DESCRIPTION
Update panel background colour to match GDS


GDS:

<img width="775" alt="Screenshot 2023-09-29 at 10 56 04" src="https://github.com/govuk-react/govuk-react/assets/1027024/32140e57-f0d7-493a-b96c-0329e4702656">


Link to the Gov Panel Component https://design-system.service.gov.uk/patterns/confirmation-pages/

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
