### PR TITLE
Add href attribute to error-summary links to allow triggering onClick with keyboard

### DIFF
--- a/components/error-summary/src/index.tsx
+++ b/components/error-summary/src/index.tsx
@@ -104,7 +104,14 @@ export const ErrorSummary: React.FC<ErrorSummaryProps> = ({
       <UnorderedList mb={0} listStyleType="none">
         {errors.map((error, index) => (
           <ListItem key={error.targetName}>
-            <StyledErrorText tabIndex={0} onClick={() => onHandleErrorClick?.(error.targetName)}>
+            <StyledErrorText
+              tabIndex={0}
+              onClick={(event) => {
+                event.preventDefault();
+                onHandleErrorClick?.(error.targetName);
+              }}
+              href={onHandleErrorClick ? '#' : undefined}
+            >
               {error.text}
             </StyledErrorText>
           </ListItem>

--- a/components/error-summary/src/stories.tsx
+++ b/components/error-summary/src/stories.tsx
@@ -8,6 +8,9 @@ export default {
   title: 'Form/Error summary',
   id: 'error-summary',
   component: ErrorSummary,
+  argTypes: {
+    onClick: { action: 'Error clicked' },
+  },
 };
 
 const errors = [
@@ -27,4 +30,5 @@ Default.args = {
   heading: 'Message to alert the user to a problem goes here',
   description: 'Optional description of the errors and how to correct them',
   errors,
+  onHandleErrorClick: () => {},
 };

--- a/components/error-summary/src/test.tsx
+++ b/components/error-summary/src/test.tsx
@@ -62,7 +62,6 @@ describe('error summary', () => {
     fireEvent.focus(errorLink);
     await user.type(errorLink, '{Enter}');
 
-    expect(onHandleErrorClick).toHaveBeenCalled();
     expect(onHandleErrorClick).toHaveBeenCalledWith(targetName);
   });
 });

--- a/components/error-summary/src/test.tsx
+++ b/components/error-summary/src/test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
+import userEvent from '@testing-library/user-event';
 import { ErrorSummary } from '.';
 
 describe('error summary', () => {
@@ -44,5 +45,24 @@ describe('error summary', () => {
 
       expect(onHandleErrorClick).toHaveBeenCalledWith(targetName);
     });
+  });
+
+  it('handles onClick of error with Enter', async () => {
+    const text = 'error description';
+    const targetName = 'error target';
+    const onHandleErrorClick = jest.fn();
+    const { getByText } = render(
+      <ErrorSummary errors={[{ text, targetName }]} onHandleErrorClick={onHandleErrorClick} />
+    );
+    const user = userEvent.setup();
+
+    const errorLink = getByText(text);
+    expect(errorLink).toBeInTheDocument();
+    expect(onHandleErrorClick).not.toHaveBeenCalledWith(targetName);
+    fireEvent.focus(errorLink);
+    await user.type(errorLink, '{Enter}');
+
+    expect(onHandleErrorClick).toHaveBeenCalled();
+    expect(onHandleErrorClick).toHaveBeenCalledWith(targetName);
   });
 });


### PR DESCRIPTION
Add href attribute to error-summary links to allow triggering onClick with keyboard

Related issue: #1409

**Checklist**:

* [ x ] Documentation N/A
* [ x ] Tests
* [ x ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
